### PR TITLE
drivers: build spi targets

### DIFF
--- a/mcux/drivers/lpc/CMakeLists.txt
+++ b/mcux/drivers/lpc/CMakeLists.txt
@@ -6,4 +6,5 @@
 
 zephyr_include_directories(.)
 
+zephyr_sources_ifdef(CONFIG_SPI_MCUX_FLEXCOMM   fsl_spi.c fsl_flexcomm.c)
 zephyr_sources_ifdef(CONFIG_USART_MCUX_LPC    fsl_usart.c fsl_flexcomm.c)


### PR DESCRIPTION
Added fsl_spi.c and fsl_flexcomm.c when building Flexcomm's SPI driver

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>

Work with https://github.com/zephyrproject-rtos/zephyr/pull/17322 