### PR TITLE
README: remove comments on PTP patches

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -83,12 +83,6 @@ License Link:
 
 Patch List:
 
-   * Changes from official delivery:
-     - Fix ethernet timestamping driver. The nanosecond part of the frame
-       timestamp wasn't saved.
-     - Fix PTP event packet type check. The PTP message type was incorrectly
-       checked.
-
    * Automatically enable ENET_ENHANCEDBUFFERDESCRIPTOR_MODE in HAL if gPTP
      support is enabled.
 


### PR DESCRIPTION
The PTP patches are now in the upstream SDK HALs so we don't need
comments about those patches anymore.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>