### PR TITLE
cmake: Fix how compile definition is added

### DIFF
--- a/mcux/drivers/kinetis/CMakeLists.txt
+++ b/mcux/drivers/kinetis/CMakeLists.txt
@@ -6,8 +6,9 @@
 
 zephyr_include_directories(.)
 
-zephyr_library_compile_definitions_ifdef(
-  CONFIG_PTP_CLOCK_MCUX ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+zephyr_compile_definitions_ifdef(
+  CONFIG_PTP_CLOCK_MCUX
+  ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
 )
 
 zephyr_sources_ifdef(CONFIG_HAS_MCUX_CACHE    fsl_cache.c)


### PR DESCRIPTION
The compile definition ENET_ENHANCEDBUFFERDESCRIPTOR_MODE has been
added by modifying the build environment of the 'zephyr' library. But
modifying this library is not supported.

The intention was to modify the global build environment, so we change
to use the zephyr_ API instead of the zephyr_library_ API as this API
will behave as intended.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>