### PR TITLE
imx: Compile clock drivers unconditionally

### DIFF
--- a/imx/drivers/CMakeLists.txt
+++ b/imx/drivers/CMakeLists.txt
@@ -1,13 +1,17 @@
 zephyr_include_directories(.)
 
 if(CONFIG_SOC_MCIMX7_M4)
-zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_IMX_CCM   ccm_imx7d.c)
-zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_IMX_CCM   ccm_analog_imx7d.c)
+zephyr_sources(
+  ccm_imx7d.c
+  ccm_analog_imx7d.c
+)
 endif()
 
 if(CONFIG_SOC_MCIMX6X_M4)
-zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_IMX_CCM   ccm_imx6sx.c)
-zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_IMX_CCM   ccm_analog_imx6sx.c)
+zephyr_sources(
+  ccm_imx6sx.c
+  ccm_analog_imx6sx.c
+)
 endif()
 
 zephyr_sources_ifdef(CONFIG_UART_IMX                uart_imx.c)


### PR DESCRIPTION
The imx6/7 soc init always requires clock control module (ccm) drivers
from the hal, so there is no need for ifdefs.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>

cc: @ulfalizer