### PR TITLE
cmake: support offload board

### DIFF
--- a/mcux/boards/CMakeLists.txt
+++ b/mcux/boards/CMakeLists.txt
@@ -20,5 +20,7 @@ zephyr_compile_definitions_ifdef(CONFIG_NXP_IMX_RT_BOOT_HEADER XIP_BOOT_HEADER_E
 zephyr_compile_definitions_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA XIP_BOOT_HEADER_DCD_ENABLE=1)
 zephyr_compile_definitions_ifdef(CONFIG_BOOT_FLEXSPI_NOR BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE)
 
+if(MCUX_BOARD)
 zephyr_sources_ifdef(CONFIG_BOOT_FLEXSPI_NOR ${MCUX_BOARD}/${MCUX_BOARD}_flexspi_nor_config.c)
 zephyr_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA ${MCUX_BOARD}/${MCUX_BOARD}_sdram_ini_dcd.c)
+endif()


### PR DESCRIPTION
When more mcux boards are added, the new ".boot_hdr.conf" and ".boot_hdr.dcd_data" will be placed in zephyr / board/arm/new_board, No need to add more MCUX_BOARD to mcux/boards

Signed-off-by: Frank Li <lgl88911@163.com>