### PR TITLE
mcux: Rename lpc usart shim driver config

### DIFF
--- a/mcux/drivers/lpc/CMakeLists.txt
+++ b/mcux/drivers/lpc/CMakeLists.txt
@@ -7,5 +7,5 @@
 zephyr_include_directories(.)
 
 zephyr_sources_ifdef(CONFIG_SPI_MCUX_FLEXCOMM   fsl_spi.c fsl_flexcomm.c)
-zephyr_sources_ifdef(CONFIG_USART_MCUX_LPC    fsl_usart.c fsl_flexcomm.c)
+zephyr_sources_ifdef(CONFIG_UART_MCUX_FLEXCOMM	fsl_usart.c fsl_flexcomm.c)
 zephyr_sources_ifdef(CONFIG_GPIO_MCUX_LPC     fsl_gpio.c fsl_pint.c fsl_inputmux.c)


### PR DESCRIPTION
Renames CONFIG_USART_MCUX_LPC to CONFIG_UART_MCUX_FLEXCOMM to more
accurately reflect the flexcomm hardware IP and to prepare for
instantiating it on an SoC outside the LPC family.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>