### PR TITLE
mcux:cmake: the fsl_clock uses SDK_DelayAtLeastUs in fsl_common.c

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -32,6 +32,10 @@ zephyr_compile_definitions(${MCUX_CPU})
 # practice, drilling down like this avoids the need for repetitive
 # build scripts for every mcux device.
 zephyr_sources(devices/${MCUX_DEVICE}/fsl_clock.c)
+# fsl_clock use the functions in fsl_common.
+if (${MCUX_DEVICE} MATCHES "LPC55S69")
+  zephyr_sources(drivers/lpc/fsl_common.c)
+endif()
 if (${MCUX_DEVICE} MATCHES "LPC")
   zephyr_sources(devices/${MCUX_DEVICE}/fsl_power.c)
   zephyr_sources(devices/${MCUX_DEVICE}/fsl_reset.c)


### PR DESCRIPTION
Signed-off-by: Mark Wang <yichang.wang@nxp.com>