### PR TITLE
zephyr: fix driver include paths

### DIFF
--- a/mcux/middleware/usb/device/port/zephyr/usb_dc_mcux.h
+++ b/mcux/middleware/usb/device/port/zephyr/usb_dc_mcux.h
@@ -8,7 +8,7 @@
 #ifndef __USB_DC_MCUX_H__
 #define __USB_DC_MCUX_H__
 
-#include <usb/usb_dc.h>
+#include <drivers/usb/usb_dc.h>
 #include "usb_spec.h"
 
 /******************************************************************************


### PR DESCRIPTION
Zephyr no longer adds the drivers subdirectory of the include
hierarchy to the search path, so references to driver headers must
include the drivers/ prefix.

Signed-off-by: Peter Bigot <peter.bigot@nordicsemi.no>