### PR TITLE
mcux: Build lpc flexcomm i2c driver

### DIFF
--- a/mcux/drivers/lpc/CMakeLists.txt
+++ b/mcux/drivers/lpc/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 zephyr_include_directories(.)
 
+zephyr_sources_ifdef(CONFIG_I2C_MCUX_FLEXCOMM   fsl_i2c.c fsl_flexcomm.c)
 zephyr_sources_ifdef(CONFIG_SPI_MCUX_FLEXCOMM   fsl_spi.c fsl_flexcomm.c)
 zephyr_sources_ifdef(CONFIG_UART_MCUX_FLEXCOMM	fsl_usart.c fsl_flexcomm.c)
 zephyr_sources_ifdef(CONFIG_GPIO_MCUX_LPC     fsl_gpio.c fsl_pint.c fsl_inputmux.c)


### PR DESCRIPTION
Builds the lpc flexcomm i2c hal driver when the corresponding shim
driver is enabled.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>