### PR TITLE
mcux: drivers: imx: fix spi timing delay overflow

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -95,3 +95,6 @@ Patch List:
    * Add USB device controller drivers, the drivers are based on MCUXpresso SDK release tag REL_2.5.0_REL9_RFP_RC3_7_1.
 
    * Add EDMA bug fix for EDMA_SubmitTransfer busy state judgement, this fix applys to 2.7.0
+
+   * Add Time delay bug fix for LPSPI_MasterSetDelayTimes of fsl_lpspi.c to avoid realDelay and bestDelay overflow.
+

--- a/mcux/drivers/imx/fsl_lpspi.c
+++ b/mcux/drivers/imx/fsl_lpspi.c
@@ -577,7 +577,7 @@ uint32_t LPSPI_MasterSetDelayTimes(LPSPI_Type *base,
                                    lpspi_delay_type_t whichDelay,
                                    uint32_t srcClock_Hz)
 {
-    uint32_t realDelay, bestDelay;
+    uint64_t realDelay, bestDelay;
     uint32_t scaler, bestScaler;
     uint32_t diff, min_diff;
     uint64_t initialDelayNanoSec;


### PR DESCRIPTION
define realDelay by uint32_t may be overflow.
overflow will cause delay cal error.

Signed-off-by: Frank Li <lgl88911@163.com>