### PR TITLE
drivers: kinetis: enable support for the TPM driver

### DIFF
--- a/mcux/drivers/kinetis/CMakeLists.txt
+++ b/mcux/drivers/kinetis/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2020 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -35,6 +35,7 @@ zephyr_sources_ifdef(CONFIG_HAS_MCUX_SMC       fsl_smc.c)
 zephyr_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR fsl_lptmr.c)
 zephyr_sources_ifdef(CONFIG_DAC_MCUX_DAC       fsl_dac.c)
 zephyr_sources_ifdef(CONFIG_DAC_MCUX_DAC32     fsl_dac32.c)
+zephyr_sources_ifdef(CONFIG_PWM_MCUX_TPM       fsl_tpm.c)
 
 if(NOT CONFIG_ASSERT OR CONFIG_FORCE_NO_ASSERT)
   zephyr_compile_definitions(NDEBUG) # squelch fsl_flexcan.c warning


### PR DESCRIPTION
The TPM (Timer/PWM Module) is a 2- to 8-channel timer which
supports input capture, output compare, and the generation of
PWM signals to control electric motor and power management
applications.

Signed-off-by: Alex Porosanu <alexandru.porosanu@nxp.com>