### PR TITLE
mcux: drivers: imx: fix Other interrupts treated as transfer completion

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -95,3 +95,5 @@ Patch List:
    * Add USB device controller drivers, the drivers are based on MCUXpresso SDK release tag REL_2.5.0_REL9_RFP_RC3_7_1.
 
    * Add EDMA bug fix for EDMA_SubmitTransfer busy state judgement, this fix applys to 2.7.0
+
+   * Add spi bug fix in fsl_lpspi.c for other interrupts treated as transfer completion.

--- a/mcux/drivers/imx/fsl_lpspi.c
+++ b/mcux/drivers/imx/fsl_lpspi.c
@@ -1198,6 +1198,8 @@ static void LPSPI_MasterTransferComplete(LPSPI_Type *base, lpspi_master_handle_t
 {
     assert(handle);
 
+    LPSPI_ClearStatusFlags(base, kLPSPI_TransferCompleteFlag);
+
     /* Disable interrupt requests*/
     LPSPI_DisableInterrupts(base, (uint32_t)kLPSPI_AllInterruptEnable);
 

--- a/mcux/drivers/kinetis/fsl_lpspi.c
+++ b/mcux/drivers/kinetis/fsl_lpspi.c
@@ -1198,6 +1198,8 @@ static void LPSPI_MasterTransferComplete(LPSPI_Type *base, lpspi_master_handle_t
 {
     assert(handle);
 
+    LPSPI_ClearStatusFlags(base, kLPSPI_TransferCompleteFlag);
+
     /* Disable interrupt requests*/
     LPSPI_DisableInterrupts(base, (uint32_t)kLPSPI_AllInterruptEnable);
 


### PR DESCRIPTION
After the master transfer is completed,
if the sr flag is not clear, the callback of the transfer
completion will be called again in other interrupts.

Signed-off-by: Frank Li <lgl88911@163.com>