### PR TITLE
drivers: lpc: fsl_spi allow NULL Rx

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -97,3 +97,6 @@ Patch List:
    * Add EDMA bug fix for EDMA_SubmitTransfer busy state judgement, this fix applys to 2.7.0
 
    * Add spi bug fix in fsl_lpspi.c for other interrupts treated as transfer completion.
+
+   * Add support for LPC's Flexcomm spi driver to discard Rx by providing NULL Rx buffer.
+ 

--- a/mcux/drivers/lpc/fsl_spi.c
+++ b/mcux/drivers/lpc/fsl_spi.c
@@ -525,8 +525,8 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     uint32_t fifoDepth;
 
     /* check params */
-    assert(!((NULL == base) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData))));
-    if ((NULL == base) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData)))
+    assert(!((NULL == base) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData) && (0 == xfer->dataSize))));
+    if ((NULL == base) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData) && (0 == xfer->dataSize)))
     {
         return kStatus_InvalidArgument;
     }
@@ -535,7 +535,7 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
     txData           = xfer->txData;
     rxData           = xfer->rxData;
     txRemainingBytes = (txData != NULL) ? xfer->dataSize : 0U;
-    rxRemainingBytes = (rxData != NULL) ? xfer->dataSize : 0U;
+    rxRemainingBytes = xfer->dataSize;
 
     instance  = SPI_GetInstance(base);
     dataWidth = (uint32_t)(g_configs[instance].dataWidth);
@@ -568,12 +568,16 @@ status_t SPI_MasterTransferBlocking(SPI_Type *base, spi_transfer_t *xfer)
             /* rxBuffer is not empty */
             if (rxRemainingBytes != 0U)
             {
-                *(rxData++) = (uint8_t)tmp32;
+                if (rxData) {
+                    *(rxData++) = (uint8_t)tmp32;
+                }
                 rxRemainingBytes--;
                 /* read 16 bits at once */
                 if (dataWidth > 8U)
                 {
-                    *(rxData++) = (uint8_t)(tmp32 >> 8);
+                    if (rxData) {
+                        *(rxData++) = (uint8_t)(tmp32 >> 8);
+                    }
                     rxRemainingBytes--;
                 }
             }
@@ -637,8 +641,8 @@ status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *hand
 {
     /* check params */
     assert(
-        !((NULL == base) || (NULL == handle) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData))));
-    if ((NULL == base) || (NULL == handle) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData)))
+        !((NULL == base) || (NULL == handle) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData) && (0 == xfer->dataSize))));
+    if ((NULL == base) || (NULL == handle) || (NULL == xfer) || ((NULL == xfer->txData) && (NULL == xfer->rxData) && (0 == xfer->dataSize)))
     {
         return kStatus_InvalidArgument;
     }
@@ -661,7 +665,7 @@ status_t SPI_MasterTransferNonBlocking(SPI_Type *base, spi_master_handle_t *hand
     handle->rxData = xfer->rxData;
     /* set count */
     handle->txRemainingBytes = (xfer->txData != NULL) ? xfer->dataSize : 0U;
-    handle->rxRemainingBytes = (xfer->rxData != NULL) ? xfer->dataSize : 0U;
+    handle->rxRemainingBytes = xfer->dataSize;
     handle->totalByteCount   = xfer->dataSize;
     /* other options */
     handle->toReceiveCount = 0U;
@@ -899,12 +903,16 @@ static void SPI_TransferHandleIRQInternal(SPI_Type *base, spi_master_handle_t *h
             if (handle->rxRemainingBytes != 0U)
             {
                 /* low byte must go first */
-                *(handle->rxData++) = (uint8_t)tmp32;
+                if (handle->rxData) {
+                    *(handle->rxData++) = (uint8_t)tmp32;
+                }
                 handle->rxRemainingBytes--;
                 /* read 16 bits at once */
                 if (handle->dataWidth > (uint8_t)kSPI_Data8Bits)
                 {
-                    *(handle->rxData++) = (uint8_t)(tmp32 >> 8);
+                    if (handle->rxData) {
+                        *(handle->rxData++) = (uint8_t)(tmp32 >> 8);
+                    }
                     handle->rxRemainingBytes--;
                 }
             }


### PR DESCRIPTION
Allow receving SPI data without saving it, i.e. Rx buffer is NULL.

Signed-off-by: Andrei Gansari <andrei.gansari@nxp.com>