### PR TITLE
mcux: usb: Fix USB_DEVICE_CONFIG_ENDPOINTS definition

### DIFF
--- a/mcux/middleware/usb/device/usb_device_ehci.h
+++ b/mcux/middleware/usb/device/usb_device_ehci.h
@@ -19,7 +19,7 @@
  * Definitions
  ******************************************************************************/
 
-#define USB_DEVICE_CONFIG_ENDPOINTS (DT_INST_PROP(0, num_bidir_endpoints) / 2)
+#define USB_DEVICE_CONFIG_ENDPOINTS (DT_INST_PROP(0, num_bidir_endpoints))
 
 /*! @brief The maximum value of ISO type maximum packet size for HS in USB specification 2.0 */
 #define USB_DEVICE_MAX_HS_ISO_MAX_PACKET_SIZE (1024U)


### PR DESCRIPTION
The define for USB_DEVICE_CONFIG_ENDPOINTS erroneously divided
the DTS value for number of USB endpoints by 2.

Signed-off-by: David Leach <david.leach@nxp.com>