### PR TITLE
drivers: cmake: Fix how compile definition is added

### DIFF
--- a/mcux/drivers/imx/CMakeLists.txt
+++ b/mcux/drivers/imx/CMakeLists.txt
@@ -6,8 +6,9 @@
 
 zephyr_include_directories(.)
 
-zephyr_library_compile_definitions_ifdef(
-  CONFIG_PTP_CLOCK_MCUX ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+zephyr_compile_definitions_ifdef(
+  CONFIG_PTP_CLOCK_MCUX
+  ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
 )
 
 zephyr_library_compile_definitions_ifdef(


### PR DESCRIPTION
This has been fixed on kinetis devices by
commit#47914cb291b3cfdea8248bd15787d7d733f71729.
Similar change is needed for iMXRT devices
