### PR TITLE
mcux: Build imx flexcan driver

### DIFF
--- a/mcux/drivers/imx/CMakeLists.txt
+++ b/mcux/drivers/imx/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_compile_definitions_ifdef(
   CONFIG_HAS_MCUX_CACHE FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
 )
 
+zephyr_library_sources_ifdef(CONFIG_CAN_MCUX_FLEXCAN	fsl_flexcan.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_GPT	fsl_gpt.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_PIT	fsl_pit.c)
 zephyr_library_sources_ifdef(CONFIG_DISPLAY_MCUX_ELCDIF	fsl_elcdif.c)


### PR DESCRIPTION
Builds the imx flexcan driver when the corresponding shim driver is
enabled.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>