### PR TITLE
iMX: can: Fix building flexcan driver

### DIFF
--- a/mcux/drivers/imx/CMakeLists.txt
+++ b/mcux/drivers/imx/CMakeLists.txt
@@ -34,3 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_MCUX_LPUART	fsl_lpuart.c)
 zephyr_library_sources_ifdef(CONFIG_VIDEO_MCUX_CSI	fsl_csi.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_MCUX_IMX_WDOG    fsl_wdog.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_MCUX_FLEXCAN	fsl_flexcan.c)
+
+if(NOT CONFIG_ASSERT OR CONFIG_FORCE_NO_ASSERT)
+  zephyr_compile_definitions(NDEBUG) # squelch fsl_flexcan.c warning
+endif()


### PR DESCRIPTION
We need to same ASSERT/NDEBUG support that exists for kinetis for imx.
Otherwise we get build errors with building the flexcan drivers on
imx-rt.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>