### PR TITLE
usb: Fix build errors due to update to SDK 2.8

### DIFF
--- a/mcux/middleware/usb/device/port/zephyr/usb_dc_mcux.h
+++ b/mcux/middleware/usb/device/port/zephyr/usb_dc_mcux.h
@@ -323,22 +323,12 @@ typedef struct _usb_device_struct {
 	/* Controller handle */
 	usb_device_controller_handle controllerHandle;
 	/* Controller interface handle */
-	const usb_device_controller_interface_struct_t *controllerInterface;
-#if USB_DEVICE_CONFIG_USE_TASK
-	/*!< Message queue buffer*/
-	OSA_MSGQ_HANDLE_DEFINE(notificationQueueBuffer,
-						   USB_DEVICE_CONFIG_MAX_MESSAGES,
-						   USB_DEVICE_MESSAGES_SIZE);
-	/*!< Message queue*/
-	osa_msgq_handle_t notificationQueue;
-#endif
-	/* Device callback function pointer */
-	usb_device_callback_t deviceCallback;
-	/* Endpoint callback function structure */
-	usb_device_endpoint_callback_struct_t
-		epCallback[USB_DEVICE_CONFIG_ENDPOINTS << 1U];
+	const usb_device_controller_interface_struct_t *interface;
+	usb_dc_status_callback status_callback;
+	usb_ep_ctrl_data_t *eps;
+	bool attached;
 	/* Current device address */
-	uint8_t deviceAddress;
+	uint8_t address;
 	/* Controller ID */
 	uint8_t controllerId;
 	/* Current device state */
@@ -349,10 +339,7 @@ typedef struct _usb_device_struct {
 #endif
 	/* Is doing device reset or not */
 	uint8_t isResetting;
-#if (defined(USB_DEVICE_CONFIG_USE_TASK) && (USB_DEVICE_CONFIG_USE_TASK > 0U))
-	/* Whether call ep callback directly when the task is enabled */
-	uint8_t epCallbackDirectly;
-#endif
+	uint8_t setupDataStage;
 } usb_device_struct_t;
 
 /* Endpoint status structure */

--- a/mcux/middleware/usb/device/usb_device_ehci.c
+++ b/mcux/middleware/usb/device/usb_device_ehci.c
@@ -58,6 +58,8 @@ static usb_status_t USB_DeviceEhciTransfer(usb_device_ehci_state_struct_t *ehciS
                                            uint8_t *buffer,
                                            uint32_t length);
 
+extern usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg);
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -913,7 +915,6 @@ static usb_status_t USB_DeviceEhciTransfer(usb_device_ehci_state_struct_t *ehciS
     uint8_t qhIdle = 0U;
     uint8_t waitingSafelyAccess = 1U;
     uint32_t primeTimesCount = 0U;
-    void *temp;
     USB_OSA_SR_ALLOC();
 
     if (NULL == ehciState)
@@ -1662,17 +1663,13 @@ usb_status_t USB_DeviceEhciControl(usb_device_controller_handle ehciHandle, usb_
                 }
             }
             break;
-        case kUSB_DeviceControlPreSetDeviceAddress:
-            if (NULL != param)
+        case kUSB_DeviceControlSetDeviceAddress:
+            if (param)
             {
                 temp8 = (uint8_t *)param;
-                ehciState->registerBase->DEVICEADDR =
-                    ((((uint32_t)(*temp8)) << USBHS_DEVICEADDR_USBADR_SHIFT) | USBHS_DEVICEADDR_USBADRA_MASK);
+                ehciState->registerBase->DEVICEADDR = (((uint32_t)(*temp8)) << USBHS_DEVICEADDR_USBADR_SHIFT);
                 error = kStatus_USB_Success;
             }
-            break;
-        case kUSB_DeviceControlSetDeviceAddress:
-            error = kStatus_USB_Success;
             break;
         case kUSB_DeviceControlGetSynchFrame:
             break;


### PR DESCRIPTION
Re-add fields that were deleted as part of the update. This is a fix for issue https://github.com/zephyrproject-rtos/zephyr/issues/29710.

Tested Zephyr USB HID tests on MXRT devices. 