### PR TITLE
enet: dsa: Extend the ENET_FRAME_MAX_FRAMELEN to accommodate 1B DSA tag

### DIFF
--- a/mcux/drivers/kinetis/fsl_enet.h
+++ b/mcux/drivers/kinetis/fsl_enet.h
@@ -118,7 +118,7 @@
 
 /*! @name Defines some Ethernet parameters. */
 /*@{*/
-#define ENET_FRAME_MAX_FRAMELEN 1518U /*!< Default maximum Ethernet frame size. */
+#define ENET_FRAME_MAX_FRAMELEN 1519U /*!< Default maximum Ethernet frame size. */
 
 #define ENET_FIFO_MIN_RX_FULL  5U                                        /*!< ENET minimum receive FIFO full. */
 #define ENET_RX_MIN_BUFFERSIZE 256U                                      /*!< ENET minimum buffer size. */


### PR DESCRIPTION
The ENET_FRAME_MAX_FRAMELEN needs to be adjusted to allow reading extra
bytes (i.e. tags) appended by DSA switches (like KSZ8794) to the received
frame.

Without this change - frames with maximal length (i.e. 1588) will be
dropped as tag bytes (1 byte in case of KSZ8794) will be truncated and
not provided to upper Zephyr layers.

Signed-off-by: Lukasz Majewski <lukma@denx.de>

---
I do have some questions regarding this patch:
1. It looks like I would need some conditional alteration of `ENET_FRAME_MAX_FRAMELEN` to avoid side effects when 
the DSA is not supported/enabled (https://github.com/zephyrproject-rtos/zephyr/pull/27620). I'm wondering how I can provide it - as hal_nxp should to be a separate layer (on top of which Zephyr runs). 

I could do (in hal/nxp/mcux/drivers/kinetis/fsl_enet.h):
`#if defined(CONFIG_NET_DSA) && defined(CONFIG_DSA_KSZ8794_TAIL_TAGGING)`
`#define ENET_FRAME_MAX_FRAMELEN 1519`
`#endif`

But I'm not sure if this is the correct approach. To be more specific - I'm afraid of Zephyr layers violation.

2. The other idea would be to add new board like **ip_k66f** ,which do have the switch onboard. However, it can work with and without tagging enabled (i.e. the KSZ8794 switch can be configured to add the tag or not), so I don't see how this can be done.
Moreover, adding a separate board seems like an overkill to just modify the single define.

Ideas and help more than welcome.