### PR TITLE
mcux: Relocate FlexSPI driver with XIP

### DIFF
--- a/mcux/drivers/imx/CMakeLists.txt
+++ b/mcux/drivers/imx/CMakeLists.txt
@@ -36,6 +36,10 @@ zephyr_library_sources_ifdef(CONFIG_VIDEO_MCUX_CSI	fsl_csi.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_MCUX_IMX_WDOG    fsl_wdog.c)
 zephyr_library_sources_ifdef(CONFIG_CAN_MCUX_FLEXCAN	fsl_flexcan.c)
 
+if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+  zephyr_code_relocate(fsl_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
+endif()
+
 if(NOT CONFIG_ASSERT OR CONFIG_FORCE_NO_ASSERT)
   zephyr_compile_definitions(NDEBUG) # squelch fsl_flexcan.c warning
 endif()

--- a/mcux/drivers/imxrt6xx/CMakeLists.txt
+++ b/mcux/drivers/imxrt6xx/CMakeLists.txt
@@ -21,3 +21,7 @@ zephyr_sources_ifdef(CONFIG_DMA_MCUX_LPC      fsl_dma.c)
 zephyr_sources_ifdef(CONFIG_MCUX_ACMP         fsl_acmp.c)
 zephyr_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI	fsl_flexspi.c)
 zephyr_sources_ifdef(CONFIG_MCUX_OS_TIMER	fsl_ostimer.c)
+
+if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+  zephyr_code_relocate(fsl_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
+endif()


### PR DESCRIPTION
Relocates the i.MX RT FlexSPI driver to the configured memory target if required.

This commit is needed for https://github.com/zephyrproject-rtos/zephyr/pull/33701
