### PR TITLE
RT600: Add SDK TRNG driver

### DIFF
--- a/mcux/drivers/imxrt6xx/CMakeLists.txt
+++ b/mcux/drivers/imxrt6xx/CMakeLists.txt
@@ -25,3 +25,5 @@ zephyr_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC	fsl_rtc.c)
 if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
   zephyr_code_relocate(fsl_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
 endif()
+zephyr_sources_ifdef(CONFIG_ENTROPY_MCUX_TRNG	fsl_trng.c)
+


### PR DESCRIPTION
Builds the RT600 TRNG driver when the corresponding
CONFIG_ENTROPY_MCUX_TRNG flag is set.

Signed-off-by: David Leach <david.leach@nxp.com>