### PR TITLE
mcux: usb: replace CONFIG_USB with CONFIG_USB_DEVICE_DRIVER

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -76,7 +76,7 @@ add_subdirectory(components)
 add_subdirectory(drivers)
 
 add_subdirectory_ifdef(
-  CONFIG_USB
+  CONFIG_USB_DEVICE_DRIVER
   middleware/usb
   )
 

--- a/mcux/middleware/usb/CMakeLists.txt
+++ b/mcux/middleware/usb/CMakeLists.txt
@@ -6,10 +6,10 @@
 
 zephyr_include_directories(./include)
 add_subdirectory_ifdef(
-  CONFIG_USB
+  CONFIG_USB_DEVICE_DRIVER
   device
   )
 add_subdirectory_ifdef(
-  CONFIG_USB
+  CONFIG_USB_DEVICE_DRIVER
   phy
   )


### PR DESCRIPTION
It is planned to remove the config option USB (CONFIG_USB)
in upstream project. Replace it with CONFIG_USB_DEVICE_DRIVER.

See https://github.com/zephyrproject-rtos/zephyr/pull/36630