### PR TITLE
zephyr/module.yml: Update to use cmake-ext/kconfig-ext

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,6 @@
+name: hal_nxp
 build:
-  cmake: .
+  cmake-ext: True
+  kconfig-ext: True
   settings:
     dts_root: .
-


### PR DESCRIPTION
Move to using cmake-ext/kconfig-ext which means we'll look in the
zephyr repo for cmake and kconfig files.  This allows us to put
zephyr specific integrations with zephyr itself.

We'll have the zephyr side cmake include the module cmake so this
should effectively be transparent at this point.  (we'd do the same
for kconfig, but there are no kconfig files in this repo).

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>