### PR TITLE
Fix LPC builds post SDK 2.10.0 update

### DIFF
--- a/mcux/drivers/lpc/CMakeLists.txt
+++ b/mcux/drivers/lpc/CMakeLists.txt
@@ -7,6 +7,7 @@
 zephyr_include_directories(.)
 
 zephyr_library_sources(fsl_common.c)
+zephyr_library_sources(fsl_common_arm.c)
 zephyr_library_sources_ifdef(CONFIG_ADC_MCUX_LPADC		fsl_lpadc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC	fsl_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_MCUX_LPC		fsl_dma.c)


### PR DESCRIPTION
SDK split out some stuff from fsl_common.c into fsl_common_arm.c so
we ned to build that as well (similar to what is already happening
for imx and imxrt6xx).

(Fixes build issue with watchdog driver needing SDK_DelayAtLeastUs)

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>