### PR TITLE
RT600: Add SDK LPADC Driver

### DIFF
--- a/mcux/drivers/imxrt6xx/CMakeLists.txt
+++ b/mcux/drivers/imxrt6xx/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_compile_definitions_ifdef(
 
 zephyr_library_sources(fsl_common.c)
 zephyr_library_sources(fsl_common_arm.c)
+zephyr_library_sources_ifdef(CONFIG_ADC_MCUX_LPADC		fsl_lpadc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_CTIMER   fsl_ctimer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC	fsl_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_MCUX_LPC		fsl_dma.c)


### PR DESCRIPTION
Builds the RT600 LPADC driver when the corresponding
CONFIG_ADC_MCUX_LPADC flag is set.

Signed-off-by: David Leach <david.leach@nxp.com>