### PR TITLE
RT685: Update CTimer Clock API

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -101,3 +101,5 @@ Patch List:
 
    * Add support for LPC's Flexcomm spi driver to discard Rx by providing NULL Rx buffer.
 
+   * Align the CTimer Clock Get API on RT685 with LPC series
+

--- a/mcux/devices/MIMXRT685S/fsl_clock.c
+++ b/mcux/devices/MIMXRT685S/fsl_clock.c
@@ -654,7 +654,7 @@ uint32_t CLOCK_GetFlexCommClkFreq(uint32_t id)
  *  param   id    : ctimer index to get frequency.
  *  return Frequency of Ctimer Clock
  */
-uint32_t CLOCK_GetCtimerClkFreq(uint32_t id)
+uint32_t CLOCK_GetCTimerClkFreq(uint32_t id)
 {
     uint32_t freq = 0U;
 

--- a/mcux/devices/MIMXRT685S/fsl_clock.h
+++ b/mcux/devices/MIMXRT685S/fsl_clock.h
@@ -1117,7 +1117,7 @@ uint32_t CLOCK_GetFlexCommClkFreq(uint32_t id);
  *  @param   id    : ctimer index to get frequency.
  *  @return Frequency of Ctimer Clock
  */
-uint32_t CLOCK_GetCtimerClkFreq(uint32_t id);
+uint32_t CLOCK_GetCTimerClkFreq(uint32_t id);
 /*! @brief  Return Frequency of ClockOut
  *  @return Frequency of ClockOut
  */


### PR DESCRIPTION
LPC series has the CTimer Clock API as CLOCK_GetCTimerClkFreq(). The RT685 CTimer API is defined as CLOCK_GetCtimerClkFreq(), change this to match the LPC series.

This has also been reported to the SDK team to fix in the SDK code base.
