### PR TITLE
MIMXRT685S: Rename INPUTMUX_PINT_SEL count

### DIFF
--- a/mcux/devices/MIMXRT685S/MIMXRT685S_cm33.h
+++ b/mcux/devices/MIMXRT685S/MIMXRT685S_cm33.h
@@ -17417,7 +17417,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - DSP Interrupt Input Multiplexers N */
 /*! @{ */

--- a/mcux/devices/MIMXRT685S/MIMXRT685S_dsp.h
+++ b/mcux/devices/MIMXRT685S/MIMXRT685S_dsp.h
@@ -12474,7 +12474,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - DSP Interrupt Input Multiplexers N */
 /*! @{ */


### PR DESCRIPTION
Rename the GPIO INPUTMUX_PINT_SEL from INPUTMUX_PINT_SEL_COUNT
to INPUTMUX_PINTSEL_COUNT.

Signed-off-by: Navin Sankar Velliangiri <navin@linumiz.com>

Fixes: [37148](https://github.com/zephyrproject-rtos/zephyr/pull/37148) build failure.