### PR TITLE
drivers: lpc: Add SCTimer SDK driver

### DIFF
--- a/mcux/drivers/lpc/CMakeLists.txt
+++ b/mcux/drivers/lpc/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_MCUX_LPC		fsl_gpio.c fsl_pint.c fsl_inp
 zephyr_library_sources_ifdef(CONFIG_I2C_MCUX_FLEXCOMM		fsl_i2c.c fsl_flexcomm.c)
 zephyr_library_sources_ifdef(CONFIG_I2S_MCUX_FLEXCOMM		fsl_i2s.c fsl_flexcomm.c)
 zephyr_library_sources_ifdef(CONFIG_MCUX_OS_TIMER		fsl_ostimer.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_MCUX_SCTIMER		fsl_sctimer.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_LPC		fsl_flashiap.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_FLASH_MCUX		fsl_iap.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_MCUX_FLEXCOMM		fsl_spi.c fsl_flexcomm.c)


### PR DESCRIPTION
This driver is used to add PWM support
