### PR TITLE
mcux: devices: mke1xf: fix CAN_Type number of mailboxes

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -103,3 +103,4 @@ Patch List:
 
    * Align the CTimer Clock Get API on RT685 with LPC series
 
+   * Fix the number of FlexCAN mailboxes in the MKE1xF CAN_Type structs.

--- a/mcux/devices/MKE16F16/MKE16F16.h
+++ b/mcux/devices/MKE16F16/MKE16F16.h
@@ -1487,8 +1487,8 @@ typedef struct {
     __IO uint32_t ID;                                /**< Message Buffer 0 ID Register..Message Buffer 63 ID Register, array offset: 0x84, array step: 0x10 */
     __IO uint32_t WORD0;                             /**< Message Buffer 0 WORD0 Register..Message Buffer 63 WORD0 Register, array offset: 0x88, array step: 0x10 */
     __IO uint32_t WORD1;                             /**< Message Buffer 0 WORD1 Register..Message Buffer 63 WORD1 Register, array offset: 0x8C, array step: 0x10 */
-  } MB[64];
-       uint8_t RESERVED_5[1024];
+  } MB[16];
+       uint8_t RESERVED_5[1792];
   __IO uint32_t RXIMR[16];                         /**< Rx Individual Mask Registers, array offset: 0x880, array step: 0x4 */
 } CAN_Type;
 

--- a/mcux/devices/MKE18F16/MKE18F16.h
+++ b/mcux/devices/MKE18F16/MKE18F16.h
@@ -1487,8 +1487,8 @@ typedef struct {
     __IO uint32_t ID;                                /**< Message Buffer 0 ID Register..Message Buffer 63 ID Register, array offset: 0x84, array step: 0x10 */
     __IO uint32_t WORD0;                             /**< Message Buffer 0 WORD0 Register..Message Buffer 63 WORD0 Register, array offset: 0x88, array step: 0x10 */
     __IO uint32_t WORD1;                             /**< Message Buffer 0 WORD1 Register..Message Buffer 63 WORD1 Register, array offset: 0x8C, array step: 0x10 */
-  } MB[64];
-       uint8_t RESERVED_5[1024];
+  } MB[16];
+       uint8_t RESERVED_5[1792];
   __IO uint32_t RXIMR[16];                         /**< Rx Individual Mask Registers, array offset: 0x880, array step: 0x4 */
 } CAN_Type;
 


### PR DESCRIPTION
Fix the size of mailbox registers (the KE1xF has 16 mailboxes, not 64). Fix the offset of the RXIMR registers.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>