### PR TITLE
mcux: Add support for mimxrt1050_evk_qspi

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -209,6 +209,9 @@ elseif(CONFIG_BOARD_MIMXRT1024_EVK)
   set(MCUX_BOARD evkmimxrt1024)
 elseif(CONFIG_BOARD_MIMXRT1050_EVK OR CONFIG_BOARD_MIMXRT1050_EVK_QSPI)
   set(MCUX_BOARD evkbimxrt1050)
+if (CONFIG_BOARD_MIMXRT1050_EVK_QSPI)
+  set(MCUX_BOARD_MOD _qspi)
+endif()
 elseif(CONFIG_BOARD_MIMXRT1060_EVK OR CONFIG_BOARD_MIMXRT1060_EVK_HYPERFLASH)
   set(MCUX_BOARD evkmimxrt1060)
 elseif(CONFIG_BOARD_MIMXRT1064_EVK)
@@ -228,7 +231,7 @@ if (${MCUX_BOARD} MATCHES "evk[bm]imxrt1[0-9][0-9][0-9]")
   list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD}/xip
   )
-  include_ifdef(CONFIG_BOOT_FLEXSPI_NOR driver_xip_board_${MCUX_BOARD})
+  include_ifdef(CONFIG_BOOT_FLEXSPI_NOR driver_xip_board_${MCUX_BOARD}${MCUX_BOARD_MOD})
   zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mcux-sdk/boards/${MCUX_BOARD}/dcd.c)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD})
 

--- a/mcux/mcux-sdk/boards/evkbimxrt1050/xip/driver_xip_board_evkbimxrt1050_qspi.cmake
+++ b/mcux/mcux-sdk/boards/evkbimxrt1050/xip/driver_xip_board_evkbimxrt1050_qspi.cmake
@@ -1,0 +1,14 @@
+#Description: XIP Board Driver; user_visible: True
+include_guard(GLOBAL)
+message("driver_xip_board_evkbimxrt1050 component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/evkbimxrt1050_flexspi_nor_qspi_config.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common)

--- a/mcux/mcux-sdk/boards/evkbimxrt1050/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
+++ b/mcux/mcux-sdk/boards/evkbimxrt1050/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "evkbimxrt1050_flexspi_nor_config.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.xip_board"
+#endif
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+__attribute__((section(".boot_hdr.conf"), used))
+#elif defined(__ICCARM__)
+#pragma location = ".boot_hdr.conf"
+#endif
+
+const flexspi_nor_config_t qspiflash_config = {
+    .memConfig =
+        {
+            .tag              = FLEXSPI_CFG_BLK_TAG,
+            .version          = FLEXSPI_CFG_BLK_VERSION,
+            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+            .csHoldTime       = 3u,
+            .csSetupTime      = 3u,
+            .sflashPadType    = kSerialFlash_4Pads,
+            .serialClkFreq    = kFlexSpiSerialClk_100MHz,
+            .sflashA1Size     = 8u * 1024u * 1024u,
+            .lookupTable =
+                {
+                    // Read LUTs
+                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+                },
+        },
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .blockSize          = 64u * 1024u,
+    .isUniformBlockSize = false,
+};
+#endif /* XIP_BOOT_HEADER_ENABLE */


### PR DESCRIPTION
Add support for mimxrt1050_evk_qspi. This board should support both
boot-from-hyperflash and boot-from-qspi. This modification enables a
modified board to boot from the on-board qspi nor chip.

Signed-off-by: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>