### PR TITLE
cmake: Include system_xxx.c file

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -99,4 +99,3 @@ include(${CMAKE_CURRENT_LIST_DIR}/hal_nxp.cmake)
 enable_language(C ASM)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_LPC54114_M4 mcux-sdk/devices/${MCUX_DEVICE}/gcc/startup_LPC54114_cm4.S)
-zephyr_library_sources_ifdef(CONFIG_SOC_MIMXRT685S_CM33 mcux-sdk/devices/${MCUX_DEVICE}/system_MIMXRT685S_cm33.c)

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -43,6 +43,8 @@ zephyr_library_compile_definitions_ifdef(
 )
 
 include(driver_common)
+include(device_system)
+
 zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/common)
 
 #include shared drivers

--- a/mcux/mcux-sdk/devices/MIMXRT595S/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MIMXRT595S/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MIMXRT595S_cm33.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)

--- a/mcux/mcux-sdk/devices/MIMXRT685S/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MIMXRT685S/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MIMXRT685S_cm33.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)


### PR DESCRIPTION
Include the `system_xxx.c` file that the SDK provides into the zephyr build.

