### PR TITLE
Enable Power Management HAL drivers

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -149,6 +149,7 @@ if (${MCUX_DEVICE} MATCHES "MIMXRT11[0-9][0-9]")
 elseif (${MCUX_DEVICE} MATCHES "MIMXRT10[0-9][0-9]")
    include_driver_ifdef(CONFIG_PM_MCUX_GPC		gpc_1		driver_gpc_1)
    include_driver_ifdef(CONFIG_PM_MCUX_DCDC		dcdc_1		driver_dcdc_1)
+   include_driver_ifdef(CONFIG_PM_MCUX_PMU		pmu		driver_pmu)
 endif()
 
 if("${CONFIG_SOC_FAMILY}" STREQUAL "nxp_kinetis")

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -144,6 +144,13 @@ elseif((${MCUX_DEVICE} MATCHES "MK(28|66)") OR (${MCUX_DEVICE} MATCHES "MKE(14|1
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/lmem	driver_cache_lmem)
 endif()
 
+if (${MCUX_DEVICE} MATCHES "MIMXRT11[0-9][0-9]")
+   include_driver_ifdef(CONFIG_PM_MCUX_GPC		gpc_3		driver_gpc_3)
+elseif (${MCUX_DEVICE} MATCHES "MIMXRT10[0-9][0-9]")
+   include_driver_ifdef(CONFIG_PM_MCUX_GPC		gpc_1		driver_gpc_1)
+   include_driver_ifdef(CONFIG_PM_MCUX_DCDC		dcdc_1		driver_dcdc_1)
+endif()
+
 if("${CONFIG_SOC_FAMILY}" STREQUAL "nxp_kinetis")
 
   include_driver_ifdef(CONFIG_SOC_FLASH_MCUX		flash		driver_flash)

--- a/mcux/mcux-sdk/drivers/pmu/driver_pmu.cmake
+++ b/mcux/mcux-sdk/drivers/pmu/driver_pmu.cmake
@@ -1,0 +1,14 @@
+#Description: PMU Driver; user_visible: True
+include_guard(GLOBAL)
+message("driver_pmu component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/fsl_pmu.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common)


### PR DESCRIPTION
Adds required include file definitions to NXP HAL cmake file, to include the PMU, GPC, and DCDC hal drivers. Additionally updates MCUX HAL to commit `81a42c9e5875b70f0acdf10c23aa977ce1135100`, which includes the required driver cmake file to the PMU component.