### PR TITLE
mcux: Enable inclusion of soc_src driver for RT11xx

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -146,6 +146,7 @@ endif()
 
 if (${MCUX_DEVICE} MATCHES "MIMXRT11[0-9][0-9]")
    include_driver_ifdef(CONFIG_PM_MCUX_GPC		gpc_3		driver_gpc_3)
+   include_ifdef(CONFIG_HWINFO_MCUX_SRC_V2		driver_soc_src)
 elseif (${MCUX_DEVICE} MATCHES "MIMXRT10[0-9][0-9]")
    include_driver_ifdef(CONFIG_PM_MCUX_GPC		gpc_1		driver_gpc_1)
    include_driver_ifdef(CONFIG_PM_MCUX_DCDC		dcdc_1		driver_dcdc_1)


### PR DESCRIPTION
RT11xx has soc specific system reset controller driver. Enable inclusion
of this driver, and only include generic SOC driver if not building for
RT11xx

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>