### PR TITLE
dts: update iMX RT pinctrl nodes with /omit-if-no-ref/ property

### DIFF
--- a/dts/nxp/nxp_imx/rt/mimxrt1011cae4a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1011cae4a-pinctrl.dtsi
@@ -18,941 +18,941 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_00_flexspi_b_dqs: IOMUXC_GPIO_00_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_00_flexspi_b_dqs: IOMUXC_GPIO_00_FLEXSPI_B_DQS {
 		pinmux = <0x401f80bc 0 0x401f8198 1 0x401f816c>;
 	};
-	iomuxc_gpio_00_gpiomux_io00: IOMUXC_GPIO_00_GPIOMUX_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_00_gpiomux_io00: IOMUXC_GPIO_00_GPIOMUX_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_lpspi1_pcs3: IOMUXC_GPIO_00_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_00_lpspi1_pcs3: IOMUXC_GPIO_00_LPSPI1_PCS3 {
 		pinmux = <0x401f80bc 3 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_lpspi2_pcs3: IOMUXC_GPIO_00_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_00_lpspi2_pcs3: IOMUXC_GPIO_00_LPSPI2_PCS3 {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_pit_trigger0: IOMUXC_GPIO_00_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_00_pit_trigger0: IOMUXC_GPIO_00_PIT_TRIGGER0 {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_sai3_mclk: IOMUXC_GPIO_00_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_00_sai3_mclk: IOMUXC_GPIO_00_SAI3_MCLK {
 		pinmux = <0x401f80bc 1 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_01_flexpwm1_pwm0_b: IOMUXC_GPIO_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_01_flexpwm1_pwm0_b: IOMUXC_GPIO_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x401f80b8 2 0x401f8184 1 0x401f8168>;
 	};
-	iomuxc_gpio_01_gpiomux_io01: IOMUXC_GPIO_01_GPIOMUX_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_01_gpiomux_io01: IOMUXC_GPIO_01_GPIOMUX_IO01 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_01_kpp_row3: IOMUXC_GPIO_01_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_01_kpp_row3: IOMUXC_GPIO_01_KPP_ROW3 {
 		pinmux = <0x401f80b8 4 0x401f81b8 1 0x401f8168>;
 	};
-	iomuxc_gpio_01_lpi2c1_sda: IOMUXC_GPIO_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_01_lpi2c1_sda: IOMUXC_GPIO_01_LPI2C1_SDA {
 		pinmux = <0x401f80b8 3 0x401f81c4 3 0x401f8168>;
 	};
-	iomuxc_gpio_01_sai1_rx_bclk: IOMUXC_GPIO_01_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_01_sai1_rx_bclk: IOMUXC_GPIO_01_SAI1_RX_BCLK {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_01_wdog1_any: IOMUXC_GPIO_01_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_01_wdog1_any: IOMUXC_GPIO_01_WDOG1_ANY {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_02_flexpwm1_pwm0_a: IOMUXC_GPIO_02_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_02_flexpwm1_pwm0_a: IOMUXC_GPIO_02_FLEXPWM1_PWM0_A {
 		pinmux = <0x401f80b4 2 0x401f8174 1 0x401f8164>;
 	};
-	iomuxc_gpio_02_gpiomux_io02: IOMUXC_GPIO_02_GPIOMUX_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_02_gpiomux_io02: IOMUXC_GPIO_02_GPIOMUX_IO02 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_02_kpp_col3: IOMUXC_GPIO_02_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_02_kpp_col3: IOMUXC_GPIO_02_KPP_COL3 {
 		pinmux = <0x401f80b4 4 0x401f81a8 1 0x401f8164>;
 	};
-	iomuxc_gpio_02_lpi2c1_scl: IOMUXC_GPIO_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_02_lpi2c1_scl: IOMUXC_GPIO_02_LPI2C1_SCL {
 		pinmux = <0x401f80b4 3 0x401f81c0 3 0x401f8164>;
 	};
-	iomuxc_gpio_02_sai1_rx_sync: IOMUXC_GPIO_02_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_02_sai1_rx_sync: IOMUXC_GPIO_02_SAI1_RX_SYNC {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_02_wdog2_b: IOMUXC_GPIO_02_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_02_wdog2_b: IOMUXC_GPIO_02_WDOG2_B {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_03_flexpwm1_pwm1_b: IOMUXC_GPIO_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_03_flexpwm1_pwm1_b: IOMUXC_GPIO_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x401f80b0 2 0x401f8188 1 0x401f8160>;
 	};
-	iomuxc_gpio_03_gpiomux_io03: IOMUXC_GPIO_03_GPIOMUX_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_03_gpiomux_io03: IOMUXC_GPIO_03_GPIOMUX_IO03 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_gpt1_compare3: IOMUXC_GPIO_03_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_03_gpt1_compare3: IOMUXC_GPIO_03_GPT1_COMPARE3 {
 		pinmux = <0x401f80b0 1 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_sai1_rx_data0: IOMUXC_GPIO_03_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_03_sai1_rx_data0: IOMUXC_GPIO_03_SAI1_RX_DATA0 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_spdif_sr_clk: IOMUXC_GPIO_03_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_03_spdif_sr_clk: IOMUXC_GPIO_03_SPDIF_SR_CLK {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_04_flexpwm1_pwm1_a: IOMUXC_GPIO_04_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_04_flexpwm1_pwm1_a: IOMUXC_GPIO_04_FLEXPWM1_PWM1_A {
 		pinmux = <0x401f80ac 2 0x401f8178 1 0x401f815c>;
 	};
-	iomuxc_gpio_04_gpiomux_io04: IOMUXC_GPIO_04_GPIOMUX_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_04_gpiomux_io04: IOMUXC_GPIO_04_GPIOMUX_IO04 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_gpt1_capture2: IOMUXC_GPIO_04_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_04_gpt1_capture2: IOMUXC_GPIO_04_GPT1_CAPTURE2 {
 		pinmux = <0x401f80ac 1 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_sai1_tx_data0: IOMUXC_GPIO_04_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_04_sai1_tx_data0: IOMUXC_GPIO_04_SAI1_TX_DATA0 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_spdif_in: IOMUXC_GPIO_04_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_04_spdif_in: IOMUXC_GPIO_04_SPDIF_IN {
 		pinmux = <0x401f80ac 4 0x401f8214 1 0x401f815c>;
 	};
-	iomuxc_gpio_05_flexpwm1_pwm2_b: IOMUXC_GPIO_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_05_flexpwm1_pwm2_b: IOMUXC_GPIO_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x401f80a8 2 0x401f818c 1 0x401f8158>;
 	};
-	iomuxc_gpio_05_gpiomux_io05: IOMUXC_GPIO_05_GPIOMUX_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_05_gpiomux_io05: IOMUXC_GPIO_05_GPIOMUX_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_gpt1_compare2: IOMUXC_GPIO_05_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_05_gpt1_compare2: IOMUXC_GPIO_05_GPT1_COMPARE2 {
 		pinmux = <0x401f80a8 1 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_lpuart4_rxd: IOMUXC_GPIO_05_LPUART4_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_05_lpuart4_rxd: IOMUXC_GPIO_05_LPUART4_RXD {
 		pinmux = <0x401f80a8 3 0x401f8208 1 0x401f8158>;
 	};
-	iomuxc_gpio_05_sai1_tx_data1: IOMUXC_GPIO_05_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_05_sai1_tx_data1: IOMUXC_GPIO_05_SAI1_TX_DATA1 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_spdif_out: IOMUXC_GPIO_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_05_spdif_out: IOMUXC_GPIO_05_SPDIF_OUT {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_06_flexpwm1_pwm2_a: IOMUXC_GPIO_06_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_06_flexpwm1_pwm2_a: IOMUXC_GPIO_06_FLEXPWM1_PWM2_A {
 		pinmux = <0x401f80a4 2 0x401f817c 1 0x401f8154>;
 	};
-	iomuxc_gpio_06_gpiomux_io06: IOMUXC_GPIO_06_GPIOMUX_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_06_gpiomux_io06: IOMUXC_GPIO_06_GPIOMUX_IO06 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_gpt1_capture1: IOMUXC_GPIO_06_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_06_gpt1_capture1: IOMUXC_GPIO_06_GPT1_CAPTURE1 {
 		pinmux = <0x401f80a4 1 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_lpuart4_txd: IOMUXC_GPIO_06_LPUART4_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_06_lpuart4_txd: IOMUXC_GPIO_06_LPUART4_TXD {
 		pinmux = <0x401f80a4 3 0x401f820c 1 0x401f8154>;
 	};
-	iomuxc_gpio_06_sai1_tx_bclk: IOMUXC_GPIO_06_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_06_sai1_tx_bclk: IOMUXC_GPIO_06_SAI1_TX_BCLK {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_spdif_ext_clk: IOMUXC_GPIO_06_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_06_spdif_ext_clk: IOMUXC_GPIO_06_SPDIF_EXT_CLK {
 		pinmux = <0x401f80a4 4 0x401f8218 1 0x401f8154>;
 	};
-	iomuxc_gpio_07_flexpwm1_pwm3_b: IOMUXC_GPIO_07_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_07_flexpwm1_pwm3_b: IOMUXC_GPIO_07_FLEXPWM1_PWM3_B {
 		pinmux = <0x401f80a0 2 0x401f8190 1 0x401f8150>;
 	};
-	iomuxc_gpio_07_gpiomux_io07: IOMUXC_GPIO_07_GPIOMUX_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_07_gpiomux_io07: IOMUXC_GPIO_07_GPIOMUX_IO07 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_gpt1_compare1: IOMUXC_GPIO_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_07_gpt1_compare1: IOMUXC_GPIO_07_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 1 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_lpuart1_rts_b: IOMUXC_GPIO_07_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_07_lpuart1_rts_b: IOMUXC_GPIO_07_LPUART1_RTS_B {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_lpuart3_rxd: IOMUXC_GPIO_07_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_07_lpuart3_rxd: IOMUXC_GPIO_07_LPUART3_RXD {
 		pinmux = <0x401f80a0 3 0x401f8200 2 0x401f8150>;
 	};
-	iomuxc_gpio_07_sai1_tx_sync: IOMUXC_GPIO_07_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_07_sai1_tx_sync: IOMUXC_GPIO_07_SAI1_TX_SYNC {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_spdif_lock: IOMUXC_GPIO_07_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_07_spdif_lock: IOMUXC_GPIO_07_SPDIF_LOCK {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_08_flexio1_io00: IOMUXC_GPIO_08_FLEXIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_08_flexio1_io00: IOMUXC_GPIO_08_FLEXIO1_IO00 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_flexpwm1_pwm3_a: IOMUXC_GPIO_08_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_08_flexpwm1_pwm3_a: IOMUXC_GPIO_08_FLEXPWM1_PWM3_A {
 		pinmux = <0x401f809c 2 0x401f8180 1 0x401f814c>;
 	};
-	iomuxc_gpio_08_gpiomux_io08: IOMUXC_GPIO_08_GPIOMUX_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_08_gpiomux_io08: IOMUXC_GPIO_08_GPIOMUX_IO08 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_gpt1_clk: IOMUXC_GPIO_08_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_08_gpt1_clk: IOMUXC_GPIO_08_GPT1_CLK {
 		pinmux = <0x401f809c 1 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_lpuart1_cts_b: IOMUXC_GPIO_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_08_lpuart1_cts_b: IOMUXC_GPIO_08_LPUART1_CTS_B {
 		pinmux = <0x401f809c 6 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_lpuart3_txd: IOMUXC_GPIO_08_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_08_lpuart3_txd: IOMUXC_GPIO_08_LPUART3_TXD {
 		pinmux = <0x401f809c 3 0x401f8204 2 0x401f814c>;
 	};
-	iomuxc_gpio_08_sai1_mclk: IOMUXC_GPIO_08_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_08_sai1_mclk: IOMUXC_GPIO_08_SAI1_MCLK {
 		pinmux = <0x401f809c 0 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_09_flexio1_io01: IOMUXC_GPIO_09_FLEXIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_09_flexio1_io01: IOMUXC_GPIO_09_FLEXIO1_IO01 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_flexspi_a_ss1_b: IOMUXC_GPIO_09_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_09_flexspi_a_ss1_b: IOMUXC_GPIO_09_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_gpiomux_io09: IOMUXC_GPIO_09_GPIOMUX_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_09_gpiomux_io09: IOMUXC_GPIO_09_GPIOMUX_IO09 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_lpi2c2_sda: IOMUXC_GPIO_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_09_lpi2c2_sda: IOMUXC_GPIO_09_LPI2C2_SDA {
 		pinmux = <0x401f8098 3 0x401f81cc 3 0x401f8148>;
 	};
-	iomuxc_gpio_09_lpuart1_rxd: IOMUXC_GPIO_09_LPUART1_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_09_lpuart1_rxd: IOMUXC_GPIO_09_LPUART1_RXD {
 		pinmux = <0x401f8098 0 0x401f81f0 1 0x401f8148>;
 	};
-	iomuxc_gpio_09_spdif_sr_clk: IOMUXC_GPIO_09_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_09_spdif_sr_clk: IOMUXC_GPIO_09_SPDIF_SR_CLK {
 		pinmux = <0x401f8098 6 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_wdog1_b: IOMUXC_GPIO_09_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_09_wdog1_b: IOMUXC_GPIO_09_WDOG1_B {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_10_ewm_out_b: IOMUXC_GPIO_10_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_10_ewm_out_b: IOMUXC_GPIO_10_EWM_OUT_B {
 		pinmux = <0x401f8094 2 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_flexio1_io02: IOMUXC_GPIO_10_FLEXIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_10_flexio1_io02: IOMUXC_GPIO_10_FLEXIO1_IO02 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_gpiomux_io10: IOMUXC_GPIO_10_GPIOMUX_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_10_gpiomux_io10: IOMUXC_GPIO_10_GPIOMUX_IO10 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpi2c1_hreq: IOMUXC_GPIO_10_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpi2c1_hreq: IOMUXC_GPIO_10_LPI2C1_HREQ {
 		pinmux = <0x401f8094 1 0x401f81bc 1 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpi2c2_scl: IOMUXC_GPIO_10_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpi2c2_scl: IOMUXC_GPIO_10_LPI2C2_SCL {
 		pinmux = <0x401f8094 3 0x401f81c8 3 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpuart1_txd: IOMUXC_GPIO_10_LPUART1_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpuart1_txd: IOMUXC_GPIO_10_LPUART1_TXD {
 		pinmux = <0x401f8094 0 0x401f81f4 1 0x401f8144>;
 	};
-	iomuxc_gpio_10_spdif_in: IOMUXC_GPIO_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_10_spdif_in: IOMUXC_GPIO_10_SPDIF_IN {
 		pinmux = <0x401f8094 6 0x401f8214 0 0x401f8144>;
 	};
-	iomuxc_gpio_11_arm_trace3: IOMUXC_GPIO_11_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_11_arm_trace3: IOMUXC_GPIO_11_ARM_TRACE3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_flexio1_io03: IOMUXC_GPIO_11_FLEXIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_11_flexio1_io03: IOMUXC_GPIO_11_FLEXIO1_IO03 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_flexspi_b_ss1_b: IOMUXC_GPIO_11_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_11_flexspi_b_ss1_b: IOMUXC_GPIO_11_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_gpiomux_io11: IOMUXC_GPIO_11_GPIOMUX_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_11_gpiomux_io11: IOMUXC_GPIO_11_GPIOMUX_IO11 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_kpp_row0: IOMUXC_GPIO_11_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_11_kpp_row0: IOMUXC_GPIO_11_KPP_ROW0 {
 		pinmux = <0x401f8090 2 0x401f81ac 1 0x401f8140>;
 	};
-	iomuxc_gpio_11_lpi2c1_sda: IOMUXC_GPIO_11_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_11_lpi2c1_sda: IOMUXC_GPIO_11_LPI2C1_SDA {
 		pinmux = <0x401f8090 1 0x401f81c4 2 0x401f8140>;
 	};
-	iomuxc_gpio_11_lpuart3_rxd: IOMUXC_GPIO_11_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_11_lpuart3_rxd: IOMUXC_GPIO_11_LPUART3_RXD {
 		pinmux = <0x401f8090 0 0x401f8200 1 0x401f8140>;
 	};
-	iomuxc_gpio_11_spdif_out: IOMUXC_GPIO_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_11_spdif_out: IOMUXC_GPIO_11_SPDIF_OUT {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_12_arm_trace2: IOMUXC_GPIO_12_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_12_arm_trace2: IOMUXC_GPIO_12_ARM_TRACE2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_flexio1_io04: IOMUXC_GPIO_12_FLEXIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_12_flexio1_io04: IOMUXC_GPIO_12_FLEXIO1_IO04 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_gpiomux_io12: IOMUXC_GPIO_12_GPIOMUX_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_12_gpiomux_io12: IOMUXC_GPIO_12_GPIOMUX_IO12 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_kpp_col0: IOMUXC_GPIO_12_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_12_kpp_col0: IOMUXC_GPIO_12_KPP_COL0 {
 		pinmux = <0x401f808c 2 0x401f819c 1 0x401f813c>;
 	};
-	iomuxc_gpio_12_lpi2c1_scl: IOMUXC_GPIO_12_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_12_lpi2c1_scl: IOMUXC_GPIO_12_LPI2C1_SCL {
 		pinmux = <0x401f808c 1 0x401f81c0 2 0x401f813c>;
 	};
-	iomuxc_gpio_12_lpuart3_txd: IOMUXC_GPIO_12_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_12_lpuart3_txd: IOMUXC_GPIO_12_LPUART3_TXD {
 		pinmux = <0x401f808c 0 0x401f8204 1 0x401f813c>;
 	};
-	iomuxc_gpio_12_spdif_ext_clk: IOMUXC_GPIO_12_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_12_spdif_ext_clk: IOMUXC_GPIO_12_SPDIF_EXT_CLK {
 		pinmux = <0x401f808c 6 0x401f8218 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_usb_otg1_oc: IOMUXC_GPIO_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_12_usb_otg1_oc: IOMUXC_GPIO_12_USB_OTG1_OC {
 		pinmux = <0x401f808c 3 0x401f821c 1 0x401f813c>;
 	};
-	iomuxc_gpio_13_arm_trace1: IOMUXC_GPIO_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_13_arm_trace1: IOMUXC_GPIO_13_ARM_TRACE1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_flexio1_io05: IOMUXC_GPIO_13_FLEXIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_13_flexio1_io05: IOMUXC_GPIO_13_FLEXIO1_IO05 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_gpiomux_io13: IOMUXC_GPIO_13_GPIOMUX_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_13_gpiomux_io13: IOMUXC_GPIO_13_GPIOMUX_IO13 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_kpp_row3: IOMUXC_GPIO_13_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_13_kpp_row3: IOMUXC_GPIO_13_KPP_ROW3 {
 		pinmux = <0x401f8088 2 0x401f81b8 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_lpspi2_pcs2: IOMUXC_GPIO_13_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_13_lpspi2_pcs2: IOMUXC_GPIO_13_LPSPI2_PCS2 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_lpuart2_rxd: IOMUXC_GPIO_13_LPUART2_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_13_lpuart2_rxd: IOMUXC_GPIO_13_LPUART2_RXD {
 		pinmux = <0x401f8088 0 0x401f81f8 1 0x401f8138>;
 	};
-	iomuxc_gpio_13_spdif_lock: IOMUXC_GPIO_13_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_13_spdif_lock: IOMUXC_GPIO_13_SPDIF_LOCK {
 		pinmux = <0x401f8088 6 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_usb_otg1_id: IOMUXC_GPIO_13_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_13_usb_otg1_id: IOMUXC_GPIO_13_USB_OTG1_ID {
 		pinmux = <0x401f8088 3 0x401f8170 1 0x401f8138>;
 	};
-	iomuxc_gpio_ad_00_adc1_in0: IOMUXC_GPIO_AD_00_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_adc1_in0: IOMUXC_GPIO_AD_00_ADC1_IN0 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_arm_nmi: IOMUXC_GPIO_AD_00_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_arm_nmi: IOMUXC_GPIO_AD_00_ARM_NMI {
 		pinmux = <0x401f8048 6 0x401f8210 1 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_arm_trace0: IOMUXC_GPIO_AD_00_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_arm_trace0: IOMUXC_GPIO_AD_00_ARM_TRACE0 {
 		pinmux = <0x401f8048 7 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_flexio1_io20: IOMUXC_GPIO_AD_00_FLEXIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio1_io20: IOMUXC_GPIO_AD_00_FLEXIO1_IO20 {
 		pinmux = <0x401f8048 4 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_gpiomux_io14: IOMUXC_GPIO_AD_00_GPIOMUX_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpiomux_io14: IOMUXC_GPIO_AD_00_GPIOMUX_IO14 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_kpp_col3: IOMUXC_GPIO_AD_00_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_kpp_col3: IOMUXC_GPIO_AD_00_KPP_COL3 {
 		pinmux = <0x401f8048 2 0x401f81a8 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_lpspi1_pcs2: IOMUXC_GPIO_AD_00_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpspi1_pcs2: IOMUXC_GPIO_AD_00_LPSPI1_PCS2 {
 		pinmux = <0x401f8048 1 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_lpuart2_txd: IOMUXC_GPIO_AD_00_LPUART2_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart2_txd: IOMUXC_GPIO_AD_00_LPUART2_TXD {
 		pinmux = <0x401f8048 0 0x401f81fc 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_usb_otg1_pwr: IOMUXC_GPIO_AD_00_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_usb_otg1_pwr: IOMUXC_GPIO_AD_00_USB_OTG1_PWR {
 		pinmux = <0x401f8048 3 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_01_adc1_in1: IOMUXC_GPIO_AD_01_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_adc1_in1: IOMUXC_GPIO_AD_01_ADC1_IN1 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_arm_trace_swo: IOMUXC_GPIO_AD_01_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_arm_trace_swo: IOMUXC_GPIO_AD_01_ARM_TRACE_SWO {
 		pinmux = <0x401f8044 7 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_gpiomux_io15: IOMUXC_GPIO_AD_01_GPIOMUX_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpiomux_io15: IOMUXC_GPIO_AD_01_GPIOMUX_IO15 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpi2c2_sda: IOMUXC_GPIO_AD_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpi2c2_sda: IOMUXC_GPIO_AD_01_LPI2C2_SDA {
 		pinmux = <0x401f8044 3 0x401f81cc 1 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpspi2_pcs1: IOMUXC_GPIO_AD_01_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpspi2_pcs1: IOMUXC_GPIO_AD_01_LPSPI2_PCS1 {
 		pinmux = <0x401f8044 1 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpuart4_rxd: IOMUXC_GPIO_AD_01_LPUART4_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart4_rxd: IOMUXC_GPIO_AD_01_LPUART4_RXD {
 		pinmux = <0x401f8044 0 0x401f8208 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_mqs_left: IOMUXC_GPIO_AD_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_mqs_left: IOMUXC_GPIO_AD_01_MQS_LEFT {
 		pinmux = <0x401f8044 4 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_usb_otg1_oc: IOMUXC_GPIO_AD_01_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_usb_otg1_oc: IOMUXC_GPIO_AD_01_USB_OTG1_OC {
 		pinmux = <0x401f8044 6 0x401f821c 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_wdog1_any: IOMUXC_GPIO_AD_01_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_wdog1_any: IOMUXC_GPIO_AD_01_WDOG1_ANY {
 		pinmux = <0x401f8044 2 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_02_adc1_in2: IOMUXC_GPIO_AD_02_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_adc1_in2: IOMUXC_GPIO_AD_02_ADC1_IN2 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_arm_trace_clk: IOMUXC_GPIO_AD_02_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_arm_trace_clk: IOMUXC_GPIO_AD_02_ARM_TRACE_CLK {
 		pinmux = <0x401f8040 7 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_gpiomux_io16: IOMUXC_GPIO_AD_02_GPIOMUX_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpiomux_io16: IOMUXC_GPIO_AD_02_GPIOMUX_IO16 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpi2c2_scl: IOMUXC_GPIO_AD_02_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpi2c2_scl: IOMUXC_GPIO_AD_02_LPI2C2_SCL {
 		pinmux = <0x401f8040 3 0x401f81c8 1 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpspi1_pcs1: IOMUXC_GPIO_AD_02_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpspi1_pcs1: IOMUXC_GPIO_AD_02_LPSPI1_PCS1 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpuart4_txd: IOMUXC_GPIO_AD_02_LPUART4_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart4_txd: IOMUXC_GPIO_AD_02_LPUART4_TXD {
 		pinmux = <0x401f8040 0 0x401f820c 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_mqs_right: IOMUXC_GPIO_AD_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_mqs_right: IOMUXC_GPIO_AD_02_MQS_RIGHT {
 		pinmux = <0x401f8040 4 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_wdog2_b: IOMUXC_GPIO_AD_02_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_wdog2_b: IOMUXC_GPIO_AD_02_WDOG2_B {
 		pinmux = <0x401f8040 2 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_03_adc1_in3: IOMUXC_GPIO_AD_03_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_adc1_in3: IOMUXC_GPIO_AD_03_ADC1_IN3 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM2_B {
 		pinmux = <0x401f803c 2 0x401f818c 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_gpiomux_io17: IOMUXC_GPIO_AD_03_GPIOMUX_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpiomux_io17: IOMUXC_GPIO_AD_03_GPIOMUX_IO17 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_gpt2_clk: IOMUXC_GPIO_AD_03_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_clk: IOMUXC_GPIO_AD_03_GPT2_CLK {
 		pinmux = <0x401f803c 4 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_jtag_de_b: IOMUXC_GPIO_AD_03_JTAG_DE_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_jtag_de_b: IOMUXC_GPIO_AD_03_JTAG_DE_B {
 		pinmux = <0x401f803c 7 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_kpp_row2: IOMUXC_GPIO_AD_03_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_kpp_row2: IOMUXC_GPIO_AD_03_KPP_ROW2 {
 		pinmux = <0x401f803c 3 0x401f81b4 1 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_lpspi1_sdi: IOMUXC_GPIO_AD_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpspi1_sdi: IOMUXC_GPIO_AD_03_LPSPI1_SDI {
 		pinmux = <0x401f803c 0 0x401f81d8 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_pit_trigger3: IOMUXC_GPIO_AD_03_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_pit_trigger3: IOMUXC_GPIO_AD_03_PIT_TRIGGER3 {
 		pinmux = <0x401f803c 1 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_snvs_vio_5_b: IOMUXC_GPIO_AD_03_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_snvs_vio_5_b: IOMUXC_GPIO_AD_03_SNVS_VIO_5_B {
 		pinmux = <0x401f803c 6 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_04_adc1_in4: IOMUXC_GPIO_AD_04_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_adc1_in4: IOMUXC_GPIO_AD_04_ADC1_IN4 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x401f8038 2 0x401f817c 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_gpiomux_io18: IOMUXC_GPIO_AD_04_GPIOMUX_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpiomux_io18: IOMUXC_GPIO_AD_04_GPIOMUX_IO18 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare1: IOMUXC_GPIO_AD_04_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare1: IOMUXC_GPIO_AD_04_GPT2_COMPARE1 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_kpp_col2: IOMUXC_GPIO_AD_04_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_kpp_col2: IOMUXC_GPIO_AD_04_KPP_COL2 {
 		pinmux = <0x401f8038 3 0x401f81a4 1 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_lpspi1_sdo: IOMUXC_GPIO_AD_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpspi1_sdo: IOMUXC_GPIO_AD_04_LPSPI1_SDO {
 		pinmux = <0x401f8038 0 0x401f81dc 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_pit_trigger2: IOMUXC_GPIO_AD_04_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_pit_trigger2: IOMUXC_GPIO_AD_04_PIT_TRIGGER2 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_snvs_vio_5_ctl: IOMUXC_GPIO_AD_04_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_snvs_vio_5_ctl: IOMUXC_GPIO_AD_04_SNVS_VIO_5_CTL {
 		pinmux = <0x401f8038 6 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_05_adc1_in5: IOMUXC_GPIO_AD_05_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_adc1_in5: IOMUXC_GPIO_AD_05_ADC1_IN5 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm3_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm3_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM3_B {
 		pinmux = <0x401f8034 2 0x401f8190 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_gpiomux_io19: IOMUXC_GPIO_AD_05_GPIOMUX_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpiomux_io19: IOMUXC_GPIO_AD_05_GPIOMUX_IO19 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_gpt2_capture1: IOMUXC_GPIO_AD_05_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_capture1: IOMUXC_GPIO_AD_05_GPT2_CAPTURE1 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_kpp_row1: IOMUXC_GPIO_AD_05_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_kpp_row1: IOMUXC_GPIO_AD_05_KPP_ROW1 {
 		pinmux = <0x401f8034 3 0x401f81b0 1 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_lpspi1_pcs0: IOMUXC_GPIO_AD_05_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpspi1_pcs0: IOMUXC_GPIO_AD_05_LPSPI1_PCS0 {
 		pinmux = <0x401f8034 0 0x401f81d0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_pit_trigger1: IOMUXC_GPIO_AD_05_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_pit_trigger1: IOMUXC_GPIO_AD_05_PIT_TRIGGER1 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_06_adc1_in6: IOMUXC_GPIO_AD_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_in6: IOMUXC_GPIO_AD_06_ADC1_IN6 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm3_a: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm3_a: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM3_A {
 		pinmux = <0x401f8030 2 0x401f8180 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_gpiomux_io20: IOMUXC_GPIO_AD_06_GPIOMUX_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpiomux_io20: IOMUXC_GPIO_AD_06_GPIOMUX_IO20 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_gpt2_compare2: IOMUXC_GPIO_AD_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt2_compare2: IOMUXC_GPIO_AD_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_kpp_col1: IOMUXC_GPIO_AD_06_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_kpp_col1: IOMUXC_GPIO_AD_06_KPP_COL1 {
 		pinmux = <0x401f8030 3 0x401f81a0 1 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_lpi2c1_hreq: IOMUXC_GPIO_AD_06_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_lpi2c1_hreq: IOMUXC_GPIO_AD_06_LPI2C1_HREQ {
 		pinmux = <0x401f8030 6 0x401f81bc 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_lpspi1_sck: IOMUXC_GPIO_AD_06_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_lpspi1_sck: IOMUXC_GPIO_AD_06_LPSPI1_SCK {
 		pinmux = <0x401f8030 0 0x401f81d4 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_pit_trigger0: IOMUXC_GPIO_AD_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_pit_trigger0: IOMUXC_GPIO_AD_06_PIT_TRIGGER0 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_07_adc1_in7: IOMUXC_GPIO_AD_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_in7: IOMUXC_GPIO_AD_07_ADC1_IN7 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_arm_cm7_rxev: IOMUXC_GPIO_AD_07_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_arm_cm7_rxev: IOMUXC_GPIO_AD_07_ARM_CM7_RXEV {
 		pinmux = <0x401f802c 2 0x401f8220 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_gpiomux_io21: IOMUXC_GPIO_AD_07_GPIOMUX_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpiomux_io21: IOMUXC_GPIO_AD_07_GPIOMUX_IO21 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_gpt2_capture2: IOMUXC_GPIO_AD_07_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt2_capture2: IOMUXC_GPIO_AD_07_GPT2_CAPTURE2 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpi2c2_sda: IOMUXC_GPIO_AD_07_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpi2c2_sda: IOMUXC_GPIO_AD_07_LPI2C2_SDA {
 		pinmux = <0x401f802c 0 0x401f81cc 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpuart2_rts_b: IOMUXC_GPIO_AD_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpuart2_rts_b: IOMUXC_GPIO_AD_07_LPUART2_RTS_B {
 		pinmux = <0x401f802c 3 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpuart3_rxd: IOMUXC_GPIO_AD_07_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpuart3_rxd: IOMUXC_GPIO_AD_07_LPUART3_RXD {
 		pinmux = <0x401f802c 1 0x401f8200 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_ocotp_fuse_latched: IOMUXC_GPIO_AD_07_OCOTP_FUSE_LATCHED {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_ocotp_fuse_latched: IOMUXC_GPIO_AD_07_OCOTP_FUSE_LATCHED {
 		pinmux = <0x401f802c 6 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_xbar1_in03: IOMUXC_GPIO_AD_07_XBAR1_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_xbar1_in03: IOMUXC_GPIO_AD_07_XBAR1_IN03 {
 		pinmux = <0x401f802c 7 0x0 0 0x401f80dc>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_07_xbar1_inout03: IOMUXC_GPIO_AD_07_XBAR1_INOUT03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_xbar1_inout03: IOMUXC_GPIO_AD_07_XBAR1_INOUT03 {
 		pinmux = <0x401f802c 7 0x0 0 0x401f80dc>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_08_adc1_in8: IOMUXC_GPIO_AD_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_in8: IOMUXC_GPIO_AD_08_ADC1_IN8 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_arm_cm7_txev: IOMUXC_GPIO_AD_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_arm_cm7_txev: IOMUXC_GPIO_AD_08_ARM_CM7_TXEV {
 		pinmux = <0x401f8028 2 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_ewm_out_b: IOMUXC_GPIO_AD_08_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_ewm_out_b: IOMUXC_GPIO_AD_08_EWM_OUT_B {
 		pinmux = <0x401f8028 6 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_gpiomux_io22: IOMUXC_GPIO_AD_08_GPIOMUX_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpiomux_io22: IOMUXC_GPIO_AD_08_GPIOMUX_IO22 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_gpt2_compare3: IOMUXC_GPIO_AD_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt2_compare3: IOMUXC_GPIO_AD_08_GPT2_COMPARE3 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_jtag_trstb: IOMUXC_GPIO_AD_08_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_jtag_trstb: IOMUXC_GPIO_AD_08_JTAG_TRSTB {
 		pinmux = <0x401f8028 7 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpi2c2_scl: IOMUXC_GPIO_AD_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c2_scl: IOMUXC_GPIO_AD_08_LPI2C2_SCL {
 		pinmux = <0x401f8028 0 0x401f81c8 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpuart2_cts_b: IOMUXC_GPIO_AD_08_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpuart2_cts_b: IOMUXC_GPIO_AD_08_LPUART2_CTS_B {
 		pinmux = <0x401f8028 3 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpuart3_txd: IOMUXC_GPIO_AD_08_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpuart3_txd: IOMUXC_GPIO_AD_08_LPUART3_TXD {
 		pinmux = <0x401f8028 1 0x401f8204 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_09_adc1_in9: IOMUXC_GPIO_AD_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_in9: IOMUXC_GPIO_AD_09_ADC1_IN9 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_arm_trace_swo: IOMUXC_GPIO_AD_09_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_arm_trace_swo: IOMUXC_GPIO_AD_09_ARM_TRACE_SWO {
 		pinmux = <0x401f8024 3 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_flexio1_io21: IOMUXC_GPIO_AD_09_FLEXIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio1_io21: IOMUXC_GPIO_AD_09_FLEXIO1_IO21 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x401f8024 1 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_gpiomux_io23: IOMUXC_GPIO_AD_09_GPIOMUX_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpiomux_io23: IOMUXC_GPIO_AD_09_GPIOMUX_IO23 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_jtag_tdo: IOMUXC_GPIO_AD_09_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_jtag_tdo: IOMUXC_GPIO_AD_09_JTAG_TDO {
 		pinmux = <0x401f8024 7 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_kpp_row2: IOMUXC_GPIO_AD_09_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_kpp_row2: IOMUXC_GPIO_AD_09_KPP_ROW2 {
 		pinmux = <0x401f8024 2 0x401f81b4 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_lpspi2_sdi: IOMUXC_GPIO_AD_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpspi2_sdi: IOMUXC_GPIO_AD_09_LPSPI2_SDI {
 		pinmux = <0x401f8024 0 0x401f81e8 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_10_adc1_in10: IOMUXC_GPIO_AD_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_in10: IOMUXC_GPIO_AD_10_ADC1_IN10 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_flexio1_io22: IOMUXC_GPIO_AD_10_FLEXIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio1_io22: IOMUXC_GPIO_AD_10_FLEXIO1_IO22 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_10_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_10_FLEXPWM1_PWM2_X {
 		pinmux = <0x401f8020 1 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_gpiomux_io24: IOMUXC_GPIO_AD_10_GPIOMUX_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpiomux_io24: IOMUXC_GPIO_AD_10_GPIOMUX_IO24 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_jtag_tdi: IOMUXC_GPIO_AD_10_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_jtag_tdi: IOMUXC_GPIO_AD_10_JTAG_TDI {
 		pinmux = <0x401f8020 7 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_kpp_col2: IOMUXC_GPIO_AD_10_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_kpp_col2: IOMUXC_GPIO_AD_10_KPP_COL2 {
 		pinmux = <0x401f8020 2 0x401f81a4 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_lpspi2_sdo: IOMUXC_GPIO_AD_10_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpspi2_sdo: IOMUXC_GPIO_AD_10_LPSPI2_SDO {
 		pinmux = <0x401f8020 0 0x401f81ec 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_pit_trigger3: IOMUXC_GPIO_AD_10_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_pit_trigger3: IOMUXC_GPIO_AD_10_PIT_TRIGGER3 {
 		pinmux = <0x401f8020 3 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_id: IOMUXC_GPIO_AD_10_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_id: IOMUXC_GPIO_AD_10_USB_OTG1_ID {
 		pinmux = <0x401f8020 6 0x401f8170 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_11_adc1_in11: IOMUXC_GPIO_AD_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_in11: IOMUXC_GPIO_AD_11_ADC1_IN11 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_flexio1_io23: IOMUXC_GPIO_AD_11_FLEXIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio1_io23: IOMUXC_GPIO_AD_11_FLEXIO1_IO23 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM1_PWM1_X {
 		pinmux = <0x401f801c 1 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_gpiomux_io25: IOMUXC_GPIO_AD_11_GPIOMUX_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpiomux_io25: IOMUXC_GPIO_AD_11_GPIOMUX_IO25 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_jtag_mod: IOMUXC_GPIO_AD_11_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_jtag_mod: IOMUXC_GPIO_AD_11_JTAG_MOD {
 		pinmux = <0x401f801c 7 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_kpp_row1: IOMUXC_GPIO_AD_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_kpp_row1: IOMUXC_GPIO_AD_11_KPP_ROW1 {
 		pinmux = <0x401f801c 2 0x401f81b0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_lpspi2_pcs0: IOMUXC_GPIO_AD_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpspi2_pcs0: IOMUXC_GPIO_AD_11_LPSPI2_PCS0 {
 		pinmux = <0x401f801c 0 0x401f81e0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_pit_trigger2: IOMUXC_GPIO_AD_11_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_pit_trigger2: IOMUXC_GPIO_AD_11_PIT_TRIGGER2 {
 		pinmux = <0x401f801c 3 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_wdog1_b: IOMUXC_GPIO_AD_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_wdog1_b: IOMUXC_GPIO_AD_11_WDOG1_B {
 		pinmux = <0x401f801c 6 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_12_adc1_in12: IOMUXC_GPIO_AD_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_in12: IOMUXC_GPIO_AD_12_ADC1_IN12 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_flexio1_io24: IOMUXC_GPIO_AD_12_FLEXIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio1_io24: IOMUXC_GPIO_AD_12_FLEXIO1_IO24 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_12_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_12_FLEXPWM1_PWM0_X {
 		pinmux = <0x401f8018 1 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_gpiomux_io26: IOMUXC_GPIO_AD_12_GPIOMUX_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpiomux_io26: IOMUXC_GPIO_AD_12_GPIOMUX_IO26 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_jtag_tck: IOMUXC_GPIO_AD_12_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_jtag_tck: IOMUXC_GPIO_AD_12_JTAG_TCK {
 		pinmux = <0x401f8018 7 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_kpp_col1: IOMUXC_GPIO_AD_12_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_kpp_col1: IOMUXC_GPIO_AD_12_KPP_COL1 {
 		pinmux = <0x401f8018 2 0x401f81a0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_lpspi2_sck: IOMUXC_GPIO_AD_12_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpspi2_sck: IOMUXC_GPIO_AD_12_LPSPI2_SCK {
 		pinmux = <0x401f8018 0 0x401f81e4 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_pit_trigger1: IOMUXC_GPIO_AD_12_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_pit_trigger1: IOMUXC_GPIO_AD_12_PIT_TRIGGER1 {
 		pinmux = <0x401f8018 3 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_usb_otg1_pwr: IOMUXC_GPIO_AD_12_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_usb_otg1_pwr: IOMUXC_GPIO_AD_12_USB_OTG1_PWR {
 		pinmux = <0x401f8018 6 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_13_adc1_in13: IOMUXC_GPIO_AD_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_in13: IOMUXC_GPIO_AD_13_ADC1_IN13 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_arm_nmi: IOMUXC_GPIO_AD_13_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_arm_nmi: IOMUXC_GPIO_AD_13_ARM_NMI {
 		pinmux = <0x401f8014 6 0x401f8210 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_flexio1_io25: IOMUXC_GPIO_AD_13_FLEXIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio1_io25: IOMUXC_GPIO_AD_13_FLEXIO1_IO25 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_gpiomux_io27: IOMUXC_GPIO_AD_13_GPIOMUX_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpiomux_io27: IOMUXC_GPIO_AD_13_GPIOMUX_IO27 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_jtag_tms: IOMUXC_GPIO_AD_13_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_jtag_tms: IOMUXC_GPIO_AD_13_JTAG_TMS {
 		pinmux = <0x401f8014 7 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_kpp_row0: IOMUXC_GPIO_AD_13_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_kpp_row0: IOMUXC_GPIO_AD_13_KPP_ROW0 {
 		pinmux = <0x401f8014 2 0x401f81ac 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpi2c1_sda: IOMUXC_GPIO_AD_13_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpi2c1_sda: IOMUXC_GPIO_AD_13_LPI2C1_SDA {
 		pinmux = <0x401f8014 0 0x401f81c4 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpuart3_rts_b: IOMUXC_GPIO_AD_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpuart3_rts_b: IOMUXC_GPIO_AD_13_LPUART3_RTS_B {
 		pinmux = <0x401f8014 1 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpuart4_rts_b: IOMUXC_GPIO_AD_13_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpuart4_rts_b: IOMUXC_GPIO_AD_13_LPUART4_RTS_B {
 		pinmux = <0x401f8014 3 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_14_adc1_in14: IOMUXC_GPIO_AD_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_in14: IOMUXC_GPIO_AD_14_ADC1_IN14 {
 		pinmux = <0x401f8010 5 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_flexio1_io26: IOMUXC_GPIO_AD_14_FLEXIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio1_io26: IOMUXC_GPIO_AD_14_FLEXIO1_IO26 {
 		pinmux = <0x401f8010 4 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_gpiomux_io28: IOMUXC_GPIO_AD_14_GPIOMUX_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpiomux_io28: IOMUXC_GPIO_AD_14_GPIOMUX_IO28 {
 		pinmux = <0x401f8010 5 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_kpp_col0: IOMUXC_GPIO_AD_14_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_kpp_col0: IOMUXC_GPIO_AD_14_KPP_COL0 {
 		pinmux = <0x401f8010 2 0x401f819c 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpi2c1_scl: IOMUXC_GPIO_AD_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpi2c1_scl: IOMUXC_GPIO_AD_14_LPI2C1_SCL {
 		pinmux = <0x401f8010 0 0x401f81c0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpuart3_cts_b: IOMUXC_GPIO_AD_14_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpuart3_cts_b: IOMUXC_GPIO_AD_14_LPUART3_CTS_B {
 		pinmux = <0x401f8010 1 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpuart4_cts_b: IOMUXC_GPIO_AD_14_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpuart4_cts_b: IOMUXC_GPIO_AD_14_LPUART4_CTS_B {
 		pinmux = <0x401f8010 3 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_xbar1_in02: IOMUXC_GPIO_AD_14_XBAR1_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_xbar1_in02: IOMUXC_GPIO_AD_14_XBAR1_IN02 {
 		pinmux = <0x401f8010 7 0x0 0 0x401f80c0>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_14_xbar1_inout02: IOMUXC_GPIO_AD_14_XBAR1_INOUT02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_xbar1_inout02: IOMUXC_GPIO_AD_14_XBAR1_INOUT02 {
 		pinmux = <0x401f8010 7 0x0 0 0x401f80c0>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_00_arm_cm7_rxev: IOMUXC_GPIO_SD_00_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_arm_cm7_rxev: IOMUXC_GPIO_SD_00_ARM_CM7_RXEV {
 		pinmux = <0x401f8084 2 0x401f8220 1 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_ccm_stop: IOMUXC_GPIO_SD_00_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_ccm_stop: IOMUXC_GPIO_SD_00_CCM_STOP {
 		pinmux = <0x401f8084 3 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_flexio1_io06: IOMUXC_GPIO_SD_00_FLEXIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_flexio1_io06: IOMUXC_GPIO_SD_00_FLEXIO1_IO06 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_flexspi_b_ss0_b: IOMUXC_GPIO_SD_00_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_flexspi_b_ss0_b: IOMUXC_GPIO_SD_00_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_gpio2_io00: IOMUXC_GPIO_SD_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_gpio2_io00: IOMUXC_GPIO_SD_00_GPIO2_IO00 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_sai3_tx_sync: IOMUXC_GPIO_SD_00_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_sai3_tx_sync: IOMUXC_GPIO_SD_00_SAI3_TX_SYNC {
 		pinmux = <0x401f8084 1 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_src_bt_cfg2: IOMUXC_GPIO_SD_00_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_src_bt_cfg2: IOMUXC_GPIO_SD_00_SRC_BT_CFG2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_01_ccm_clko2: IOMUXC_GPIO_SD_01_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_ccm_clko2: IOMUXC_GPIO_SD_01_CCM_CLKO2 {
 		pinmux = <0x401f8080 3 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexio1_io07: IOMUXC_GPIO_SD_01_FLEXIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexio1_io07: IOMUXC_GPIO_SD_01_FLEXIO1_IO07 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexpwm1_pwm0_b: IOMUXC_GPIO_SD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexpwm1_pwm0_b: IOMUXC_GPIO_SD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x401f8080 2 0x401f8184 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexspi_b_data1: IOMUXC_GPIO_SD_01_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexspi_b_data1: IOMUXC_GPIO_SD_01_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_gpio2_io01: IOMUXC_GPIO_SD_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_gpio2_io01: IOMUXC_GPIO_SD_01_GPIO2_IO01 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_sai3_tx_bclk: IOMUXC_GPIO_SD_01_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_sai3_tx_bclk: IOMUXC_GPIO_SD_01_SAI3_TX_BCLK {
 		pinmux = <0x401f8080 1 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_src_bt_cfg1: IOMUXC_GPIO_SD_01_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_src_bt_cfg1: IOMUXC_GPIO_SD_01_SRC_BT_CFG1 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_02_ccm_clko1: IOMUXC_GPIO_SD_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_ccm_clko1: IOMUXC_GPIO_SD_02_CCM_CLKO1 {
 		pinmux = <0x401f807c 3 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexio1_io08: IOMUXC_GPIO_SD_02_FLEXIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexio1_io08: IOMUXC_GPIO_SD_02_FLEXIO1_IO08 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexpwm1_pwm0_a: IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexpwm1_pwm0_a: IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A {
 		pinmux = <0x401f807c 2 0x401f8174 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexspi_b_data2: IOMUXC_GPIO_SD_02_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexspi_b_data2: IOMUXC_GPIO_SD_02_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_gpio2_io02: IOMUXC_GPIO_SD_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_gpio2_io02: IOMUXC_GPIO_SD_02_GPIO2_IO02 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_sai3_tx_data: IOMUXC_GPIO_SD_02_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_sai3_tx_data: IOMUXC_GPIO_SD_02_SAI3_TX_DATA {
 		pinmux = <0x401f807c 1 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_src_bt_cfg0: IOMUXC_GPIO_SD_02_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_src_bt_cfg0: IOMUXC_GPIO_SD_02_SRC_BT_CFG0 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_03_ccm_ref_en_b: IOMUXC_GPIO_SD_03_CCM_REF_EN_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_ccm_ref_en_b: IOMUXC_GPIO_SD_03_CCM_REF_EN_B {
 		pinmux = <0x401f8078 3 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexio1_io09: IOMUXC_GPIO_SD_03_FLEXIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexio1_io09: IOMUXC_GPIO_SD_03_FLEXIO1_IO09 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexpwm1_pwm1_b: IOMUXC_GPIO_SD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexpwm1_pwm1_b: IOMUXC_GPIO_SD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x401f8078 2 0x401f8188 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexspi_b_data0: IOMUXC_GPIO_SD_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexspi_b_data0: IOMUXC_GPIO_SD_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_gpio2_io03: IOMUXC_GPIO_SD_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_gpio2_io03: IOMUXC_GPIO_SD_03_GPIO2_IO03 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_sai3_rx_data: IOMUXC_GPIO_SD_03_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_sai3_rx_data: IOMUXC_GPIO_SD_03_SAI3_RX_DATA {
 		pinmux = <0x401f8078 1 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_src_boot_mode1: IOMUXC_GPIO_SD_03_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_src_boot_mode1: IOMUXC_GPIO_SD_03_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_04_ccm_wait: IOMUXC_GPIO_SD_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_ccm_wait: IOMUXC_GPIO_SD_04_CCM_WAIT {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexio1_io10: IOMUXC_GPIO_SD_04_FLEXIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexio1_io10: IOMUXC_GPIO_SD_04_FLEXIO1_IO10 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexpwm1_pwm1_a: IOMUXC_GPIO_SD_04_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexpwm1_pwm1_a: IOMUXC_GPIO_SD_04_FLEXPWM1_PWM1_A {
 		pinmux = <0x401f8074 2 0x401f8178 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexspi_b_data3: IOMUXC_GPIO_SD_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexspi_b_data3: IOMUXC_GPIO_SD_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_gpio2_io04: IOMUXC_GPIO_SD_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_gpio2_io04: IOMUXC_GPIO_SD_04_GPIO2_IO04 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_sai3_rx_sync: IOMUXC_GPIO_SD_04_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_sai3_rx_sync: IOMUXC_GPIO_SD_04_SAI3_RX_SYNC {
 		pinmux = <0x401f8074 1 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_src_boot_mode0: IOMUXC_GPIO_SD_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_src_boot_mode0: IOMUXC_GPIO_SD_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_05_flexio1_io11: IOMUXC_GPIO_SD_05_FLEXIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_flexio1_io11: IOMUXC_GPIO_SD_05_FLEXIO1_IO11 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_flexspi_a_ss1_b: IOMUXC_GPIO_SD_05_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_flexspi_a_ss1_b: IOMUXC_GPIO_SD_05_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_gpio2_io05: IOMUXC_GPIO_SD_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_gpio2_io05: IOMUXC_GPIO_SD_05_GPIO2_IO05 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_lpi2c1_sda: IOMUXC_GPIO_SD_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_lpi2c1_sda: IOMUXC_GPIO_SD_05_LPI2C1_SDA {
 		pinmux = <0x401f8070 1 0x401f81c4 1 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_lpspi1_sdi: IOMUXC_GPIO_SD_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_lpspi1_sdi: IOMUXC_GPIO_SD_05_LPSPI1_SDI {
 		pinmux = <0x401f8070 2 0x401f81d8 1 0x401f8120>;
 	};
-	iomuxc_gpio_sd_06_flexio1_io12: IOMUXC_GPIO_SD_06_FLEXIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_flexio1_io12: IOMUXC_GPIO_SD_06_FLEXIO1_IO12 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f806c 0 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_gpio2_io06: IOMUXC_GPIO_SD_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_gpio2_io06: IOMUXC_GPIO_SD_06_GPIO2_IO06 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_lpi2c1_scl: IOMUXC_GPIO_SD_06_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_lpi2c1_scl: IOMUXC_GPIO_SD_06_LPI2C1_SCL {
 		pinmux = <0x401f806c 1 0x401f81c0 1 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_lpspi1_sdo: IOMUXC_GPIO_SD_06_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_lpspi1_sdo: IOMUXC_GPIO_SD_06_LPSPI1_SDO {
 		pinmux = <0x401f806c 2 0x401f81dc 1 0x401f811c>;
 	};
-	iomuxc_gpio_sd_07_flexio1_io13: IOMUXC_GPIO_SD_07_FLEXIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_flexio1_io13: IOMUXC_GPIO_SD_07_FLEXIO1_IO13 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_flexspi_a_data1: IOMUXC_GPIO_SD_07_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_flexspi_a_data1: IOMUXC_GPIO_SD_07_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_gpio2_io07: IOMUXC_GPIO_SD_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_gpio2_io07: IOMUXC_GPIO_SD_07_GPIO2_IO07 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_lpi2c2_sda: IOMUXC_GPIO_SD_07_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_lpi2c2_sda: IOMUXC_GPIO_SD_07_LPI2C2_SDA {
 		pinmux = <0x401f8068 1 0x401f81cc 2 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_lpspi1_pcs0: IOMUXC_GPIO_SD_07_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_lpspi1_pcs0: IOMUXC_GPIO_SD_07_LPSPI1_PCS0 {
 		pinmux = <0x401f8068 2 0x401f81d0 1 0x401f8118>;
 	};
-	iomuxc_gpio_sd_08_flexio1_io14: IOMUXC_GPIO_SD_08_FLEXIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_flexio1_io14: IOMUXC_GPIO_SD_08_FLEXIO1_IO14 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_flexspi_a_data2: IOMUXC_GPIO_SD_08_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_flexspi_a_data2: IOMUXC_GPIO_SD_08_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_gpio2_io08: IOMUXC_GPIO_SD_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_gpio2_io08: IOMUXC_GPIO_SD_08_GPIO2_IO08 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_lpi2c2_scl: IOMUXC_GPIO_SD_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_lpi2c2_scl: IOMUXC_GPIO_SD_08_LPI2C2_SCL {
 		pinmux = <0x401f8064 1 0x401f81c8 2 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_lpspi1_sck: IOMUXC_GPIO_SD_08_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_lpspi1_sck: IOMUXC_GPIO_SD_08_LPSPI1_SCK {
 		pinmux = <0x401f8064 2 0x401f81d4 1 0x401f8114>;
 	};
-	iomuxc_gpio_sd_09_flexio1_io15: IOMUXC_GPIO_SD_09_FLEXIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_flexio1_io15: IOMUXC_GPIO_SD_09_FLEXIO1_IO15 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_flexspi_a_data0: IOMUXC_GPIO_SD_09_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_flexspi_a_data0: IOMUXC_GPIO_SD_09_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_gpio2_io09: IOMUXC_GPIO_SD_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_gpio2_io09: IOMUXC_GPIO_SD_09_GPIO2_IO09 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_lpspi2_sdi: IOMUXC_GPIO_SD_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_lpspi2_sdi: IOMUXC_GPIO_SD_09_LPSPI2_SDI {
 		pinmux = <0x401f8060 1 0x401f81e8 1 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_lpuart2_rxd: IOMUXC_GPIO_SD_09_LPUART2_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_lpuart2_rxd: IOMUXC_GPIO_SD_09_LPUART2_RXD {
 		pinmux = <0x401f8060 2 0x401f81f8 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_10_flexio1_io16: IOMUXC_GPIO_SD_10_FLEXIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_flexio1_io16: IOMUXC_GPIO_SD_10_FLEXIO1_IO16 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_flexspi_a_sclk: IOMUXC_GPIO_SD_10_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_flexspi_a_sclk: IOMUXC_GPIO_SD_10_FLEXSPI_A_SCLK {
 		pinmux = <0x401f805c 0 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_gpio2_io10: IOMUXC_GPIO_SD_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_gpio2_io10: IOMUXC_GPIO_SD_10_GPIO2_IO10 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_lpspi2_sdo: IOMUXC_GPIO_SD_10_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_lpspi2_sdo: IOMUXC_GPIO_SD_10_LPSPI2_SDO {
 		pinmux = <0x401f805c 1 0x401f81ec 1 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_lpuart2_txd: IOMUXC_GPIO_SD_10_LPUART2_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_lpuart2_txd: IOMUXC_GPIO_SD_10_LPUART2_TXD {
 		pinmux = <0x401f805c 2 0x401f81fc 1 0x401f810c>;
 	};
-	iomuxc_gpio_sd_11_flexio1_io17: IOMUXC_GPIO_SD_11_FLEXIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_flexio1_io17: IOMUXC_GPIO_SD_11_FLEXIO1_IO17 {
 		pinmux = <0x401f8058 4 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_flexspi_a_data3: IOMUXC_GPIO_SD_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_flexspi_a_data3: IOMUXC_GPIO_SD_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_gpio2_io11: IOMUXC_GPIO_SD_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_gpio2_io11: IOMUXC_GPIO_SD_11_GPIO2_IO11 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_lpspi2_sck: IOMUXC_GPIO_SD_11_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_lpspi2_sck: IOMUXC_GPIO_SD_11_LPSPI2_SCK {
 		pinmux = <0x401f8058 1 0x401f81e4 1 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_lpuart1_rxd: IOMUXC_GPIO_SD_11_LPUART1_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_lpuart1_rxd: IOMUXC_GPIO_SD_11_LPUART1_RXD {
 		pinmux = <0x401f8058 2 0x401f81f0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_wdog1_rst_b_deb: IOMUXC_GPIO_SD_11_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_wdog1_rst_b_deb: IOMUXC_GPIO_SD_11_WDOG1_RST_B_DEB {
 		pinmux = <0x401f8058 6 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_12_flexio1_io18: IOMUXC_GPIO_SD_12_FLEXIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_flexio1_io18: IOMUXC_GPIO_SD_12_FLEXIO1_IO18 {
 		pinmux = <0x401f8054 4 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_flexspi_a_dqs: IOMUXC_GPIO_SD_12_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_flexspi_a_dqs: IOMUXC_GPIO_SD_12_FLEXSPI_A_DQS {
 		pinmux = <0x401f8054 0 0x401f8194 1 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_gpio2_io12: IOMUXC_GPIO_SD_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_gpio2_io12: IOMUXC_GPIO_SD_12_GPIO2_IO12 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_lpspi2_pcs0: IOMUXC_GPIO_SD_12_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_lpspi2_pcs0: IOMUXC_GPIO_SD_12_LPSPI2_PCS0 {
 		pinmux = <0x401f8054 1 0x401f81e0 1 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_lpuart1_txd: IOMUXC_GPIO_SD_12_LPUART1_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_lpuart1_txd: IOMUXC_GPIO_SD_12_LPUART1_TXD {
 		pinmux = <0x401f8054 2 0x401f81f4 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_wdog2_rst_b_deb: IOMUXC_GPIO_SD_12_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_wdog2_rst_b_deb: IOMUXC_GPIO_SD_12_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8054 6 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_13_arm_cm7_txev: IOMUXC_GPIO_SD_13_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_arm_cm7_txev: IOMUXC_GPIO_SD_13_ARM_CM7_TXEV {
 		pinmux = <0x401f8050 2 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_ccm_pmic_rdy: IOMUXC_GPIO_SD_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_ccm_pmic_rdy: IOMUXC_GPIO_SD_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_flexio1_io19: IOMUXC_GPIO_SD_13_FLEXIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_flexio1_io19: IOMUXC_GPIO_SD_13_FLEXIO1_IO19 {
 		pinmux = <0x401f8050 4 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_flexspi_b_sclk: IOMUXC_GPIO_SD_13_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_flexspi_b_sclk: IOMUXC_GPIO_SD_13_FLEXSPI_B_SCLK {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_gpio2_io13: IOMUXC_GPIO_SD_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_gpio2_io13: IOMUXC_GPIO_SD_13_GPIO2_IO13 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_sai3_rx_bclk: IOMUXC_GPIO_SD_13_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_sai3_rx_bclk: IOMUXC_GPIO_SD_13_SAI3_RX_BCLK {
 		pinmux = <0x401f8050 1 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_src_bt_cfg3: IOMUXC_GPIO_SD_13_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_src_bt_cfg3: IOMUXC_GPIO_SD_13_SRC_BT_CFG3 {
 		pinmux = <0x401f8050 6 0x0 0 0x401f8100>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io00: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io00: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8000 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8008>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a8004>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1011dae5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1011dae5a-pinctrl.dtsi
@@ -18,941 +18,941 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_00_flexspi_b_dqs: IOMUXC_GPIO_00_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_00_flexspi_b_dqs: IOMUXC_GPIO_00_FLEXSPI_B_DQS {
 		pinmux = <0x401f80bc 0 0x401f8198 1 0x401f816c>;
 	};
-	iomuxc_gpio_00_gpiomux_io00: IOMUXC_GPIO_00_GPIOMUX_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_00_gpiomux_io00: IOMUXC_GPIO_00_GPIOMUX_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_lpspi1_pcs3: IOMUXC_GPIO_00_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_00_lpspi1_pcs3: IOMUXC_GPIO_00_LPSPI1_PCS3 {
 		pinmux = <0x401f80bc 3 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_lpspi2_pcs3: IOMUXC_GPIO_00_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_00_lpspi2_pcs3: IOMUXC_GPIO_00_LPSPI2_PCS3 {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_pit_trigger0: IOMUXC_GPIO_00_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_00_pit_trigger0: IOMUXC_GPIO_00_PIT_TRIGGER0 {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_00_sai3_mclk: IOMUXC_GPIO_00_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_00_sai3_mclk: IOMUXC_GPIO_00_SAI3_MCLK {
 		pinmux = <0x401f80bc 1 0x0 0 0x401f816c>;
 	};
-	iomuxc_gpio_01_flexpwm1_pwm0_b: IOMUXC_GPIO_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_01_flexpwm1_pwm0_b: IOMUXC_GPIO_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x401f80b8 2 0x401f8184 1 0x401f8168>;
 	};
-	iomuxc_gpio_01_gpiomux_io01: IOMUXC_GPIO_01_GPIOMUX_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_01_gpiomux_io01: IOMUXC_GPIO_01_GPIOMUX_IO01 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_01_kpp_row3: IOMUXC_GPIO_01_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_01_kpp_row3: IOMUXC_GPIO_01_KPP_ROW3 {
 		pinmux = <0x401f80b8 4 0x401f81b8 1 0x401f8168>;
 	};
-	iomuxc_gpio_01_lpi2c1_sda: IOMUXC_GPIO_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_01_lpi2c1_sda: IOMUXC_GPIO_01_LPI2C1_SDA {
 		pinmux = <0x401f80b8 3 0x401f81c4 3 0x401f8168>;
 	};
-	iomuxc_gpio_01_sai1_rx_bclk: IOMUXC_GPIO_01_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_01_sai1_rx_bclk: IOMUXC_GPIO_01_SAI1_RX_BCLK {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_01_wdog1_any: IOMUXC_GPIO_01_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_01_wdog1_any: IOMUXC_GPIO_01_WDOG1_ANY {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f8168>;
 	};
-	iomuxc_gpio_02_flexpwm1_pwm0_a: IOMUXC_GPIO_02_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_02_flexpwm1_pwm0_a: IOMUXC_GPIO_02_FLEXPWM1_PWM0_A {
 		pinmux = <0x401f80b4 2 0x401f8174 1 0x401f8164>;
 	};
-	iomuxc_gpio_02_gpiomux_io02: IOMUXC_GPIO_02_GPIOMUX_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_02_gpiomux_io02: IOMUXC_GPIO_02_GPIOMUX_IO02 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_02_kpp_col3: IOMUXC_GPIO_02_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_02_kpp_col3: IOMUXC_GPIO_02_KPP_COL3 {
 		pinmux = <0x401f80b4 4 0x401f81a8 1 0x401f8164>;
 	};
-	iomuxc_gpio_02_lpi2c1_scl: IOMUXC_GPIO_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_02_lpi2c1_scl: IOMUXC_GPIO_02_LPI2C1_SCL {
 		pinmux = <0x401f80b4 3 0x401f81c0 3 0x401f8164>;
 	};
-	iomuxc_gpio_02_sai1_rx_sync: IOMUXC_GPIO_02_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_02_sai1_rx_sync: IOMUXC_GPIO_02_SAI1_RX_SYNC {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_02_wdog2_b: IOMUXC_GPIO_02_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_02_wdog2_b: IOMUXC_GPIO_02_WDOG2_B {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f8164>;
 	};
-	iomuxc_gpio_03_flexpwm1_pwm1_b: IOMUXC_GPIO_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_03_flexpwm1_pwm1_b: IOMUXC_GPIO_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x401f80b0 2 0x401f8188 1 0x401f8160>;
 	};
-	iomuxc_gpio_03_gpiomux_io03: IOMUXC_GPIO_03_GPIOMUX_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_03_gpiomux_io03: IOMUXC_GPIO_03_GPIOMUX_IO03 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_gpt1_compare3: IOMUXC_GPIO_03_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_03_gpt1_compare3: IOMUXC_GPIO_03_GPT1_COMPARE3 {
 		pinmux = <0x401f80b0 1 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_sai1_rx_data0: IOMUXC_GPIO_03_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_03_sai1_rx_data0: IOMUXC_GPIO_03_SAI1_RX_DATA0 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_03_spdif_sr_clk: IOMUXC_GPIO_03_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_03_spdif_sr_clk: IOMUXC_GPIO_03_SPDIF_SR_CLK {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8160>;
 	};
-	iomuxc_gpio_04_flexpwm1_pwm1_a: IOMUXC_GPIO_04_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_04_flexpwm1_pwm1_a: IOMUXC_GPIO_04_FLEXPWM1_PWM1_A {
 		pinmux = <0x401f80ac 2 0x401f8178 1 0x401f815c>;
 	};
-	iomuxc_gpio_04_gpiomux_io04: IOMUXC_GPIO_04_GPIOMUX_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_04_gpiomux_io04: IOMUXC_GPIO_04_GPIOMUX_IO04 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_gpt1_capture2: IOMUXC_GPIO_04_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_04_gpt1_capture2: IOMUXC_GPIO_04_GPT1_CAPTURE2 {
 		pinmux = <0x401f80ac 1 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_sai1_tx_data0: IOMUXC_GPIO_04_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_04_sai1_tx_data0: IOMUXC_GPIO_04_SAI1_TX_DATA0 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f815c>;
 	};
-	iomuxc_gpio_04_spdif_in: IOMUXC_GPIO_04_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_04_spdif_in: IOMUXC_GPIO_04_SPDIF_IN {
 		pinmux = <0x401f80ac 4 0x401f8214 1 0x401f815c>;
 	};
-	iomuxc_gpio_05_flexpwm1_pwm2_b: IOMUXC_GPIO_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_05_flexpwm1_pwm2_b: IOMUXC_GPIO_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x401f80a8 2 0x401f818c 1 0x401f8158>;
 	};
-	iomuxc_gpio_05_gpiomux_io05: IOMUXC_GPIO_05_GPIOMUX_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_05_gpiomux_io05: IOMUXC_GPIO_05_GPIOMUX_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_gpt1_compare2: IOMUXC_GPIO_05_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_05_gpt1_compare2: IOMUXC_GPIO_05_GPT1_COMPARE2 {
 		pinmux = <0x401f80a8 1 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_lpuart4_rxd: IOMUXC_GPIO_05_LPUART4_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_05_lpuart4_rxd: IOMUXC_GPIO_05_LPUART4_RXD {
 		pinmux = <0x401f80a8 3 0x401f8208 1 0x401f8158>;
 	};
-	iomuxc_gpio_05_sai1_tx_data1: IOMUXC_GPIO_05_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_05_sai1_tx_data1: IOMUXC_GPIO_05_SAI1_TX_DATA1 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_05_spdif_out: IOMUXC_GPIO_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_05_spdif_out: IOMUXC_GPIO_05_SPDIF_OUT {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8158>;
 	};
-	iomuxc_gpio_06_flexpwm1_pwm2_a: IOMUXC_GPIO_06_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_06_flexpwm1_pwm2_a: IOMUXC_GPIO_06_FLEXPWM1_PWM2_A {
 		pinmux = <0x401f80a4 2 0x401f817c 1 0x401f8154>;
 	};
-	iomuxc_gpio_06_gpiomux_io06: IOMUXC_GPIO_06_GPIOMUX_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_06_gpiomux_io06: IOMUXC_GPIO_06_GPIOMUX_IO06 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_gpt1_capture1: IOMUXC_GPIO_06_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_06_gpt1_capture1: IOMUXC_GPIO_06_GPT1_CAPTURE1 {
 		pinmux = <0x401f80a4 1 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_lpuart4_txd: IOMUXC_GPIO_06_LPUART4_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_06_lpuart4_txd: IOMUXC_GPIO_06_LPUART4_TXD {
 		pinmux = <0x401f80a4 3 0x401f820c 1 0x401f8154>;
 	};
-	iomuxc_gpio_06_sai1_tx_bclk: IOMUXC_GPIO_06_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_06_sai1_tx_bclk: IOMUXC_GPIO_06_SAI1_TX_BCLK {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8154>;
 	};
-	iomuxc_gpio_06_spdif_ext_clk: IOMUXC_GPIO_06_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_06_spdif_ext_clk: IOMUXC_GPIO_06_SPDIF_EXT_CLK {
 		pinmux = <0x401f80a4 4 0x401f8218 1 0x401f8154>;
 	};
-	iomuxc_gpio_07_flexpwm1_pwm3_b: IOMUXC_GPIO_07_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_07_flexpwm1_pwm3_b: IOMUXC_GPIO_07_FLEXPWM1_PWM3_B {
 		pinmux = <0x401f80a0 2 0x401f8190 1 0x401f8150>;
 	};
-	iomuxc_gpio_07_gpiomux_io07: IOMUXC_GPIO_07_GPIOMUX_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_07_gpiomux_io07: IOMUXC_GPIO_07_GPIOMUX_IO07 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_gpt1_compare1: IOMUXC_GPIO_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_07_gpt1_compare1: IOMUXC_GPIO_07_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 1 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_lpuart1_rts_b: IOMUXC_GPIO_07_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_07_lpuart1_rts_b: IOMUXC_GPIO_07_LPUART1_RTS_B {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_lpuart3_rxd: IOMUXC_GPIO_07_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_07_lpuart3_rxd: IOMUXC_GPIO_07_LPUART3_RXD {
 		pinmux = <0x401f80a0 3 0x401f8200 2 0x401f8150>;
 	};
-	iomuxc_gpio_07_sai1_tx_sync: IOMUXC_GPIO_07_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_07_sai1_tx_sync: IOMUXC_GPIO_07_SAI1_TX_SYNC {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_07_spdif_lock: IOMUXC_GPIO_07_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_07_spdif_lock: IOMUXC_GPIO_07_SPDIF_LOCK {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8150>;
 	};
-	iomuxc_gpio_08_flexio1_io00: IOMUXC_GPIO_08_FLEXIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_08_flexio1_io00: IOMUXC_GPIO_08_FLEXIO1_IO00 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_flexpwm1_pwm3_a: IOMUXC_GPIO_08_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_08_flexpwm1_pwm3_a: IOMUXC_GPIO_08_FLEXPWM1_PWM3_A {
 		pinmux = <0x401f809c 2 0x401f8180 1 0x401f814c>;
 	};
-	iomuxc_gpio_08_gpiomux_io08: IOMUXC_GPIO_08_GPIOMUX_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_08_gpiomux_io08: IOMUXC_GPIO_08_GPIOMUX_IO08 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_gpt1_clk: IOMUXC_GPIO_08_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_08_gpt1_clk: IOMUXC_GPIO_08_GPT1_CLK {
 		pinmux = <0x401f809c 1 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_lpuart1_cts_b: IOMUXC_GPIO_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_08_lpuart1_cts_b: IOMUXC_GPIO_08_LPUART1_CTS_B {
 		pinmux = <0x401f809c 6 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_08_lpuart3_txd: IOMUXC_GPIO_08_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_08_lpuart3_txd: IOMUXC_GPIO_08_LPUART3_TXD {
 		pinmux = <0x401f809c 3 0x401f8204 2 0x401f814c>;
 	};
-	iomuxc_gpio_08_sai1_mclk: IOMUXC_GPIO_08_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_08_sai1_mclk: IOMUXC_GPIO_08_SAI1_MCLK {
 		pinmux = <0x401f809c 0 0x0 0 0x401f814c>;
 	};
-	iomuxc_gpio_09_flexio1_io01: IOMUXC_GPIO_09_FLEXIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_09_flexio1_io01: IOMUXC_GPIO_09_FLEXIO1_IO01 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_flexspi_a_ss1_b: IOMUXC_GPIO_09_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_09_flexspi_a_ss1_b: IOMUXC_GPIO_09_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_gpiomux_io09: IOMUXC_GPIO_09_GPIOMUX_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_09_gpiomux_io09: IOMUXC_GPIO_09_GPIOMUX_IO09 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_lpi2c2_sda: IOMUXC_GPIO_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_09_lpi2c2_sda: IOMUXC_GPIO_09_LPI2C2_SDA {
 		pinmux = <0x401f8098 3 0x401f81cc 3 0x401f8148>;
 	};
-	iomuxc_gpio_09_lpuart1_rxd: IOMUXC_GPIO_09_LPUART1_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_09_lpuart1_rxd: IOMUXC_GPIO_09_LPUART1_RXD {
 		pinmux = <0x401f8098 0 0x401f81f0 1 0x401f8148>;
 	};
-	iomuxc_gpio_09_spdif_sr_clk: IOMUXC_GPIO_09_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_09_spdif_sr_clk: IOMUXC_GPIO_09_SPDIF_SR_CLK {
 		pinmux = <0x401f8098 6 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_09_wdog1_b: IOMUXC_GPIO_09_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_09_wdog1_b: IOMUXC_GPIO_09_WDOG1_B {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8148>;
 	};
-	iomuxc_gpio_10_ewm_out_b: IOMUXC_GPIO_10_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_10_ewm_out_b: IOMUXC_GPIO_10_EWM_OUT_B {
 		pinmux = <0x401f8094 2 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_flexio1_io02: IOMUXC_GPIO_10_FLEXIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_10_flexio1_io02: IOMUXC_GPIO_10_FLEXIO1_IO02 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_gpiomux_io10: IOMUXC_GPIO_10_GPIOMUX_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_10_gpiomux_io10: IOMUXC_GPIO_10_GPIOMUX_IO10 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpi2c1_hreq: IOMUXC_GPIO_10_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpi2c1_hreq: IOMUXC_GPIO_10_LPI2C1_HREQ {
 		pinmux = <0x401f8094 1 0x401f81bc 1 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpi2c2_scl: IOMUXC_GPIO_10_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpi2c2_scl: IOMUXC_GPIO_10_LPI2C2_SCL {
 		pinmux = <0x401f8094 3 0x401f81c8 3 0x401f8144>;
 	};
-	iomuxc_gpio_10_lpuart1_txd: IOMUXC_GPIO_10_LPUART1_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_10_lpuart1_txd: IOMUXC_GPIO_10_LPUART1_TXD {
 		pinmux = <0x401f8094 0 0x401f81f4 1 0x401f8144>;
 	};
-	iomuxc_gpio_10_spdif_in: IOMUXC_GPIO_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_10_spdif_in: IOMUXC_GPIO_10_SPDIF_IN {
 		pinmux = <0x401f8094 6 0x401f8214 0 0x401f8144>;
 	};
-	iomuxc_gpio_11_arm_trace3: IOMUXC_GPIO_11_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_11_arm_trace3: IOMUXC_GPIO_11_ARM_TRACE3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_flexio1_io03: IOMUXC_GPIO_11_FLEXIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_11_flexio1_io03: IOMUXC_GPIO_11_FLEXIO1_IO03 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_flexspi_b_ss1_b: IOMUXC_GPIO_11_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_11_flexspi_b_ss1_b: IOMUXC_GPIO_11_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_gpiomux_io11: IOMUXC_GPIO_11_GPIOMUX_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_11_gpiomux_io11: IOMUXC_GPIO_11_GPIOMUX_IO11 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_11_kpp_row0: IOMUXC_GPIO_11_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_11_kpp_row0: IOMUXC_GPIO_11_KPP_ROW0 {
 		pinmux = <0x401f8090 2 0x401f81ac 1 0x401f8140>;
 	};
-	iomuxc_gpio_11_lpi2c1_sda: IOMUXC_GPIO_11_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_11_lpi2c1_sda: IOMUXC_GPIO_11_LPI2C1_SDA {
 		pinmux = <0x401f8090 1 0x401f81c4 2 0x401f8140>;
 	};
-	iomuxc_gpio_11_lpuart3_rxd: IOMUXC_GPIO_11_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_11_lpuart3_rxd: IOMUXC_GPIO_11_LPUART3_RXD {
 		pinmux = <0x401f8090 0 0x401f8200 1 0x401f8140>;
 	};
-	iomuxc_gpio_11_spdif_out: IOMUXC_GPIO_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_11_spdif_out: IOMUXC_GPIO_11_SPDIF_OUT {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8140>;
 	};
-	iomuxc_gpio_12_arm_trace2: IOMUXC_GPIO_12_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_12_arm_trace2: IOMUXC_GPIO_12_ARM_TRACE2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_flexio1_io04: IOMUXC_GPIO_12_FLEXIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_12_flexio1_io04: IOMUXC_GPIO_12_FLEXIO1_IO04 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_gpiomux_io12: IOMUXC_GPIO_12_GPIOMUX_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_12_gpiomux_io12: IOMUXC_GPIO_12_GPIOMUX_IO12 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_kpp_col0: IOMUXC_GPIO_12_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_12_kpp_col0: IOMUXC_GPIO_12_KPP_COL0 {
 		pinmux = <0x401f808c 2 0x401f819c 1 0x401f813c>;
 	};
-	iomuxc_gpio_12_lpi2c1_scl: IOMUXC_GPIO_12_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_12_lpi2c1_scl: IOMUXC_GPIO_12_LPI2C1_SCL {
 		pinmux = <0x401f808c 1 0x401f81c0 2 0x401f813c>;
 	};
-	iomuxc_gpio_12_lpuart3_txd: IOMUXC_GPIO_12_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_12_lpuart3_txd: IOMUXC_GPIO_12_LPUART3_TXD {
 		pinmux = <0x401f808c 0 0x401f8204 1 0x401f813c>;
 	};
-	iomuxc_gpio_12_spdif_ext_clk: IOMUXC_GPIO_12_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_12_spdif_ext_clk: IOMUXC_GPIO_12_SPDIF_EXT_CLK {
 		pinmux = <0x401f808c 6 0x401f8218 0 0x401f813c>;
 	};
-	iomuxc_gpio_12_usb_otg1_oc: IOMUXC_GPIO_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_12_usb_otg1_oc: IOMUXC_GPIO_12_USB_OTG1_OC {
 		pinmux = <0x401f808c 3 0x401f821c 1 0x401f813c>;
 	};
-	iomuxc_gpio_13_arm_trace1: IOMUXC_GPIO_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_13_arm_trace1: IOMUXC_GPIO_13_ARM_TRACE1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_flexio1_io05: IOMUXC_GPIO_13_FLEXIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_13_flexio1_io05: IOMUXC_GPIO_13_FLEXIO1_IO05 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_gpiomux_io13: IOMUXC_GPIO_13_GPIOMUX_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_13_gpiomux_io13: IOMUXC_GPIO_13_GPIOMUX_IO13 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_kpp_row3: IOMUXC_GPIO_13_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_13_kpp_row3: IOMUXC_GPIO_13_KPP_ROW3 {
 		pinmux = <0x401f8088 2 0x401f81b8 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_lpspi2_pcs2: IOMUXC_GPIO_13_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_13_lpspi2_pcs2: IOMUXC_GPIO_13_LPSPI2_PCS2 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_lpuart2_rxd: IOMUXC_GPIO_13_LPUART2_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_13_lpuart2_rxd: IOMUXC_GPIO_13_LPUART2_RXD {
 		pinmux = <0x401f8088 0 0x401f81f8 1 0x401f8138>;
 	};
-	iomuxc_gpio_13_spdif_lock: IOMUXC_GPIO_13_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_13_spdif_lock: IOMUXC_GPIO_13_SPDIF_LOCK {
 		pinmux = <0x401f8088 6 0x0 0 0x401f8138>;
 	};
-	iomuxc_gpio_13_usb_otg1_id: IOMUXC_GPIO_13_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_13_usb_otg1_id: IOMUXC_GPIO_13_USB_OTG1_ID {
 		pinmux = <0x401f8088 3 0x401f8170 1 0x401f8138>;
 	};
-	iomuxc_gpio_ad_00_adc1_in0: IOMUXC_GPIO_AD_00_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_adc1_in0: IOMUXC_GPIO_AD_00_ADC1_IN0 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_arm_nmi: IOMUXC_GPIO_AD_00_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_arm_nmi: IOMUXC_GPIO_AD_00_ARM_NMI {
 		pinmux = <0x401f8048 6 0x401f8210 1 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_arm_trace0: IOMUXC_GPIO_AD_00_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_arm_trace0: IOMUXC_GPIO_AD_00_ARM_TRACE0 {
 		pinmux = <0x401f8048 7 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_flexio1_io20: IOMUXC_GPIO_AD_00_FLEXIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio1_io20: IOMUXC_GPIO_AD_00_FLEXIO1_IO20 {
 		pinmux = <0x401f8048 4 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_gpiomux_io14: IOMUXC_GPIO_AD_00_GPIOMUX_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpiomux_io14: IOMUXC_GPIO_AD_00_GPIOMUX_IO14 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_kpp_col3: IOMUXC_GPIO_AD_00_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_kpp_col3: IOMUXC_GPIO_AD_00_KPP_COL3 {
 		pinmux = <0x401f8048 2 0x401f81a8 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_lpspi1_pcs2: IOMUXC_GPIO_AD_00_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpspi1_pcs2: IOMUXC_GPIO_AD_00_LPSPI1_PCS2 {
 		pinmux = <0x401f8048 1 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_lpuart2_txd: IOMUXC_GPIO_AD_00_LPUART2_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart2_txd: IOMUXC_GPIO_AD_00_LPUART2_TXD {
 		pinmux = <0x401f8048 0 0x401f81fc 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_00_usb_otg1_pwr: IOMUXC_GPIO_AD_00_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_usb_otg1_pwr: IOMUXC_GPIO_AD_00_USB_OTG1_PWR {
 		pinmux = <0x401f8048 3 0x0 0 0x401f80f8>;
 	};
-	iomuxc_gpio_ad_01_adc1_in1: IOMUXC_GPIO_AD_01_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_adc1_in1: IOMUXC_GPIO_AD_01_ADC1_IN1 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_arm_trace_swo: IOMUXC_GPIO_AD_01_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_arm_trace_swo: IOMUXC_GPIO_AD_01_ARM_TRACE_SWO {
 		pinmux = <0x401f8044 7 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_gpiomux_io15: IOMUXC_GPIO_AD_01_GPIOMUX_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpiomux_io15: IOMUXC_GPIO_AD_01_GPIOMUX_IO15 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpi2c2_sda: IOMUXC_GPIO_AD_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpi2c2_sda: IOMUXC_GPIO_AD_01_LPI2C2_SDA {
 		pinmux = <0x401f8044 3 0x401f81cc 1 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpspi2_pcs1: IOMUXC_GPIO_AD_01_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpspi2_pcs1: IOMUXC_GPIO_AD_01_LPSPI2_PCS1 {
 		pinmux = <0x401f8044 1 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_lpuart4_rxd: IOMUXC_GPIO_AD_01_LPUART4_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart4_rxd: IOMUXC_GPIO_AD_01_LPUART4_RXD {
 		pinmux = <0x401f8044 0 0x401f8208 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_mqs_left: IOMUXC_GPIO_AD_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_mqs_left: IOMUXC_GPIO_AD_01_MQS_LEFT {
 		pinmux = <0x401f8044 4 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_usb_otg1_oc: IOMUXC_GPIO_AD_01_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_usb_otg1_oc: IOMUXC_GPIO_AD_01_USB_OTG1_OC {
 		pinmux = <0x401f8044 6 0x401f821c 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_01_wdog1_any: IOMUXC_GPIO_AD_01_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_wdog1_any: IOMUXC_GPIO_AD_01_WDOG1_ANY {
 		pinmux = <0x401f8044 2 0x0 0 0x401f80f4>;
 	};
-	iomuxc_gpio_ad_02_adc1_in2: IOMUXC_GPIO_AD_02_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_adc1_in2: IOMUXC_GPIO_AD_02_ADC1_IN2 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_arm_trace_clk: IOMUXC_GPIO_AD_02_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_arm_trace_clk: IOMUXC_GPIO_AD_02_ARM_TRACE_CLK {
 		pinmux = <0x401f8040 7 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_gpiomux_io16: IOMUXC_GPIO_AD_02_GPIOMUX_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpiomux_io16: IOMUXC_GPIO_AD_02_GPIOMUX_IO16 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpi2c2_scl: IOMUXC_GPIO_AD_02_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpi2c2_scl: IOMUXC_GPIO_AD_02_LPI2C2_SCL {
 		pinmux = <0x401f8040 3 0x401f81c8 1 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpspi1_pcs1: IOMUXC_GPIO_AD_02_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpspi1_pcs1: IOMUXC_GPIO_AD_02_LPSPI1_PCS1 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_lpuart4_txd: IOMUXC_GPIO_AD_02_LPUART4_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart4_txd: IOMUXC_GPIO_AD_02_LPUART4_TXD {
 		pinmux = <0x401f8040 0 0x401f820c 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_mqs_right: IOMUXC_GPIO_AD_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_mqs_right: IOMUXC_GPIO_AD_02_MQS_RIGHT {
 		pinmux = <0x401f8040 4 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_02_wdog2_b: IOMUXC_GPIO_AD_02_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_wdog2_b: IOMUXC_GPIO_AD_02_WDOG2_B {
 		pinmux = <0x401f8040 2 0x0 0 0x401f80f0>;
 	};
-	iomuxc_gpio_ad_03_adc1_in3: IOMUXC_GPIO_AD_03_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_adc1_in3: IOMUXC_GPIO_AD_03_ADC1_IN3 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM2_B {
 		pinmux = <0x401f803c 2 0x401f818c 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_gpiomux_io17: IOMUXC_GPIO_AD_03_GPIOMUX_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpiomux_io17: IOMUXC_GPIO_AD_03_GPIOMUX_IO17 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_gpt2_clk: IOMUXC_GPIO_AD_03_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_clk: IOMUXC_GPIO_AD_03_GPT2_CLK {
 		pinmux = <0x401f803c 4 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_jtag_de_b: IOMUXC_GPIO_AD_03_JTAG_DE_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_jtag_de_b: IOMUXC_GPIO_AD_03_JTAG_DE_B {
 		pinmux = <0x401f803c 7 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_kpp_row2: IOMUXC_GPIO_AD_03_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_kpp_row2: IOMUXC_GPIO_AD_03_KPP_ROW2 {
 		pinmux = <0x401f803c 3 0x401f81b4 1 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_lpspi1_sdi: IOMUXC_GPIO_AD_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpspi1_sdi: IOMUXC_GPIO_AD_03_LPSPI1_SDI {
 		pinmux = <0x401f803c 0 0x401f81d8 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_pit_trigger3: IOMUXC_GPIO_AD_03_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_pit_trigger3: IOMUXC_GPIO_AD_03_PIT_TRIGGER3 {
 		pinmux = <0x401f803c 1 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_03_snvs_vio_5_b: IOMUXC_GPIO_AD_03_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_snvs_vio_5_b: IOMUXC_GPIO_AD_03_SNVS_VIO_5_B {
 		pinmux = <0x401f803c 6 0x0 0 0x401f80ec>;
 	};
-	iomuxc_gpio_ad_04_adc1_in4: IOMUXC_GPIO_AD_04_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_adc1_in4: IOMUXC_GPIO_AD_04_ADC1_IN4 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x401f8038 2 0x401f817c 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_gpiomux_io18: IOMUXC_GPIO_AD_04_GPIOMUX_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpiomux_io18: IOMUXC_GPIO_AD_04_GPIOMUX_IO18 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare1: IOMUXC_GPIO_AD_04_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare1: IOMUXC_GPIO_AD_04_GPT2_COMPARE1 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_kpp_col2: IOMUXC_GPIO_AD_04_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_kpp_col2: IOMUXC_GPIO_AD_04_KPP_COL2 {
 		pinmux = <0x401f8038 3 0x401f81a4 1 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_lpspi1_sdo: IOMUXC_GPIO_AD_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpspi1_sdo: IOMUXC_GPIO_AD_04_LPSPI1_SDO {
 		pinmux = <0x401f8038 0 0x401f81dc 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_pit_trigger2: IOMUXC_GPIO_AD_04_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_pit_trigger2: IOMUXC_GPIO_AD_04_PIT_TRIGGER2 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_04_snvs_vio_5_ctl: IOMUXC_GPIO_AD_04_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_snvs_vio_5_ctl: IOMUXC_GPIO_AD_04_SNVS_VIO_5_CTL {
 		pinmux = <0x401f8038 6 0x0 0 0x401f80e8>;
 	};
-	iomuxc_gpio_ad_05_adc1_in5: IOMUXC_GPIO_AD_05_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_adc1_in5: IOMUXC_GPIO_AD_05_ADC1_IN5 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm3_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm3_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM3_B {
 		pinmux = <0x401f8034 2 0x401f8190 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_gpiomux_io19: IOMUXC_GPIO_AD_05_GPIOMUX_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpiomux_io19: IOMUXC_GPIO_AD_05_GPIOMUX_IO19 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_gpt2_capture1: IOMUXC_GPIO_AD_05_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_capture1: IOMUXC_GPIO_AD_05_GPT2_CAPTURE1 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_kpp_row1: IOMUXC_GPIO_AD_05_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_kpp_row1: IOMUXC_GPIO_AD_05_KPP_ROW1 {
 		pinmux = <0x401f8034 3 0x401f81b0 1 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_lpspi1_pcs0: IOMUXC_GPIO_AD_05_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpspi1_pcs0: IOMUXC_GPIO_AD_05_LPSPI1_PCS0 {
 		pinmux = <0x401f8034 0 0x401f81d0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_05_pit_trigger1: IOMUXC_GPIO_AD_05_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_pit_trigger1: IOMUXC_GPIO_AD_05_PIT_TRIGGER1 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f80e4>;
 	};
-	iomuxc_gpio_ad_06_adc1_in6: IOMUXC_GPIO_AD_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_in6: IOMUXC_GPIO_AD_06_ADC1_IN6 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm3_a: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm3_a: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM3_A {
 		pinmux = <0x401f8030 2 0x401f8180 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_gpiomux_io20: IOMUXC_GPIO_AD_06_GPIOMUX_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpiomux_io20: IOMUXC_GPIO_AD_06_GPIOMUX_IO20 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_gpt2_compare2: IOMUXC_GPIO_AD_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt2_compare2: IOMUXC_GPIO_AD_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_kpp_col1: IOMUXC_GPIO_AD_06_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_kpp_col1: IOMUXC_GPIO_AD_06_KPP_COL1 {
 		pinmux = <0x401f8030 3 0x401f81a0 1 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_lpi2c1_hreq: IOMUXC_GPIO_AD_06_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_lpi2c1_hreq: IOMUXC_GPIO_AD_06_LPI2C1_HREQ {
 		pinmux = <0x401f8030 6 0x401f81bc 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_lpspi1_sck: IOMUXC_GPIO_AD_06_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_lpspi1_sck: IOMUXC_GPIO_AD_06_LPSPI1_SCK {
 		pinmux = <0x401f8030 0 0x401f81d4 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_06_pit_trigger0: IOMUXC_GPIO_AD_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_pit_trigger0: IOMUXC_GPIO_AD_06_PIT_TRIGGER0 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f80e0>;
 	};
-	iomuxc_gpio_ad_07_adc1_in7: IOMUXC_GPIO_AD_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_in7: IOMUXC_GPIO_AD_07_ADC1_IN7 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_arm_cm7_rxev: IOMUXC_GPIO_AD_07_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_arm_cm7_rxev: IOMUXC_GPIO_AD_07_ARM_CM7_RXEV {
 		pinmux = <0x401f802c 2 0x401f8220 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_gpiomux_io21: IOMUXC_GPIO_AD_07_GPIOMUX_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpiomux_io21: IOMUXC_GPIO_AD_07_GPIOMUX_IO21 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_gpt2_capture2: IOMUXC_GPIO_AD_07_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt2_capture2: IOMUXC_GPIO_AD_07_GPT2_CAPTURE2 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpi2c2_sda: IOMUXC_GPIO_AD_07_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpi2c2_sda: IOMUXC_GPIO_AD_07_LPI2C2_SDA {
 		pinmux = <0x401f802c 0 0x401f81cc 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpuart2_rts_b: IOMUXC_GPIO_AD_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpuart2_rts_b: IOMUXC_GPIO_AD_07_LPUART2_RTS_B {
 		pinmux = <0x401f802c 3 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_lpuart3_rxd: IOMUXC_GPIO_AD_07_LPUART3_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_lpuart3_rxd: IOMUXC_GPIO_AD_07_LPUART3_RXD {
 		pinmux = <0x401f802c 1 0x401f8200 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_ocotp_fuse_latched: IOMUXC_GPIO_AD_07_OCOTP_FUSE_LATCHED {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_ocotp_fuse_latched: IOMUXC_GPIO_AD_07_OCOTP_FUSE_LATCHED {
 		pinmux = <0x401f802c 6 0x0 0 0x401f80dc>;
 	};
-	iomuxc_gpio_ad_07_xbar1_in03: IOMUXC_GPIO_AD_07_XBAR1_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_xbar1_in03: IOMUXC_GPIO_AD_07_XBAR1_IN03 {
 		pinmux = <0x401f802c 7 0x0 0 0x401f80dc>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_07_xbar1_inout03: IOMUXC_GPIO_AD_07_XBAR1_INOUT03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_xbar1_inout03: IOMUXC_GPIO_AD_07_XBAR1_INOUT03 {
 		pinmux = <0x401f802c 7 0x0 0 0x401f80dc>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_08_adc1_in8: IOMUXC_GPIO_AD_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_in8: IOMUXC_GPIO_AD_08_ADC1_IN8 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_arm_cm7_txev: IOMUXC_GPIO_AD_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_arm_cm7_txev: IOMUXC_GPIO_AD_08_ARM_CM7_TXEV {
 		pinmux = <0x401f8028 2 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_ewm_out_b: IOMUXC_GPIO_AD_08_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_ewm_out_b: IOMUXC_GPIO_AD_08_EWM_OUT_B {
 		pinmux = <0x401f8028 6 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_gpiomux_io22: IOMUXC_GPIO_AD_08_GPIOMUX_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpiomux_io22: IOMUXC_GPIO_AD_08_GPIOMUX_IO22 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_gpt2_compare3: IOMUXC_GPIO_AD_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt2_compare3: IOMUXC_GPIO_AD_08_GPT2_COMPARE3 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_jtag_trstb: IOMUXC_GPIO_AD_08_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_jtag_trstb: IOMUXC_GPIO_AD_08_JTAG_TRSTB {
 		pinmux = <0x401f8028 7 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpi2c2_scl: IOMUXC_GPIO_AD_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c2_scl: IOMUXC_GPIO_AD_08_LPI2C2_SCL {
 		pinmux = <0x401f8028 0 0x401f81c8 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpuart2_cts_b: IOMUXC_GPIO_AD_08_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpuart2_cts_b: IOMUXC_GPIO_AD_08_LPUART2_CTS_B {
 		pinmux = <0x401f8028 3 0x0 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_08_lpuart3_txd: IOMUXC_GPIO_AD_08_LPUART3_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpuart3_txd: IOMUXC_GPIO_AD_08_LPUART3_TXD {
 		pinmux = <0x401f8028 1 0x401f8204 0 0x401f80d8>;
 	};
-	iomuxc_gpio_ad_09_adc1_in9: IOMUXC_GPIO_AD_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_in9: IOMUXC_GPIO_AD_09_ADC1_IN9 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_arm_trace_swo: IOMUXC_GPIO_AD_09_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_arm_trace_swo: IOMUXC_GPIO_AD_09_ARM_TRACE_SWO {
 		pinmux = <0x401f8024 3 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_flexio1_io21: IOMUXC_GPIO_AD_09_FLEXIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio1_io21: IOMUXC_GPIO_AD_09_FLEXIO1_IO21 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x401f8024 1 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_gpiomux_io23: IOMUXC_GPIO_AD_09_GPIOMUX_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpiomux_io23: IOMUXC_GPIO_AD_09_GPIOMUX_IO23 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_jtag_tdo: IOMUXC_GPIO_AD_09_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_jtag_tdo: IOMUXC_GPIO_AD_09_JTAG_TDO {
 		pinmux = <0x401f8024 7 0x0 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_kpp_row2: IOMUXC_GPIO_AD_09_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_kpp_row2: IOMUXC_GPIO_AD_09_KPP_ROW2 {
 		pinmux = <0x401f8024 2 0x401f81b4 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_09_lpspi2_sdi: IOMUXC_GPIO_AD_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpspi2_sdi: IOMUXC_GPIO_AD_09_LPSPI2_SDI {
 		pinmux = <0x401f8024 0 0x401f81e8 0 0x401f80d4>;
 	};
-	iomuxc_gpio_ad_10_adc1_in10: IOMUXC_GPIO_AD_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_in10: IOMUXC_GPIO_AD_10_ADC1_IN10 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_flexio1_io22: IOMUXC_GPIO_AD_10_FLEXIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio1_io22: IOMUXC_GPIO_AD_10_FLEXIO1_IO22 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_10_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_10_FLEXPWM1_PWM2_X {
 		pinmux = <0x401f8020 1 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_gpiomux_io24: IOMUXC_GPIO_AD_10_GPIOMUX_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpiomux_io24: IOMUXC_GPIO_AD_10_GPIOMUX_IO24 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_jtag_tdi: IOMUXC_GPIO_AD_10_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_jtag_tdi: IOMUXC_GPIO_AD_10_JTAG_TDI {
 		pinmux = <0x401f8020 7 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_kpp_col2: IOMUXC_GPIO_AD_10_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_kpp_col2: IOMUXC_GPIO_AD_10_KPP_COL2 {
 		pinmux = <0x401f8020 2 0x401f81a4 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_lpspi2_sdo: IOMUXC_GPIO_AD_10_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpspi2_sdo: IOMUXC_GPIO_AD_10_LPSPI2_SDO {
 		pinmux = <0x401f8020 0 0x401f81ec 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_pit_trigger3: IOMUXC_GPIO_AD_10_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_pit_trigger3: IOMUXC_GPIO_AD_10_PIT_TRIGGER3 {
 		pinmux = <0x401f8020 3 0x0 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_id: IOMUXC_GPIO_AD_10_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_id: IOMUXC_GPIO_AD_10_USB_OTG1_ID {
 		pinmux = <0x401f8020 6 0x401f8170 0 0x401f80d0>;
 	};
-	iomuxc_gpio_ad_11_adc1_in11: IOMUXC_GPIO_AD_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_in11: IOMUXC_GPIO_AD_11_ADC1_IN11 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_flexio1_io23: IOMUXC_GPIO_AD_11_FLEXIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio1_io23: IOMUXC_GPIO_AD_11_FLEXIO1_IO23 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM1_PWM1_X {
 		pinmux = <0x401f801c 1 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_gpiomux_io25: IOMUXC_GPIO_AD_11_GPIOMUX_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpiomux_io25: IOMUXC_GPIO_AD_11_GPIOMUX_IO25 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_jtag_mod: IOMUXC_GPIO_AD_11_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_jtag_mod: IOMUXC_GPIO_AD_11_JTAG_MOD {
 		pinmux = <0x401f801c 7 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_kpp_row1: IOMUXC_GPIO_AD_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_kpp_row1: IOMUXC_GPIO_AD_11_KPP_ROW1 {
 		pinmux = <0x401f801c 2 0x401f81b0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_lpspi2_pcs0: IOMUXC_GPIO_AD_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpspi2_pcs0: IOMUXC_GPIO_AD_11_LPSPI2_PCS0 {
 		pinmux = <0x401f801c 0 0x401f81e0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_pit_trigger2: IOMUXC_GPIO_AD_11_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_pit_trigger2: IOMUXC_GPIO_AD_11_PIT_TRIGGER2 {
 		pinmux = <0x401f801c 3 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_11_wdog1_b: IOMUXC_GPIO_AD_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_wdog1_b: IOMUXC_GPIO_AD_11_WDOG1_B {
 		pinmux = <0x401f801c 6 0x0 0 0x401f80cc>;
 	};
-	iomuxc_gpio_ad_12_adc1_in12: IOMUXC_GPIO_AD_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_in12: IOMUXC_GPIO_AD_12_ADC1_IN12 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_flexio1_io24: IOMUXC_GPIO_AD_12_FLEXIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio1_io24: IOMUXC_GPIO_AD_12_FLEXIO1_IO24 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_12_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_12_FLEXPWM1_PWM0_X {
 		pinmux = <0x401f8018 1 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_gpiomux_io26: IOMUXC_GPIO_AD_12_GPIOMUX_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpiomux_io26: IOMUXC_GPIO_AD_12_GPIOMUX_IO26 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_jtag_tck: IOMUXC_GPIO_AD_12_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_jtag_tck: IOMUXC_GPIO_AD_12_JTAG_TCK {
 		pinmux = <0x401f8018 7 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_kpp_col1: IOMUXC_GPIO_AD_12_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_kpp_col1: IOMUXC_GPIO_AD_12_KPP_COL1 {
 		pinmux = <0x401f8018 2 0x401f81a0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_lpspi2_sck: IOMUXC_GPIO_AD_12_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpspi2_sck: IOMUXC_GPIO_AD_12_LPSPI2_SCK {
 		pinmux = <0x401f8018 0 0x401f81e4 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_pit_trigger1: IOMUXC_GPIO_AD_12_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_pit_trigger1: IOMUXC_GPIO_AD_12_PIT_TRIGGER1 {
 		pinmux = <0x401f8018 3 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_12_usb_otg1_pwr: IOMUXC_GPIO_AD_12_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_usb_otg1_pwr: IOMUXC_GPIO_AD_12_USB_OTG1_PWR {
 		pinmux = <0x401f8018 6 0x0 0 0x401f80c8>;
 	};
-	iomuxc_gpio_ad_13_adc1_in13: IOMUXC_GPIO_AD_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_in13: IOMUXC_GPIO_AD_13_ADC1_IN13 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_arm_nmi: IOMUXC_GPIO_AD_13_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_arm_nmi: IOMUXC_GPIO_AD_13_ARM_NMI {
 		pinmux = <0x401f8014 6 0x401f8210 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_flexio1_io25: IOMUXC_GPIO_AD_13_FLEXIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio1_io25: IOMUXC_GPIO_AD_13_FLEXIO1_IO25 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_gpiomux_io27: IOMUXC_GPIO_AD_13_GPIOMUX_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpiomux_io27: IOMUXC_GPIO_AD_13_GPIOMUX_IO27 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_jtag_tms: IOMUXC_GPIO_AD_13_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_jtag_tms: IOMUXC_GPIO_AD_13_JTAG_TMS {
 		pinmux = <0x401f8014 7 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_kpp_row0: IOMUXC_GPIO_AD_13_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_kpp_row0: IOMUXC_GPIO_AD_13_KPP_ROW0 {
 		pinmux = <0x401f8014 2 0x401f81ac 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpi2c1_sda: IOMUXC_GPIO_AD_13_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpi2c1_sda: IOMUXC_GPIO_AD_13_LPI2C1_SDA {
 		pinmux = <0x401f8014 0 0x401f81c4 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpuart3_rts_b: IOMUXC_GPIO_AD_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpuart3_rts_b: IOMUXC_GPIO_AD_13_LPUART3_RTS_B {
 		pinmux = <0x401f8014 1 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_13_lpuart4_rts_b: IOMUXC_GPIO_AD_13_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_lpuart4_rts_b: IOMUXC_GPIO_AD_13_LPUART4_RTS_B {
 		pinmux = <0x401f8014 3 0x0 0 0x401f80c4>;
 	};
-	iomuxc_gpio_ad_14_adc1_in14: IOMUXC_GPIO_AD_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_in14: IOMUXC_GPIO_AD_14_ADC1_IN14 {
 		pinmux = <0x401f8010 5 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_flexio1_io26: IOMUXC_GPIO_AD_14_FLEXIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio1_io26: IOMUXC_GPIO_AD_14_FLEXIO1_IO26 {
 		pinmux = <0x401f8010 4 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_gpiomux_io28: IOMUXC_GPIO_AD_14_GPIOMUX_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpiomux_io28: IOMUXC_GPIO_AD_14_GPIOMUX_IO28 {
 		pinmux = <0x401f8010 5 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_kpp_col0: IOMUXC_GPIO_AD_14_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_kpp_col0: IOMUXC_GPIO_AD_14_KPP_COL0 {
 		pinmux = <0x401f8010 2 0x401f819c 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpi2c1_scl: IOMUXC_GPIO_AD_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpi2c1_scl: IOMUXC_GPIO_AD_14_LPI2C1_SCL {
 		pinmux = <0x401f8010 0 0x401f81c0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpuart3_cts_b: IOMUXC_GPIO_AD_14_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpuart3_cts_b: IOMUXC_GPIO_AD_14_LPUART3_CTS_B {
 		pinmux = <0x401f8010 1 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_lpuart4_cts_b: IOMUXC_GPIO_AD_14_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_lpuart4_cts_b: IOMUXC_GPIO_AD_14_LPUART4_CTS_B {
 		pinmux = <0x401f8010 3 0x0 0 0x401f80c0>;
 	};
-	iomuxc_gpio_ad_14_xbar1_in02: IOMUXC_GPIO_AD_14_XBAR1_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_xbar1_in02: IOMUXC_GPIO_AD_14_XBAR1_IN02 {
 		pinmux = <0x401f8010 7 0x0 0 0x401f80c0>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_14_xbar1_inout02: IOMUXC_GPIO_AD_14_XBAR1_INOUT02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_xbar1_inout02: IOMUXC_GPIO_AD_14_XBAR1_INOUT02 {
 		pinmux = <0x401f8010 7 0x0 0 0x401f80c0>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_00_arm_cm7_rxev: IOMUXC_GPIO_SD_00_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_arm_cm7_rxev: IOMUXC_GPIO_SD_00_ARM_CM7_RXEV {
 		pinmux = <0x401f8084 2 0x401f8220 1 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_ccm_stop: IOMUXC_GPIO_SD_00_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_ccm_stop: IOMUXC_GPIO_SD_00_CCM_STOP {
 		pinmux = <0x401f8084 3 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_flexio1_io06: IOMUXC_GPIO_SD_00_FLEXIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_flexio1_io06: IOMUXC_GPIO_SD_00_FLEXIO1_IO06 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_flexspi_b_ss0_b: IOMUXC_GPIO_SD_00_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_flexspi_b_ss0_b: IOMUXC_GPIO_SD_00_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_gpio2_io00: IOMUXC_GPIO_SD_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_gpio2_io00: IOMUXC_GPIO_SD_00_GPIO2_IO00 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_sai3_tx_sync: IOMUXC_GPIO_SD_00_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_sai3_tx_sync: IOMUXC_GPIO_SD_00_SAI3_TX_SYNC {
 		pinmux = <0x401f8084 1 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_00_src_bt_cfg2: IOMUXC_GPIO_SD_00_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_00_src_bt_cfg2: IOMUXC_GPIO_SD_00_SRC_BT_CFG2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f8134>;
 	};
-	iomuxc_gpio_sd_01_ccm_clko2: IOMUXC_GPIO_SD_01_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_ccm_clko2: IOMUXC_GPIO_SD_01_CCM_CLKO2 {
 		pinmux = <0x401f8080 3 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexio1_io07: IOMUXC_GPIO_SD_01_FLEXIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexio1_io07: IOMUXC_GPIO_SD_01_FLEXIO1_IO07 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexpwm1_pwm0_b: IOMUXC_GPIO_SD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexpwm1_pwm0_b: IOMUXC_GPIO_SD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x401f8080 2 0x401f8184 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_flexspi_b_data1: IOMUXC_GPIO_SD_01_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_flexspi_b_data1: IOMUXC_GPIO_SD_01_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_gpio2_io01: IOMUXC_GPIO_SD_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_gpio2_io01: IOMUXC_GPIO_SD_01_GPIO2_IO01 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_sai3_tx_bclk: IOMUXC_GPIO_SD_01_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_sai3_tx_bclk: IOMUXC_GPIO_SD_01_SAI3_TX_BCLK {
 		pinmux = <0x401f8080 1 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_01_src_bt_cfg1: IOMUXC_GPIO_SD_01_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_01_src_bt_cfg1: IOMUXC_GPIO_SD_01_SRC_BT_CFG1 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f8130>;
 	};
-	iomuxc_gpio_sd_02_ccm_clko1: IOMUXC_GPIO_SD_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_ccm_clko1: IOMUXC_GPIO_SD_02_CCM_CLKO1 {
 		pinmux = <0x401f807c 3 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexio1_io08: IOMUXC_GPIO_SD_02_FLEXIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexio1_io08: IOMUXC_GPIO_SD_02_FLEXIO1_IO08 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexpwm1_pwm0_a: IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexpwm1_pwm0_a: IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A {
 		pinmux = <0x401f807c 2 0x401f8174 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_flexspi_b_data2: IOMUXC_GPIO_SD_02_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_flexspi_b_data2: IOMUXC_GPIO_SD_02_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_gpio2_io02: IOMUXC_GPIO_SD_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_gpio2_io02: IOMUXC_GPIO_SD_02_GPIO2_IO02 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_sai3_tx_data: IOMUXC_GPIO_SD_02_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_sai3_tx_data: IOMUXC_GPIO_SD_02_SAI3_TX_DATA {
 		pinmux = <0x401f807c 1 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_02_src_bt_cfg0: IOMUXC_GPIO_SD_02_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_02_src_bt_cfg0: IOMUXC_GPIO_SD_02_SRC_BT_CFG0 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f812c>;
 	};
-	iomuxc_gpio_sd_03_ccm_ref_en_b: IOMUXC_GPIO_SD_03_CCM_REF_EN_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_ccm_ref_en_b: IOMUXC_GPIO_SD_03_CCM_REF_EN_B {
 		pinmux = <0x401f8078 3 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexio1_io09: IOMUXC_GPIO_SD_03_FLEXIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexio1_io09: IOMUXC_GPIO_SD_03_FLEXIO1_IO09 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexpwm1_pwm1_b: IOMUXC_GPIO_SD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexpwm1_pwm1_b: IOMUXC_GPIO_SD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x401f8078 2 0x401f8188 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_flexspi_b_data0: IOMUXC_GPIO_SD_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_flexspi_b_data0: IOMUXC_GPIO_SD_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_gpio2_io03: IOMUXC_GPIO_SD_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_gpio2_io03: IOMUXC_GPIO_SD_03_GPIO2_IO03 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_sai3_rx_data: IOMUXC_GPIO_SD_03_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_sai3_rx_data: IOMUXC_GPIO_SD_03_SAI3_RX_DATA {
 		pinmux = <0x401f8078 1 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_03_src_boot_mode1: IOMUXC_GPIO_SD_03_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_03_src_boot_mode1: IOMUXC_GPIO_SD_03_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f8128>;
 	};
-	iomuxc_gpio_sd_04_ccm_wait: IOMUXC_GPIO_SD_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_ccm_wait: IOMUXC_GPIO_SD_04_CCM_WAIT {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexio1_io10: IOMUXC_GPIO_SD_04_FLEXIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexio1_io10: IOMUXC_GPIO_SD_04_FLEXIO1_IO10 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexpwm1_pwm1_a: IOMUXC_GPIO_SD_04_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexpwm1_pwm1_a: IOMUXC_GPIO_SD_04_FLEXPWM1_PWM1_A {
 		pinmux = <0x401f8074 2 0x401f8178 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_flexspi_b_data3: IOMUXC_GPIO_SD_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_flexspi_b_data3: IOMUXC_GPIO_SD_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_gpio2_io04: IOMUXC_GPIO_SD_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_gpio2_io04: IOMUXC_GPIO_SD_04_GPIO2_IO04 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_sai3_rx_sync: IOMUXC_GPIO_SD_04_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_sai3_rx_sync: IOMUXC_GPIO_SD_04_SAI3_RX_SYNC {
 		pinmux = <0x401f8074 1 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_04_src_boot_mode0: IOMUXC_GPIO_SD_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_04_src_boot_mode0: IOMUXC_GPIO_SD_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f8124>;
 	};
-	iomuxc_gpio_sd_05_flexio1_io11: IOMUXC_GPIO_SD_05_FLEXIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_flexio1_io11: IOMUXC_GPIO_SD_05_FLEXIO1_IO11 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_flexspi_a_ss1_b: IOMUXC_GPIO_SD_05_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_flexspi_a_ss1_b: IOMUXC_GPIO_SD_05_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_gpio2_io05: IOMUXC_GPIO_SD_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_gpio2_io05: IOMUXC_GPIO_SD_05_GPIO2_IO05 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_lpi2c1_sda: IOMUXC_GPIO_SD_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_lpi2c1_sda: IOMUXC_GPIO_SD_05_LPI2C1_SDA {
 		pinmux = <0x401f8070 1 0x401f81c4 1 0x401f8120>;
 	};
-	iomuxc_gpio_sd_05_lpspi1_sdi: IOMUXC_GPIO_SD_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_05_lpspi1_sdi: IOMUXC_GPIO_SD_05_LPSPI1_SDI {
 		pinmux = <0x401f8070 2 0x401f81d8 1 0x401f8120>;
 	};
-	iomuxc_gpio_sd_06_flexio1_io12: IOMUXC_GPIO_SD_06_FLEXIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_flexio1_io12: IOMUXC_GPIO_SD_06_FLEXIO1_IO12 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f806c 0 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_gpio2_io06: IOMUXC_GPIO_SD_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_gpio2_io06: IOMUXC_GPIO_SD_06_GPIO2_IO06 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_lpi2c1_scl: IOMUXC_GPIO_SD_06_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_lpi2c1_scl: IOMUXC_GPIO_SD_06_LPI2C1_SCL {
 		pinmux = <0x401f806c 1 0x401f81c0 1 0x401f811c>;
 	};
-	iomuxc_gpio_sd_06_lpspi1_sdo: IOMUXC_GPIO_SD_06_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_06_lpspi1_sdo: IOMUXC_GPIO_SD_06_LPSPI1_SDO {
 		pinmux = <0x401f806c 2 0x401f81dc 1 0x401f811c>;
 	};
-	iomuxc_gpio_sd_07_flexio1_io13: IOMUXC_GPIO_SD_07_FLEXIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_flexio1_io13: IOMUXC_GPIO_SD_07_FLEXIO1_IO13 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_flexspi_a_data1: IOMUXC_GPIO_SD_07_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_flexspi_a_data1: IOMUXC_GPIO_SD_07_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_gpio2_io07: IOMUXC_GPIO_SD_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_gpio2_io07: IOMUXC_GPIO_SD_07_GPIO2_IO07 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_lpi2c2_sda: IOMUXC_GPIO_SD_07_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_lpi2c2_sda: IOMUXC_GPIO_SD_07_LPI2C2_SDA {
 		pinmux = <0x401f8068 1 0x401f81cc 2 0x401f8118>;
 	};
-	iomuxc_gpio_sd_07_lpspi1_pcs0: IOMUXC_GPIO_SD_07_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_07_lpspi1_pcs0: IOMUXC_GPIO_SD_07_LPSPI1_PCS0 {
 		pinmux = <0x401f8068 2 0x401f81d0 1 0x401f8118>;
 	};
-	iomuxc_gpio_sd_08_flexio1_io14: IOMUXC_GPIO_SD_08_FLEXIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_flexio1_io14: IOMUXC_GPIO_SD_08_FLEXIO1_IO14 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_flexspi_a_data2: IOMUXC_GPIO_SD_08_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_flexspi_a_data2: IOMUXC_GPIO_SD_08_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_gpio2_io08: IOMUXC_GPIO_SD_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_gpio2_io08: IOMUXC_GPIO_SD_08_GPIO2_IO08 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_lpi2c2_scl: IOMUXC_GPIO_SD_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_lpi2c2_scl: IOMUXC_GPIO_SD_08_LPI2C2_SCL {
 		pinmux = <0x401f8064 1 0x401f81c8 2 0x401f8114>;
 	};
-	iomuxc_gpio_sd_08_lpspi1_sck: IOMUXC_GPIO_SD_08_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_08_lpspi1_sck: IOMUXC_GPIO_SD_08_LPSPI1_SCK {
 		pinmux = <0x401f8064 2 0x401f81d4 1 0x401f8114>;
 	};
-	iomuxc_gpio_sd_09_flexio1_io15: IOMUXC_GPIO_SD_09_FLEXIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_flexio1_io15: IOMUXC_GPIO_SD_09_FLEXIO1_IO15 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_flexspi_a_data0: IOMUXC_GPIO_SD_09_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_flexspi_a_data0: IOMUXC_GPIO_SD_09_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_gpio2_io09: IOMUXC_GPIO_SD_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_gpio2_io09: IOMUXC_GPIO_SD_09_GPIO2_IO09 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_lpspi2_sdi: IOMUXC_GPIO_SD_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_lpspi2_sdi: IOMUXC_GPIO_SD_09_LPSPI2_SDI {
 		pinmux = <0x401f8060 1 0x401f81e8 1 0x401f8110>;
 	};
-	iomuxc_gpio_sd_09_lpuart2_rxd: IOMUXC_GPIO_SD_09_LPUART2_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_09_lpuart2_rxd: IOMUXC_GPIO_SD_09_LPUART2_RXD {
 		pinmux = <0x401f8060 2 0x401f81f8 0 0x401f8110>;
 	};
-	iomuxc_gpio_sd_10_flexio1_io16: IOMUXC_GPIO_SD_10_FLEXIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_flexio1_io16: IOMUXC_GPIO_SD_10_FLEXIO1_IO16 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_flexspi_a_sclk: IOMUXC_GPIO_SD_10_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_flexspi_a_sclk: IOMUXC_GPIO_SD_10_FLEXSPI_A_SCLK {
 		pinmux = <0x401f805c 0 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_gpio2_io10: IOMUXC_GPIO_SD_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_gpio2_io10: IOMUXC_GPIO_SD_10_GPIO2_IO10 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_lpspi2_sdo: IOMUXC_GPIO_SD_10_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_lpspi2_sdo: IOMUXC_GPIO_SD_10_LPSPI2_SDO {
 		pinmux = <0x401f805c 1 0x401f81ec 1 0x401f810c>;
 	};
-	iomuxc_gpio_sd_10_lpuart2_txd: IOMUXC_GPIO_SD_10_LPUART2_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_10_lpuart2_txd: IOMUXC_GPIO_SD_10_LPUART2_TXD {
 		pinmux = <0x401f805c 2 0x401f81fc 1 0x401f810c>;
 	};
-	iomuxc_gpio_sd_11_flexio1_io17: IOMUXC_GPIO_SD_11_FLEXIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_flexio1_io17: IOMUXC_GPIO_SD_11_FLEXIO1_IO17 {
 		pinmux = <0x401f8058 4 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_flexspi_a_data3: IOMUXC_GPIO_SD_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_flexspi_a_data3: IOMUXC_GPIO_SD_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_gpio2_io11: IOMUXC_GPIO_SD_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_gpio2_io11: IOMUXC_GPIO_SD_11_GPIO2_IO11 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_lpspi2_sck: IOMUXC_GPIO_SD_11_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_lpspi2_sck: IOMUXC_GPIO_SD_11_LPSPI2_SCK {
 		pinmux = <0x401f8058 1 0x401f81e4 1 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_lpuart1_rxd: IOMUXC_GPIO_SD_11_LPUART1_RXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_lpuart1_rxd: IOMUXC_GPIO_SD_11_LPUART1_RXD {
 		pinmux = <0x401f8058 2 0x401f81f0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_11_wdog1_rst_b_deb: IOMUXC_GPIO_SD_11_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_sd_11_wdog1_rst_b_deb: IOMUXC_GPIO_SD_11_WDOG1_RST_B_DEB {
 		pinmux = <0x401f8058 6 0x0 0 0x401f8108>;
 	};
-	iomuxc_gpio_sd_12_flexio1_io18: IOMUXC_GPIO_SD_12_FLEXIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_flexio1_io18: IOMUXC_GPIO_SD_12_FLEXIO1_IO18 {
 		pinmux = <0x401f8054 4 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_flexspi_a_dqs: IOMUXC_GPIO_SD_12_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_flexspi_a_dqs: IOMUXC_GPIO_SD_12_FLEXSPI_A_DQS {
 		pinmux = <0x401f8054 0 0x401f8194 1 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_gpio2_io12: IOMUXC_GPIO_SD_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_gpio2_io12: IOMUXC_GPIO_SD_12_GPIO2_IO12 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_lpspi2_pcs0: IOMUXC_GPIO_SD_12_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_lpspi2_pcs0: IOMUXC_GPIO_SD_12_LPSPI2_PCS0 {
 		pinmux = <0x401f8054 1 0x401f81e0 1 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_lpuart1_txd: IOMUXC_GPIO_SD_12_LPUART1_TXD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_lpuart1_txd: IOMUXC_GPIO_SD_12_LPUART1_TXD {
 		pinmux = <0x401f8054 2 0x401f81f4 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_12_wdog2_rst_b_deb: IOMUXC_GPIO_SD_12_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_sd_12_wdog2_rst_b_deb: IOMUXC_GPIO_SD_12_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8054 6 0x0 0 0x401f8104>;
 	};
-	iomuxc_gpio_sd_13_arm_cm7_txev: IOMUXC_GPIO_SD_13_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_arm_cm7_txev: IOMUXC_GPIO_SD_13_ARM_CM7_TXEV {
 		pinmux = <0x401f8050 2 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_ccm_pmic_rdy: IOMUXC_GPIO_SD_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_ccm_pmic_rdy: IOMUXC_GPIO_SD_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_flexio1_io19: IOMUXC_GPIO_SD_13_FLEXIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_flexio1_io19: IOMUXC_GPIO_SD_13_FLEXIO1_IO19 {
 		pinmux = <0x401f8050 4 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_flexspi_b_sclk: IOMUXC_GPIO_SD_13_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_flexspi_b_sclk: IOMUXC_GPIO_SD_13_FLEXSPI_B_SCLK {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_gpio2_io13: IOMUXC_GPIO_SD_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_gpio2_io13: IOMUXC_GPIO_SD_13_GPIO2_IO13 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_sai3_rx_bclk: IOMUXC_GPIO_SD_13_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_sai3_rx_bclk: IOMUXC_GPIO_SD_13_SAI3_RX_BCLK {
 		pinmux = <0x401f8050 1 0x0 0 0x401f8100>;
 	};
-	iomuxc_gpio_sd_13_src_bt_cfg3: IOMUXC_GPIO_SD_13_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_13_src_bt_cfg3: IOMUXC_GPIO_SD_13_SRC_BT_CFG3 {
 		pinmux = <0x401f8050 6 0x0 0 0x401f8100>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io00: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io00: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8000 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8008>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a8004>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1015caf4a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1015caf4a-pinctrl.dtsi
@@ -18,824 +18,824 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_ccm_ref_en_b: IOMUXC_GPIO_SD_B1_09_CCM_REF_EN_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_ccm_ref_en_b: IOMUXC_GPIO_SD_B1_09_CCM_REF_EN_B {
 		pinmux = <0x401f817c 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1015daf5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1015daf5a-pinctrl.dtsi
@@ -18,824 +18,824 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_ccm_ref_en_b: IOMUXC_GPIO_SD_B1_09_CCM_REF_EN_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_ccm_ref_en_b: IOMUXC_GPIO_SD_B1_09_CCM_REF_EN_B {
 		pinmux = <0x401f817c 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1021caf4a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1021caf4a-pinctrl.dtsi
@@ -18,1275 +18,1275 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1021cag4a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1021cag4a-pinctrl.dtsi
@@ -18,2302 +18,2302 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp1_in2: IOMUXC_GPIO_AD_B1_00_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp1_in2: IOMUXC_GPIO_AD_B1_00_ACMP1_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_00_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_00_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f80fc 6 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexcan2_tx: IOMUXC_GPIO_AD_B1_00_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexcan2_tx: IOMUXC_GPIO_AD_B1_00_FLEXCAN2_TX {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio1_flexio15: IOMUXC_GPIO_AD_B1_00_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio1_flexio15: IOMUXC_GPIO_AD_B1_00_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexspi_a_data3: IOMUXC_GPIO_AD_B1_00_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexspi_a_data3: IOMUXC_GPIO_AD_B1_00_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f80fc 1 0x401f8374 1 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_col4: IOMUXC_GPIO_AD_B1_00_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_col4: IOMUXC_GPIO_AD_B1_00_KPP_COL4 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_sai1_mclk: IOMUXC_GPIO_AD_B1_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_sai1_mclk: IOMUXC_GPIO_AD_B1_00_SAI1_MCLK {
 		pinmux = <0x401f80fc 3 0x401f8430 2 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_semc_rdy: IOMUXC_GPIO_AD_B1_00_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_semc_rdy: IOMUXC_GPIO_AD_B1_00_SEMC_RDY {
 		pinmux = <0x401f80fc 0 0x401f8484 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in2: IOMUXC_GPIO_AD_B1_01_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in2: IOMUXC_GPIO_AD_B1_01_ACMP2_IN2 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in3: IOMUXC_GPIO_AD_B1_01_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in3: IOMUXC_GPIO_AD_B1_01_ADC1_IN3 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_01_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_01_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8100 6 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexcan2_rx: IOMUXC_GPIO_AD_B1_01_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexcan2_rx: IOMUXC_GPIO_AD_B1_01_FLEXCAN2_RX {
 		pinmux = <0x401f8100 2 0x401f8324 3 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio1_flexio14: IOMUXC_GPIO_AD_B1_01_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio1_flexio14: IOMUXC_GPIO_AD_B1_01_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8100 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_01_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_01_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8100 1 0x401f8378 1 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_row4: IOMUXC_GPIO_AD_B1_01_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_row4: IOMUXC_GPIO_AD_B1_01_KPP_ROW4 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_01_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_01_SAI1_TX_BCLK {
 		pinmux = <0x401f8100 3 0x401f844c 1 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_semc_csx0: IOMUXC_GPIO_AD_B1_01_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_semc_csx0: IOMUXC_GPIO_AD_B1_01_SEMC_CSX0 {
 		pinmux = <0x401f8100 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp3_in2: IOMUXC_GPIO_AD_B1_02_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp3_in2: IOMUXC_GPIO_AD_B1_02_ACMP3_IN2 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in3: IOMUXC_GPIO_AD_B1_02_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in3: IOMUXC_GPIO_AD_B1_02_ADC2_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event3_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event3_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f8104 6 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio1_flexio13: IOMUXC_GPIO_AD_B1_02_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio1_flexio13: IOMUXC_GPIO_AD_B1_02_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8104 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_flexspi_a_data0: IOMUXC_GPIO_AD_B1_02_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexspi_a_data0: IOMUXC_GPIO_AD_B1_02_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8104 1 0x401f8368 1 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_col5: IOMUXC_GPIO_AD_B1_02_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_col5: IOMUXC_GPIO_AD_B1_02_KPP_COL5 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_lpspi4_sck: IOMUXC_GPIO_AD_B1_02_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpspi4_sck: IOMUXC_GPIO_AD_B1_02_LPSPI4_SCK {
 		pinmux = <0x401f8104 2 0x401f83c0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_sai1_tx_sync: IOMUXC_GPIO_AD_B1_02_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_sai1_tx_sync: IOMUXC_GPIO_AD_B1_02_SAI1_TX_SYNC {
 		pinmux = <0x401f8104 3 0x401f8450 1 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_semc_csx1: IOMUXC_GPIO_AD_B1_02_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_semc_csx1: IOMUXC_GPIO_AD_B1_02_SEMC_CSX1 {
 		pinmux = <0x401f8104 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp4_in2: IOMUXC_GPIO_AD_B1_03_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp4_in2: IOMUXC_GPIO_AD_B1_03_ACMP4_IN2 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in4: IOMUXC_GPIO_AD_B1_03_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in4: IOMUXC_GPIO_AD_B1_03_ADC1_IN4 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event3_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event3_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f8108 6 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio1_flexio12: IOMUXC_GPIO_AD_B1_03_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio1_flexio12: IOMUXC_GPIO_AD_B1_03_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f8108 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_flexspi_a_data2: IOMUXC_GPIO_AD_B1_03_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexspi_a_data2: IOMUXC_GPIO_AD_B1_03_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8108 1 0x401f8370 1 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_row5: IOMUXC_GPIO_AD_B1_03_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_row5: IOMUXC_GPIO_AD_B1_03_KPP_ROW5 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_lpspi4_pcs0: IOMUXC_GPIO_AD_B1_03_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpspi4_pcs0: IOMUXC_GPIO_AD_B1_03_LPSPI4_PCS0 {
 		pinmux = <0x401f8108 2 0x401f83bc 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_sai1_tx_data0: IOMUXC_GPIO_AD_B1_03_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_sai1_tx_data0: IOMUXC_GPIO_AD_B1_03_SAI1_TX_DATA0 {
 		pinmux = <0x401f8108 3 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_semc_csx2: IOMUXC_GPIO_AD_B1_03_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_semc_csx2: IOMUXC_GPIO_AD_B1_03_SEMC_CSX2 {
 		pinmux = <0x401f8108 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp1_in3: IOMUXC_GPIO_AD_B1_04_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp1_in3: IOMUXC_GPIO_AD_B1_04_ACMP1_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in4: IOMUXC_GPIO_AD_B1_04_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in4: IOMUXC_GPIO_AD_B1_04_ADC2_IN4 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio1_flexio11: IOMUXC_GPIO_AD_B1_04_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio1_flexio11: IOMUXC_GPIO_AD_B1_04_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f810c 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_a_data1: IOMUXC_GPIO_AD_B1_04_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_a_data1: IOMUXC_GPIO_AD_B1_04_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f810c 1 0x401f836c 1 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_col6: IOMUXC_GPIO_AD_B1_04_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_col6: IOMUXC_GPIO_AD_B1_04_KPP_COL6 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_lpspi1_pcs1: IOMUXC_GPIO_AD_B1_04_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpspi1_pcs1: IOMUXC_GPIO_AD_B1_04_LPSPI1_PCS1 {
 		pinmux = <0x401f810c 6 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_lpspi4_sdo: IOMUXC_GPIO_AD_B1_04_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpspi4_sdo: IOMUXC_GPIO_AD_B1_04_LPSPI4_SDO {
 		pinmux = <0x401f810c 2 0x401f83c8 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_sai1_rx_sync: IOMUXC_GPIO_AD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_sai1_rx_sync: IOMUXC_GPIO_AD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f810c 3 0x401f8448 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_semc_csx3: IOMUXC_GPIO_AD_B1_04_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_semc_csx3: IOMUXC_GPIO_AD_B1_04_SEMC_CSX3 {
 		pinmux = <0x401f810c 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp2_in3: IOMUXC_GPIO_AD_B1_05_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp2_in3: IOMUXC_GPIO_AD_B1_05_ACMP2_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in5: IOMUXC_GPIO_AD_B1_05_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in5: IOMUXC_GPIO_AD_B1_05_ADC1_IN5 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in5: IOMUXC_GPIO_AD_B1_05_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in5: IOMUXC_GPIO_AD_B1_05_ADC2_IN5 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio1_flexio10: IOMUXC_GPIO_AD_B1_05_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio1_flexio10: IOMUXC_GPIO_AD_B1_05_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_05_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_05_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8110 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_row6: IOMUXC_GPIO_AD_B1_05_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_row6: IOMUXC_GPIO_AD_B1_05_KPP_ROW6 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_lpspi1_pcs2: IOMUXC_GPIO_AD_B1_05_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpspi1_pcs2: IOMUXC_GPIO_AD_B1_05_LPSPI1_PCS2 {
 		pinmux = <0x401f8110 6 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_lpspi4_sdi: IOMUXC_GPIO_AD_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpspi4_sdi: IOMUXC_GPIO_AD_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8110 2 0x401f83c4 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_sai1_rx_data0: IOMUXC_GPIO_AD_B1_05_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_sai1_rx_data0: IOMUXC_GPIO_AD_B1_05_SAI1_RX_DATA0 {
 		pinmux = <0x401f8110 3 0x401f8438 1 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc1_wp: IOMUXC_GPIO_AD_B1_05_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc1_wp: IOMUXC_GPIO_AD_B1_05_USDHC1_WP {
 		pinmux = <0x401f8110 0 0x401f8494 2 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8114 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8114 1 0x401f8328 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
 		pinmux = <0x401f8114 6 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
 		pinmux = <0x401f8114 2 0x401f83cc 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
 		pinmux = <0x401f8114 3 0x401f8434 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
 		pinmux = <0x401f8114 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8118 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8118 1 0x401f8338 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
 		pinmux = <0x401f8118 6 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
 		pinmux = <0x401f8118 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
 		pinmux = <0x401f8118 3 0x401f8444 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
 		pinmux = <0x401f8118 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f811c 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f811c 1 0x401f832c 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
 		pinmux = <0x401f811c 0 0x401f8384 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
 		pinmux = <0x401f811c 6 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
 		pinmux = <0x401f811c 2 0x401f83d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
 		pinmux = <0x401f811c 3 0x401f8440 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f8120 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8120 1 0x401f833c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
 		pinmux = <0x401f8120 0 0x401f8388 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
 		pinmux = <0x401f8120 6 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
 		pinmux = <0x401f8120 2 0x401f83d0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
 		pinmux = <0x401f8120 3 0x401f843c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
 		pinmux = <0x401f8014 6 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 4 0x401f83b0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
 		pinmux = <0x401f8014 2 0x401f83e0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
 		pinmux = <0x401f8014 7 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
 		pinmux = <0x401f8014 1 0x401f8420 0 0x401f8188>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
 		pinmux = <0x401f8014 3 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
 		pinmux = <0x401f8018 6 0x401f8320 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 4 0x401f83ac 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
 		pinmux = <0x401f8018 2 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
 		pinmux = <0x401f8018 7 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
 		pinmux = <0x401f8018 1 0x401f8424 0 0x401f818c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
 		pinmux = <0x401f8018 3 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
 		pinmux = <0x401f801c 6 0x401f837c 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 4 0x401f83b8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
 		pinmux = <0x401f801c 2 0x401f83e8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
 		pinmux = <0x401f801c 1 0x401f8428 0 0x401f8190>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
 		pinmux = <0x401f801c 3 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
 		pinmux = <0x401f8020 6 0x401f8380 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 4 0x401f83b4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
 		pinmux = <0x401f8020 2 0x401f83e4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
 		pinmux = <0x401f8020 1 0x401f842c 0 0x401f8194>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
 		pinmux = <0x401f8020 3 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
 		pinmux = <0x401f803c 6 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
 		pinmux = <0x401f803c 2 0x401f8398 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
 		pinmux = <0x401f803c 4 0x401f83b0 1 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
 		pinmux = <0x401f803c 0 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
 		pinmux = <0x401f8040 6 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
 		pinmux = <0x401f8040 2 0x401f8394 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
 		pinmux = <0x401f8040 4 0x401f83ac 1 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
 		pinmux = <0x401f8040 3 0x401f844c 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
 		pinmux = <0x401f8040 0 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
 		pinmux = <0x401f8044 6 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
 		pinmux = <0x401f8044 4 0x401f83b8 1 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
 		pinmux = <0x401f8044 2 0x401f83f8 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
 		pinmux = <0x401f8044 3 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8048 7 0x401f8300 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
 		pinmux = <0x401f8048 6 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
 		pinmux = <0x401f8048 4 0x401f83b4 1 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
 		pinmux = <0x401f8048 2 0x401f83f4 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
 		pinmux = <0x401f8048 3 0x401f8438 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
 		pinmux = <0x401f804c 6 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
 		pinmux = <0x401f804c 2 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
 		pinmux = <0x401f804c 3 0x401f8434 1 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
 		pinmux = <0x401f8050 6 0x401f8320 3 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
 		pinmux = <0x401f8050 2 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
 		pinmux = <0x401f8050 3 0x401f8448 1 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
 		pinmux = <0x401f8050 4 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
 		pinmux = <0x401f8084 4 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f8084 7 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8084 1 0x401f8354 1 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
 		pinmux = <0x401f8084 3 0x401f846c 2 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
 		pinmux = <0x401f8084 0 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8088 1 0x401f8364 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
 		pinmux = <0x401f8088 6 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
 		pinmux = <0x401f8088 3 0x401f8470 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
 		pinmux = <0x401f8088 0 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8088 4 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f808c 1 0x401f8350 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
 		pinmux = <0x401f808c 6 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
 		pinmux = <0x401f808c 2 0x401f83e0 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
 		pinmux = <0x401f808c 3 0x401f8478 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
 		pinmux = <0x401f808c 0 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
 		pinmux = <0x401f808c 4 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8090 1 0x401f8360 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
 		pinmux = <0x401f8090 2 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
 		pinmux = <0x401f8090 3 0x401f8474 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
 		pinmux = <0x401f80a4 3 0x401f8300 3 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
 		pinmux = <0x401f80a4 6 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80a4 1 0x401f834c 1 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 7 0x401f8494 4 0x401f8218>;
 	};
-	iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
 		pinmux = <0x401f80a8 6 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80a8 1 0x401f835c 1 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
 		pinmux = <0x401f80a8 7 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80ac 1 0x401f8348 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
 		pinmux = <0x401f80ac 2 0x401f83f0 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
 		pinmux = <0x401f80ac 7 0x401f8490 3 0x401f8220>;
 	};
-	iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
 		pinmux = <0x401f80b0 6 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80b0 1 0x401f8358 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
 		pinmux = <0x401f80b0 7 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
 		pinmux = <0x401f80b0 2 0x401f83ec 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
 		pinmux = <0x401f80b0 3 0x401f848c 2 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
 		pinmux = <0x401f80b4 4 0x401f8308 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
 		pinmux = <0x401f80b4 7 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
 		pinmux = <0x401f80b4 3 0x401f82fc 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
 		pinmux = <0x401f80b8 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
 		pinmux = <0x401f80b8 7 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
 		pinmux = <0x401f80b8 0 0x401f8484 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
 		pinmux = <0x401f80b8 2 0x401f8488 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f813c 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f813c 4 0x401f838c 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x401f8410 0 0x401f82b0>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
 		pinmux = <0x401f813c 2 0x401f8430 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
 		pinmux = <0x401f813c 3 0x401f8454 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
 		pinmux = <0x401f813c 0 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8140 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f8140 4 0x401f8390 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x401f8414 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
 		pinmux = <0x401f8140 3 0x401f8460 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
 		pinmux = <0x401f8140 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
 		pinmux = <0x401f8144 6 0x401f8308 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
 		pinmux = <0x401f8144 4 0x401f83a0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
 		pinmux = <0x401f8144 2 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x401f8418 0 0x401f82b8>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
 		pinmux = <0x401f8144 3 0x401f8458 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
 		pinmux = <0x401f8144 0 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
 		pinmux = <0x401f8148 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
 		pinmux = <0x401f8148 4 0x401f839c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
 		pinmux = <0x401f8148 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
 		pinmux = <0x401f8148 1 0x401f841c 0 0x401f82bc>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
 		pinmux = <0x401f8148 3 0x401f845c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
 		pinmux = <0x401f8148 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
 		pinmux = <0x401f814c 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f814c 6 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
 		pinmux = <0x401f814c 4 0x401f83a8 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
 		pinmux = <0x401f814c 2 0x401f8400 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
 		pinmux = <0x401f814c 3 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
 		pinmux = <0x401f8150 1 0x401f8324 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f8150 6 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
 		pinmux = <0x401f8150 4 0x401f83a4 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
 		pinmux = <0x401f8150 2 0x401f83fc 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f8150 3 0x401f8464 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f8154 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
 		pinmux = <0x401f8154 3 0x401f8468 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
 		pinmux = <0x401f8154 0 0x401f8490 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
 		pinmux = <0x401f8154 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
 		pinmux = <0x401f8154 4 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f840c 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1021daf5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1021daf5a-pinctrl.dtsi
@@ -18,1275 +18,1275 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1021dag5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1021dag5a-pinctrl.dtsi
@@ -18,2302 +18,2302 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp1_in2: IOMUXC_GPIO_AD_B1_00_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp1_in2: IOMUXC_GPIO_AD_B1_00_ACMP1_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_00_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_00_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f80fc 6 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexcan2_tx: IOMUXC_GPIO_AD_B1_00_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexcan2_tx: IOMUXC_GPIO_AD_B1_00_FLEXCAN2_TX {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio1_flexio15: IOMUXC_GPIO_AD_B1_00_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio1_flexio15: IOMUXC_GPIO_AD_B1_00_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_flexspi_a_data3: IOMUXC_GPIO_AD_B1_00_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexspi_a_data3: IOMUXC_GPIO_AD_B1_00_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f80fc 1 0x401f8374 1 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_col4: IOMUXC_GPIO_AD_B1_00_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_col4: IOMUXC_GPIO_AD_B1_00_KPP_COL4 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_sai1_mclk: IOMUXC_GPIO_AD_B1_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_sai1_mclk: IOMUXC_GPIO_AD_B1_00_SAI1_MCLK {
 		pinmux = <0x401f80fc 3 0x401f8430 2 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_00_semc_rdy: IOMUXC_GPIO_AD_B1_00_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_semc_rdy: IOMUXC_GPIO_AD_B1_00_SEMC_RDY {
 		pinmux = <0x401f80fc 0 0x401f8484 0 0x401f8270>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in2: IOMUXC_GPIO_AD_B1_01_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in2: IOMUXC_GPIO_AD_B1_01_ACMP2_IN2 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in3: IOMUXC_GPIO_AD_B1_01_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in3: IOMUXC_GPIO_AD_B1_01_ADC1_IN3 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_01_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_01_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8100 6 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexcan2_rx: IOMUXC_GPIO_AD_B1_01_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexcan2_rx: IOMUXC_GPIO_AD_B1_01_FLEXCAN2_RX {
 		pinmux = <0x401f8100 2 0x401f8324 3 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio1_flexio14: IOMUXC_GPIO_AD_B1_01_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio1_flexio14: IOMUXC_GPIO_AD_B1_01_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8100 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_01_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_01_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8100 1 0x401f8378 1 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_row4: IOMUXC_GPIO_AD_B1_01_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_row4: IOMUXC_GPIO_AD_B1_01_KPP_ROW4 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_01_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_01_SAI1_TX_BCLK {
 		pinmux = <0x401f8100 3 0x401f844c 1 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_01_semc_csx0: IOMUXC_GPIO_AD_B1_01_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_semc_csx0: IOMUXC_GPIO_AD_B1_01_SEMC_CSX0 {
 		pinmux = <0x401f8100 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp3_in2: IOMUXC_GPIO_AD_B1_02_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp3_in2: IOMUXC_GPIO_AD_B1_02_ACMP3_IN2 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in3: IOMUXC_GPIO_AD_B1_02_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in3: IOMUXC_GPIO_AD_B1_02_ADC2_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event3_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event3_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f8104 6 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio1_flexio13: IOMUXC_GPIO_AD_B1_02_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio1_flexio13: IOMUXC_GPIO_AD_B1_02_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8104 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_flexspi_a_data0: IOMUXC_GPIO_AD_B1_02_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexspi_a_data0: IOMUXC_GPIO_AD_B1_02_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8104 1 0x401f8368 1 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_col5: IOMUXC_GPIO_AD_B1_02_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_col5: IOMUXC_GPIO_AD_B1_02_KPP_COL5 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_lpspi4_sck: IOMUXC_GPIO_AD_B1_02_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpspi4_sck: IOMUXC_GPIO_AD_B1_02_LPSPI4_SCK {
 		pinmux = <0x401f8104 2 0x401f83c0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_sai1_tx_sync: IOMUXC_GPIO_AD_B1_02_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_sai1_tx_sync: IOMUXC_GPIO_AD_B1_02_SAI1_TX_SYNC {
 		pinmux = <0x401f8104 3 0x401f8450 1 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_02_semc_csx1: IOMUXC_GPIO_AD_B1_02_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_semc_csx1: IOMUXC_GPIO_AD_B1_02_SEMC_CSX1 {
 		pinmux = <0x401f8104 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp4_in2: IOMUXC_GPIO_AD_B1_03_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp4_in2: IOMUXC_GPIO_AD_B1_03_ACMP4_IN2 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in4: IOMUXC_GPIO_AD_B1_03_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in4: IOMUXC_GPIO_AD_B1_03_ADC1_IN4 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event3_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event3_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f8108 6 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio1_flexio12: IOMUXC_GPIO_AD_B1_03_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio1_flexio12: IOMUXC_GPIO_AD_B1_03_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f8108 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_flexspi_a_data2: IOMUXC_GPIO_AD_B1_03_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexspi_a_data2: IOMUXC_GPIO_AD_B1_03_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8108 1 0x401f8370 1 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_row5: IOMUXC_GPIO_AD_B1_03_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_row5: IOMUXC_GPIO_AD_B1_03_KPP_ROW5 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_lpspi4_pcs0: IOMUXC_GPIO_AD_B1_03_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpspi4_pcs0: IOMUXC_GPIO_AD_B1_03_LPSPI4_PCS0 {
 		pinmux = <0x401f8108 2 0x401f83bc 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_sai1_tx_data0: IOMUXC_GPIO_AD_B1_03_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_sai1_tx_data0: IOMUXC_GPIO_AD_B1_03_SAI1_TX_DATA0 {
 		pinmux = <0x401f8108 3 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_03_semc_csx2: IOMUXC_GPIO_AD_B1_03_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_semc_csx2: IOMUXC_GPIO_AD_B1_03_SEMC_CSX2 {
 		pinmux = <0x401f8108 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp1_in3: IOMUXC_GPIO_AD_B1_04_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp1_in3: IOMUXC_GPIO_AD_B1_04_ACMP1_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in4: IOMUXC_GPIO_AD_B1_04_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in4: IOMUXC_GPIO_AD_B1_04_ADC2_IN4 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio1_flexio11: IOMUXC_GPIO_AD_B1_04_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio1_flexio11: IOMUXC_GPIO_AD_B1_04_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f810c 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_a_data1: IOMUXC_GPIO_AD_B1_04_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_a_data1: IOMUXC_GPIO_AD_B1_04_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f810c 1 0x401f836c 1 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_col6: IOMUXC_GPIO_AD_B1_04_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_col6: IOMUXC_GPIO_AD_B1_04_KPP_COL6 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_lpspi1_pcs1: IOMUXC_GPIO_AD_B1_04_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpspi1_pcs1: IOMUXC_GPIO_AD_B1_04_LPSPI1_PCS1 {
 		pinmux = <0x401f810c 6 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_lpspi4_sdo: IOMUXC_GPIO_AD_B1_04_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpspi4_sdo: IOMUXC_GPIO_AD_B1_04_LPSPI4_SDO {
 		pinmux = <0x401f810c 2 0x401f83c8 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_sai1_rx_sync: IOMUXC_GPIO_AD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_sai1_rx_sync: IOMUXC_GPIO_AD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f810c 3 0x401f8448 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_04_semc_csx3: IOMUXC_GPIO_AD_B1_04_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_semc_csx3: IOMUXC_GPIO_AD_B1_04_SEMC_CSX3 {
 		pinmux = <0x401f810c 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp2_in3: IOMUXC_GPIO_AD_B1_05_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp2_in3: IOMUXC_GPIO_AD_B1_05_ACMP2_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in5: IOMUXC_GPIO_AD_B1_05_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in5: IOMUXC_GPIO_AD_B1_05_ADC1_IN5 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in5: IOMUXC_GPIO_AD_B1_05_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in5: IOMUXC_GPIO_AD_B1_05_ADC2_IN5 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio1_flexio10: IOMUXC_GPIO_AD_B1_05_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio1_flexio10: IOMUXC_GPIO_AD_B1_05_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_05_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_05_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8110 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_row6: IOMUXC_GPIO_AD_B1_05_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_row6: IOMUXC_GPIO_AD_B1_05_KPP_ROW6 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_lpspi1_pcs2: IOMUXC_GPIO_AD_B1_05_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpspi1_pcs2: IOMUXC_GPIO_AD_B1_05_LPSPI1_PCS2 {
 		pinmux = <0x401f8110 6 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_lpspi4_sdi: IOMUXC_GPIO_AD_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpspi4_sdi: IOMUXC_GPIO_AD_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8110 2 0x401f83c4 0 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_sai1_rx_data0: IOMUXC_GPIO_AD_B1_05_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_sai1_rx_data0: IOMUXC_GPIO_AD_B1_05_SAI1_RX_DATA0 {
 		pinmux = <0x401f8110 3 0x401f8438 1 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc1_wp: IOMUXC_GPIO_AD_B1_05_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc1_wp: IOMUXC_GPIO_AD_B1_05_USDHC1_WP {
 		pinmux = <0x401f8110 0 0x401f8494 2 0x401f8284>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8114 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8114 1 0x401f8328 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
 		pinmux = <0x401f8114 6 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
 		pinmux = <0x401f8114 2 0x401f83cc 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
 		pinmux = <0x401f8114 3 0x401f8434 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
 		pinmux = <0x401f8114 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8118 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8118 1 0x401f8338 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
 		pinmux = <0x401f8118 6 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
 		pinmux = <0x401f8118 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
 		pinmux = <0x401f8118 3 0x401f8444 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
 		pinmux = <0x401f8118 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f811c 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f811c 1 0x401f832c 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
 		pinmux = <0x401f811c 0 0x401f8384 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
 		pinmux = <0x401f811c 6 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
 		pinmux = <0x401f811c 2 0x401f83d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
 		pinmux = <0x401f811c 3 0x401f8440 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f8120 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8120 1 0x401f833c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
 		pinmux = <0x401f8120 0 0x401f8388 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
 		pinmux = <0x401f8120 6 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
 		pinmux = <0x401f8120 2 0x401f83d0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
 		pinmux = <0x401f8120 3 0x401f843c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
 		pinmux = <0x401f8014 6 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 4 0x401f83b0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
 		pinmux = <0x401f8014 2 0x401f83e0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
 		pinmux = <0x401f8014 7 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
 		pinmux = <0x401f8014 1 0x401f8420 0 0x401f8188>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
 		pinmux = <0x401f8014 3 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
 		pinmux = <0x401f8018 6 0x401f8320 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 4 0x401f83ac 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
 		pinmux = <0x401f8018 2 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
 		pinmux = <0x401f8018 7 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
 		pinmux = <0x401f8018 1 0x401f8424 0 0x401f818c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
 		pinmux = <0x401f8018 3 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
 		pinmux = <0x401f801c 6 0x401f837c 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 4 0x401f83b8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
 		pinmux = <0x401f801c 2 0x401f83e8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
 		pinmux = <0x401f801c 1 0x401f8428 0 0x401f8190>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
 		pinmux = <0x401f801c 3 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
 		pinmux = <0x401f8020 6 0x401f8380 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 4 0x401f83b4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
 		pinmux = <0x401f8020 2 0x401f83e4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
 		pinmux = <0x401f8020 1 0x401f842c 0 0x401f8194>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
 		pinmux = <0x401f8020 3 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
 		pinmux = <0x401f803c 6 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
 		pinmux = <0x401f803c 2 0x401f8398 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
 		pinmux = <0x401f803c 4 0x401f83b0 1 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
 		pinmux = <0x401f803c 0 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
 		pinmux = <0x401f8040 6 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
 		pinmux = <0x401f8040 2 0x401f8394 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
 		pinmux = <0x401f8040 4 0x401f83ac 1 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
 		pinmux = <0x401f8040 3 0x401f844c 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
 		pinmux = <0x401f8040 0 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
 		pinmux = <0x401f8044 6 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
 		pinmux = <0x401f8044 4 0x401f83b8 1 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
 		pinmux = <0x401f8044 2 0x401f83f8 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
 		pinmux = <0x401f8044 3 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8048 7 0x401f8300 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
 		pinmux = <0x401f8048 6 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
 		pinmux = <0x401f8048 4 0x401f83b4 1 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
 		pinmux = <0x401f8048 2 0x401f83f4 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
 		pinmux = <0x401f8048 3 0x401f8438 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
 		pinmux = <0x401f804c 6 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
 		pinmux = <0x401f804c 2 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
 		pinmux = <0x401f804c 3 0x401f8434 1 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
 		pinmux = <0x401f8050 6 0x401f8320 3 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
 		pinmux = <0x401f8050 2 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
 		pinmux = <0x401f8050 3 0x401f8448 1 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
 		pinmux = <0x401f8050 4 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
 		pinmux = <0x401f8084 4 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f8084 7 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8084 1 0x401f8354 1 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
 		pinmux = <0x401f8084 3 0x401f846c 2 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
 		pinmux = <0x401f8084 0 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8088 1 0x401f8364 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
 		pinmux = <0x401f8088 6 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
 		pinmux = <0x401f8088 3 0x401f8470 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
 		pinmux = <0x401f8088 0 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8088 4 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f808c 1 0x401f8350 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
 		pinmux = <0x401f808c 6 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
 		pinmux = <0x401f808c 2 0x401f83e0 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
 		pinmux = <0x401f808c 3 0x401f8478 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
 		pinmux = <0x401f808c 0 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
 		pinmux = <0x401f808c 4 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8090 1 0x401f8360 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
 		pinmux = <0x401f8090 2 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
 		pinmux = <0x401f8090 3 0x401f8474 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
 		pinmux = <0x401f80a4 3 0x401f8300 3 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
 		pinmux = <0x401f80a4 6 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80a4 1 0x401f834c 1 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 7 0x401f8494 4 0x401f8218>;
 	};
-	iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
 		pinmux = <0x401f80a8 6 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80a8 1 0x401f835c 1 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
 		pinmux = <0x401f80a8 7 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80ac 1 0x401f8348 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
 		pinmux = <0x401f80ac 2 0x401f83f0 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
 		pinmux = <0x401f80ac 7 0x401f8490 3 0x401f8220>;
 	};
-	iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
 		pinmux = <0x401f80b0 6 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80b0 1 0x401f8358 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
 		pinmux = <0x401f80b0 7 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
 		pinmux = <0x401f80b0 2 0x401f83ec 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
 		pinmux = <0x401f80b0 3 0x401f848c 2 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
 		pinmux = <0x401f80b4 4 0x401f8308 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
 		pinmux = <0x401f80b4 7 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
 		pinmux = <0x401f80b4 3 0x401f82fc 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
 		pinmux = <0x401f80b8 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
 		pinmux = <0x401f80b8 7 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
 		pinmux = <0x401f80b8 0 0x401f8484 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
 		pinmux = <0x401f80b8 2 0x401f8488 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f813c 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f813c 4 0x401f838c 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x401f8410 0 0x401f82b0>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
 		pinmux = <0x401f813c 2 0x401f8430 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
 		pinmux = <0x401f813c 3 0x401f8454 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
 		pinmux = <0x401f813c 0 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8140 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f8140 4 0x401f8390 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x401f8414 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
 		pinmux = <0x401f8140 3 0x401f8460 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
 		pinmux = <0x401f8140 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
 		pinmux = <0x401f8144 6 0x401f8308 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
 		pinmux = <0x401f8144 4 0x401f83a0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
 		pinmux = <0x401f8144 2 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x401f8418 0 0x401f82b8>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
 		pinmux = <0x401f8144 3 0x401f8458 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
 		pinmux = <0x401f8144 0 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
 		pinmux = <0x401f8148 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
 		pinmux = <0x401f8148 4 0x401f839c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
 		pinmux = <0x401f8148 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
 		pinmux = <0x401f8148 1 0x401f841c 0 0x401f82bc>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
 		pinmux = <0x401f8148 3 0x401f845c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
 		pinmux = <0x401f8148 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
 		pinmux = <0x401f814c 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f814c 6 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
 		pinmux = <0x401f814c 4 0x401f83a8 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
 		pinmux = <0x401f814c 2 0x401f8400 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
 		pinmux = <0x401f814c 3 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
 		pinmux = <0x401f8150 1 0x401f8324 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f8150 6 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
 		pinmux = <0x401f8150 4 0x401f83a4 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
 		pinmux = <0x401f8150 2 0x401f83fc 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f8150 3 0x401f8464 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f8154 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
 		pinmux = <0x401f8154 3 0x401f8468 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
 		pinmux = <0x401f8154 0 0x401f8490 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
 		pinmux = <0x401f8154 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
 		pinmux = <0x401f8154 4 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f840c 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1024cag4a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1024cag4a-pinctrl.dtsi
@@ -18,2122 +18,2122 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8114 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8114 1 0x401f8328 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
 		pinmux = <0x401f8114 6 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
 		pinmux = <0x401f8114 2 0x401f83cc 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
 		pinmux = <0x401f8114 3 0x401f8434 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
 		pinmux = <0x401f8114 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8118 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8118 1 0x401f8338 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
 		pinmux = <0x401f8118 6 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
 		pinmux = <0x401f8118 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
 		pinmux = <0x401f8118 3 0x401f8444 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
 		pinmux = <0x401f8118 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f811c 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f811c 1 0x401f832c 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
 		pinmux = <0x401f811c 0 0x401f8384 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
 		pinmux = <0x401f811c 6 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
 		pinmux = <0x401f811c 2 0x401f83d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
 		pinmux = <0x401f811c 3 0x401f8440 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f8120 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8120 1 0x401f833c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
 		pinmux = <0x401f8120 0 0x401f8388 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
 		pinmux = <0x401f8120 6 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
 		pinmux = <0x401f8120 2 0x401f83d0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
 		pinmux = <0x401f8120 3 0x401f843c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
 		pinmux = <0x401f8014 6 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 4 0x401f83b0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
 		pinmux = <0x401f8014 2 0x401f83e0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
 		pinmux = <0x401f8014 7 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
 		pinmux = <0x401f8014 1 0x401f8420 0 0x401f8188>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
 		pinmux = <0x401f8014 3 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
 		pinmux = <0x401f8018 6 0x401f8320 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 4 0x401f83ac 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
 		pinmux = <0x401f8018 2 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
 		pinmux = <0x401f8018 7 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
 		pinmux = <0x401f8018 1 0x401f8424 0 0x401f818c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
 		pinmux = <0x401f8018 3 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
 		pinmux = <0x401f801c 6 0x401f837c 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 4 0x401f83b8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
 		pinmux = <0x401f801c 2 0x401f83e8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
 		pinmux = <0x401f801c 1 0x401f8428 0 0x401f8190>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
 		pinmux = <0x401f801c 3 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
 		pinmux = <0x401f8020 6 0x401f8380 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 4 0x401f83b4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
 		pinmux = <0x401f8020 2 0x401f83e4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
 		pinmux = <0x401f8020 1 0x401f842c 0 0x401f8194>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
 		pinmux = <0x401f8020 3 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
 		pinmux = <0x401f803c 6 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
 		pinmux = <0x401f803c 2 0x401f8398 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
 		pinmux = <0x401f803c 4 0x401f83b0 1 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
 		pinmux = <0x401f803c 0 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
 		pinmux = <0x401f8040 6 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
 		pinmux = <0x401f8040 2 0x401f8394 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
 		pinmux = <0x401f8040 4 0x401f83ac 1 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
 		pinmux = <0x401f8040 3 0x401f844c 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
 		pinmux = <0x401f8040 0 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
 		pinmux = <0x401f8044 6 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
 		pinmux = <0x401f8044 4 0x401f83b8 1 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
 		pinmux = <0x401f8044 2 0x401f83f8 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
 		pinmux = <0x401f8044 3 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8048 7 0x401f8300 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
 		pinmux = <0x401f8048 6 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
 		pinmux = <0x401f8048 4 0x401f83b4 1 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
 		pinmux = <0x401f8048 2 0x401f83f4 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
 		pinmux = <0x401f8048 3 0x401f8438 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
 		pinmux = <0x401f804c 6 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
 		pinmux = <0x401f804c 2 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
 		pinmux = <0x401f804c 3 0x401f8434 1 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
 		pinmux = <0x401f8050 6 0x401f8320 3 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
 		pinmux = <0x401f8050 2 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
 		pinmux = <0x401f8050 3 0x401f8448 1 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
 		pinmux = <0x401f8050 4 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
 		pinmux = <0x401f8084 4 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f8084 7 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8084 1 0x401f8354 1 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
 		pinmux = <0x401f8084 3 0x401f846c 2 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
 		pinmux = <0x401f8084 0 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8088 1 0x401f8364 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
 		pinmux = <0x401f8088 6 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
 		pinmux = <0x401f8088 3 0x401f8470 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
 		pinmux = <0x401f8088 0 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8088 4 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f808c 1 0x401f8350 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
 		pinmux = <0x401f808c 6 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
 		pinmux = <0x401f808c 2 0x401f83e0 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
 		pinmux = <0x401f808c 3 0x401f8478 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
 		pinmux = <0x401f808c 0 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
 		pinmux = <0x401f808c 4 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8090 1 0x401f8360 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
 		pinmux = <0x401f8090 2 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
 		pinmux = <0x401f8090 3 0x401f8474 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
 		pinmux = <0x401f80a4 3 0x401f8300 3 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
 		pinmux = <0x401f80a4 6 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80a4 1 0x401f834c 1 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 7 0x401f8494 4 0x401f8218>;
 	};
-	iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
 		pinmux = <0x401f80a8 6 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80a8 1 0x401f835c 1 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
 		pinmux = <0x401f80a8 7 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80ac 1 0x401f8348 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
 		pinmux = <0x401f80ac 2 0x401f83f0 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
 		pinmux = <0x401f80ac 7 0x401f8490 3 0x401f8220>;
 	};
-	iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
 		pinmux = <0x401f80b0 6 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80b0 1 0x401f8358 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
 		pinmux = <0x401f80b0 7 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
 		pinmux = <0x401f80b0 2 0x401f83ec 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
 		pinmux = <0x401f80b0 3 0x401f848c 2 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
 		pinmux = <0x401f80b4 4 0x401f8308 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
 		pinmux = <0x401f80b4 7 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
 		pinmux = <0x401f80b4 3 0x401f82fc 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
 		pinmux = <0x401f80b8 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
 		pinmux = <0x401f80b8 7 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
 		pinmux = <0x401f80b8 0 0x401f8484 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
 		pinmux = <0x401f80b8 2 0x401f8488 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f813c 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f813c 4 0x401f838c 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x401f8410 0 0x401f82b0>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
 		pinmux = <0x401f813c 2 0x401f8430 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
 		pinmux = <0x401f813c 3 0x401f8454 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
 		pinmux = <0x401f813c 0 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8140 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f8140 4 0x401f8390 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x401f8414 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
 		pinmux = <0x401f8140 3 0x401f8460 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
 		pinmux = <0x401f8140 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
 		pinmux = <0x401f8144 6 0x401f8308 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
 		pinmux = <0x401f8144 4 0x401f83a0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
 		pinmux = <0x401f8144 2 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x401f8418 0 0x401f82b8>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
 		pinmux = <0x401f8144 3 0x401f8458 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
 		pinmux = <0x401f8144 0 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
 		pinmux = <0x401f8148 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
 		pinmux = <0x401f8148 4 0x401f839c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
 		pinmux = <0x401f8148 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
 		pinmux = <0x401f8148 1 0x401f841c 0 0x401f82bc>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
 		pinmux = <0x401f8148 3 0x401f845c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
 		pinmux = <0x401f8148 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
 		pinmux = <0x401f814c 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f814c 6 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
 		pinmux = <0x401f814c 4 0x401f83a8 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
 		pinmux = <0x401f814c 2 0x401f8400 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
 		pinmux = <0x401f814c 3 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
 		pinmux = <0x401f8150 1 0x401f8324 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f8150 6 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
 		pinmux = <0x401f8150 4 0x401f83a4 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
 		pinmux = <0x401f8150 2 0x401f83fc 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f8150 3 0x401f8464 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f8154 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
 		pinmux = <0x401f8154 3 0x401f8468 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
 		pinmux = <0x401f8154 0 0x401f8490 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
 		pinmux = <0x401f8154 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
 		pinmux = <0x401f8154 4 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f840c 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1024dag5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1024dag5a-pinctrl.dtsi
@@ -18,2122 +18,2122 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpt1_compare1: IOMUXC_GPIO_AD_B0_00_GPT1_COMPARE1 {
 		pinmux = <0x401f80bc 7 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_jtag_tms: IOMUXC_GPIO_AD_B0_00_JTAG_TMS {
 		pinmux = <0x401f80bc 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpt1_capture2: IOMUXC_GPIO_AD_B0_01_GPT1_CAPTURE2 {
 		pinmux = <0x401f80c0 7 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_jtag_tck: IOMUXC_GPIO_AD_B0_01_JTAG_TCK {
 		pinmux = <0x401f80c0 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpt1_capture1: IOMUXC_GPIO_AD_B0_02_GPT1_CAPTURE1 {
 		pinmux = <0x401f80c4 7 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_jtag_mod: IOMUXC_GPIO_AD_B0_02_JTAG_MOD {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_03_CCM_PMIC_RDY {
 		pinmux = <0x401f80c8 7 0x401f8300 2 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_jtag_tdi: IOMUXC_GPIO_AD_B0_03_JTAG_TDI {
 		pinmux = <0x401f80c8 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_sai1_mclk: IOMUXC_GPIO_AD_B0_03_SAI1_MCLK {
 		pinmux = <0x401f80c8 3 0x401f8430 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 6 0x401f848c 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc1_wp: IOMUXC_GPIO_AD_B0_03_USDHC1_WP {
 		pinmux = <0x401f80c8 4 0x401f8494 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B0_03_USDHC2_CD_B {
 		pinmux = <0x401f80c8 1 0x401f8498 1 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_wdog1_b: IOMUXC_GPIO_AD_B0_03_WDOG1_B {
 		pinmux = <0x401f80c8 2 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_mdio: IOMUXC_GPIO_AD_B0_04_ENET_MDIO {
 		pinmux = <0x401f80cc 4 0x401f8308 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_ewm_out_b: IOMUXC_GPIO_AD_B0_04_EWM_OUT_B {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_flexcan1_tx: IOMUXC_GPIO_AD_B0_04_FLEXCAN1_TX {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_jtag_tdo: IOMUXC_GPIO_AD_B0_04_JTAG_TDO {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_qtimer2_timer0: IOMUXC_GPIO_AD_B0_04_QTIMER2_TIMER0 {
 		pinmux = <0x401f80cc 3 0x401f8420 1 0x401f8240>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_04_USB_OTG1_PWR {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_usdhc1_wp: IOMUXC_GPIO_AD_B0_04_USDHC1_WP {
 		pinmux = <0x401f80cc 2 0x401f8494 1 0x401f8240>;
 	};
-	iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_arm_nmi: IOMUXC_GPIO_AD_B0_05_ARM_NMI {
 		pinmux = <0x401f80d0 7 0x401f840c 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_mdc: IOMUXC_GPIO_AD_B0_05_ENET_MDC {
 		pinmux = <0x401f80d0 4 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_flexcan1_rx: IOMUXC_GPIO_AD_B0_05_FLEXCAN1_RX {
 		pinmux = <0x401f80d0 1 0x401f8320 2 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_jtag_trstb: IOMUXC_GPIO_AD_B0_05_JTAG_TRSTB {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_qtimer2_timer1: IOMUXC_GPIO_AD_B0_05_QTIMER2_TIMER1 {
 		pinmux = <0x401f80d0 3 0x401f8424 1 0x401f8244>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usb_otg1_id: IOMUXC_GPIO_AD_B0_05_USB_OTG1_ID {
 		pinmux = <0x401f80d0 6 0x401f82fc 0 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_usdhc1_cd_b: IOMUXC_GPIO_AD_B0_05_USDHC1_CD_B {
 		pinmux = <0x401f80d0 2 0x401f8490 1 0x401f8244>;
 	};
-	iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_06_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80d4 4 0x401f8354 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpuart1_tx: IOMUXC_GPIO_AD_B0_06_LPUART1_TX {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_mqs_right: IOMUXC_GPIO_AD_B0_06_MQS_RIGHT {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_pit_trigger0: IOMUXC_GPIO_AD_B0_06_PIT_TRIGGER0 {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_qtimer2_timer2: IOMUXC_GPIO_AD_B0_06_QTIMER2_TIMER2 {
 		pinmux = <0x401f80d4 3 0x401f8428 1 0x401f8248>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_ref_32k_out: IOMUXC_GPIO_AD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f80d4 6 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_07_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80d8 4 0x401f8364 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_lpuart1_rx: IOMUXC_GPIO_AD_B0_07_LPUART1_RX {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_mqs_left: IOMUXC_GPIO_AD_B0_07_MQS_LEFT {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_pit_trigger1: IOMUXC_GPIO_AD_B0_07_PIT_TRIGGER1 {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_qtimer2_timer3: IOMUXC_GPIO_AD_B0_07_QTIMER2_TIMER3 {
 		pinmux = <0x401f80d8 3 0x401f842c 1 0x401f824c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_ref_24m_out: IOMUXC_GPIO_AD_B0_07_REF_24M_OUT {
 		pinmux = <0x401f80d8 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_acmp1_in4: IOMUXC_GPIO_AD_B0_08_ACMP1_IN4 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_arm_cm7_txev: IOMUXC_GPIO_AD_B0_08_ARM_CM7_TXEV {
 		pinmux = <0x401f80dc 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_ref_clk: IOMUXC_GPIO_AD_B0_08_ENET_REF_CLK {
 		pinmux = <0x401f80dc 4 0x401f8304 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_tx_clk: IOMUXC_GPIO_AD_B0_08_ENET_TX_CLK {
 		pinmux = <0x401f80dc 0 0x401f831c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_kpp_col0: IOMUXC_GPIO_AD_B0_08_KPP_COL0 {
 		pinmux = <0x401f80dc 3 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpi2c3_scl: IOMUXC_GPIO_AD_B0_08_LPI2C3_SCL {
 		pinmux = <0x401f80dc 1 0x401f838c 1 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_08_LPUART1_CTS_B {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_acmp2_in4: IOMUXC_GPIO_AD_B0_09_ACMP2_IN4 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_arm_cm7_rxev: IOMUXC_GPIO_AD_B0_09_ARM_CM7_RXEV {
 		pinmux = <0x401f80e0 6 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data1: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA1 {
 		pinmux = <0x401f80e0 0 0x401f8310 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_kpp_row0: IOMUXC_GPIO_AD_B0_09_KPP_ROW0 {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpi2c3_sda: IOMUXC_GPIO_AD_B0_09_LPI2C3_SDA {
 		pinmux = <0x401f80e0 1 0x401f8390 1 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_09_LPUART1_RTS_B {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_acmp3_in4: IOMUXC_GPIO_AD_B0_10_ACMP3_IN4 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_clk: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_CLK {
 		pinmux = <0x401f80e4 6 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_rx_data0: IOMUXC_GPIO_AD_B0_10_ENET_RX_DATA0 {
 		pinmux = <0x401f80e4 0 0x401f830c 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_AD_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f80e4 4 0x401f8350 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_kpp_col1: IOMUXC_GPIO_AD_B0_10_KPP_COL1 {
 		pinmux = <0x401f80e4 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpspi1_sck: IOMUXC_GPIO_AD_B0_10_LPSPI1_SCK {
 		pinmux = <0x401f80e4 1 0x401f83a0 1 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_lpuart5_tx: IOMUXC_GPIO_AD_B0_10_LPUART5_TX {
 		pinmux = <0x401f80e4 2 0x401f83f0 0 0x401f8258>;
 	};
-	iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_acmp4_in4: IOMUXC_GPIO_AD_B0_11_ACMP4_IN4 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_arm_trace_swo: IOMUXC_GPIO_AD_B0_11_ARM_TRACE_SWO {
 		pinmux = <0x401f80e8 6 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_rx_en: IOMUXC_GPIO_AD_B0_11_ENET_RX_EN {
 		pinmux = <0x401f80e8 0 0x401f8314 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_AD_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f80e8 4 0x401f8360 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_kpp_row1: IOMUXC_GPIO_AD_B0_11_KPP_ROW1 {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpspi1_pcs0: IOMUXC_GPIO_AD_B0_11_LPSPI1_PCS0 {
 		pinmux = <0x401f80e8 1 0x401f839c 1 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_lpuart5_rx: IOMUXC_GPIO_AD_B0_11_LPUART5_RX {
 		pinmux = <0x401f80e8 2 0x401f83ec 0 0x401f825c>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in0: IOMUXC_GPIO_AD_B0_12_ADC1_IN0 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_trace0: IOMUXC_GPIO_AD_B0_12_ARM_TRACE0 {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_rx_er: IOMUXC_GPIO_AD_B0_12_ENET_RX_ER {
 		pinmux = <0x401f80ec 0 0x401f8318 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm2_pwma1: IOMUXC_GPIO_AD_B0_12_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80ec 4 0x401f834c 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_kpp_col2: IOMUXC_GPIO_AD_B0_12_KPP_COL2 {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpspi1_sdo: IOMUXC_GPIO_AD_B0_12_LPSPI1_SDO {
 		pinmux = <0x401f80ec 1 0x401f83a8 1 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart3_cts_b: IOMUXC_GPIO_AD_B0_12_LPUART3_CTS_B {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_snvs_vio_5_ctl: IOMUXC_GPIO_AD_B0_12_SNVS_VIO_5_CTL {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc2_in0: IOMUXC_GPIO_AD_B0_13_ADC2_IN0 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_arm_trace1: IOMUXC_GPIO_AD_B0_13_ARM_TRACE1 {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_tx_en: IOMUXC_GPIO_AD_B0_13_ENET_TX_EN {
 		pinmux = <0x401f80f0 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm2_pwmb1: IOMUXC_GPIO_AD_B0_13_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80f0 4 0x401f835c 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_kpp_row2: IOMUXC_GPIO_AD_B0_13_KPP_ROW2 {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpspi1_sdi: IOMUXC_GPIO_AD_B0_13_LPSPI1_SDI {
 		pinmux = <0x401f80f0 1 0x401f83a4 1 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart3_rts_b: IOMUXC_GPIO_AD_B0_13_LPUART3_RTS_B {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_snvs_vio_5_b: IOMUXC_GPIO_AD_B0_13_SNVS_VIO_5_B {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp1_in0: IOMUXC_GPIO_AD_B0_14_ACMP1_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in0: IOMUXC_GPIO_AD_B0_14_ACMP2_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp3_in0: IOMUXC_GPIO_AD_B0_14_ACMP3_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp4_in0: IOMUXC_GPIO_AD_B0_14_ACMP4_IN0 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in1: IOMUXC_GPIO_AD_B0_14_ADC1_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc2_in1: IOMUXC_GPIO_AD_B0_14_ADC2_IN1 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_arm_trace2: IOMUXC_GPIO_AD_B0_14_ARM_TRACE2 {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_tx_data0: IOMUXC_GPIO_AD_B0_14_ENET_TX_DATA0 {
 		pinmux = <0x401f80f4 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 1 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexpwm2_pwma0: IOMUXC_GPIO_AD_B0_14_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80f4 4 0x401f8348 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_kpp_col3: IOMUXC_GPIO_AD_B0_14_KPP_COL3 {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart3_tx: IOMUXC_GPIO_AD_B0_14_LPUART3_TX {
 		pinmux = <0x401f80f4 2 0x401f83dc 1 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_wdog1_any: IOMUXC_GPIO_AD_B0_14_WDOG1_ANY {
 		pinmux = <0x401f80f4 7 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp1_in1: IOMUXC_GPIO_AD_B0_15_ACMP1_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp2_in1: IOMUXC_GPIO_AD_B0_15_ACMP2_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in1: IOMUXC_GPIO_AD_B0_15_ACMP3_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp4_in1: IOMUXC_GPIO_AD_B0_15_ACMP4_IN1 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in2: IOMUXC_GPIO_AD_B0_15_ADC1_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc2_in2: IOMUXC_GPIO_AD_B0_15_ADC2_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_arm_trace3: IOMUXC_GPIO_AD_B0_15_ARM_TRACE3 {
 		pinmux = <0x401f80f8 6 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_tx_data1: IOMUXC_GPIO_AD_B0_15_ENET_TX_DATA1 {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 1 0x401f8324 2 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexpwm2_pwmb0: IOMUXC_GPIO_AD_B0_15_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80f8 4 0x401f8358 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_kpp_row3: IOMUXC_GPIO_AD_B0_15_KPP_ROW3 {
 		pinmux = <0x401f80f8 3 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart3_rx: IOMUXC_GPIO_AD_B0_15_LPUART3_RX {
 		pinmux = <0x401f80f8 2 0x401f83d8 1 0x401f826c>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in3: IOMUXC_GPIO_AD_B1_06_ACMP3_IN3 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in6: IOMUXC_GPIO_AD_B1_06_ADC1_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in6: IOMUXC_GPIO_AD_B1_06_ADC2_IN6 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio1_flexio09: IOMUXC_GPIO_AD_B1_06_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8114 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexpwm1_pwma0: IOMUXC_GPIO_AD_B1_06_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8114 1 0x401f8328 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_col7: IOMUXC_GPIO_AD_B1_06_KPP_COL7 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpspi1_pcs3: IOMUXC_GPIO_AD_B1_06_LPSPI1_PCS3 {
 		pinmux = <0x401f8114 6 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_06_LPUART2_CTS_B {
 		pinmux = <0x401f8114 2 0x401f83cc 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_06_SAI1_RX_BCLK {
 		pinmux = <0x401f8114 3 0x401f8434 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc1_reset_b: IOMUXC_GPIO_AD_B1_06_USDHC1_RESET_B {
 		pinmux = <0x401f8114 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp4_in3: IOMUXC_GPIO_AD_B1_07_ACMP4_IN3 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in7: IOMUXC_GPIO_AD_B1_07_ADC1_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in7: IOMUXC_GPIO_AD_B1_07_ADC2_IN7 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio1_flexio08: IOMUXC_GPIO_AD_B1_07_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8118 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexpwm1_pwmb0: IOMUXC_GPIO_AD_B1_07_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8118 1 0x401f8338 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_row7: IOMUXC_GPIO_AD_B1_07_KPP_ROW7 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpspi3_pcs3: IOMUXC_GPIO_AD_B1_07_LPSPI3_PCS3 {
 		pinmux = <0x401f8118 6 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_07_LPUART2_RTS_B {
 		pinmux = <0x401f8118 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_sai1_tx_data1: IOMUXC_GPIO_AD_B1_07_SAI1_TX_DATA1 {
 		pinmux = <0x401f8118 3 0x401f8444 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc1_vselect: IOMUXC_GPIO_AD_B1_07_USDHC1_VSELECT {
 		pinmux = <0x401f8118 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp1_in5: IOMUXC_GPIO_AD_B1_08_ACMP1_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in8: IOMUXC_GPIO_AD_B1_08_ADC1_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in8: IOMUXC_GPIO_AD_B1_08_ADC2_IN8 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio1_flexio07: IOMUXC_GPIO_AD_B1_08_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f811c 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm1_pwma1: IOMUXC_GPIO_AD_B1_08_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f811c 1 0x401f832c 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpi2c2_scl: IOMUXC_GPIO_AD_B1_08_LPI2C2_SCL {
 		pinmux = <0x401f811c 0 0x401f8384 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpspi3_pcs2: IOMUXC_GPIO_AD_B1_08_LPSPI3_PCS2 {
 		pinmux = <0x401f811c 6 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_lpuart2_tx: IOMUXC_GPIO_AD_B1_08_LPUART2_TX {
 		pinmux = <0x401f811c 2 0x401f83d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_sai1_tx_data2: IOMUXC_GPIO_AD_B1_08_SAI1_TX_DATA2 {
 		pinmux = <0x401f811c 3 0x401f8440 0 0x401f8290>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_in12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_xbar1_xbar_inout12: IOMUXC_GPIO_AD_B1_08_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f811c 7 0x401f84b4 1 0x401f8290>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp2_in5: IOMUXC_GPIO_AD_B1_09_ACMP2_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in9: IOMUXC_GPIO_AD_B1_09_ADC1_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in9: IOMUXC_GPIO_AD_B1_09_ADC2_IN9 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio1_flexio06: IOMUXC_GPIO_AD_B1_09_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f8120 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm1_pwmb1: IOMUXC_GPIO_AD_B1_09_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8120 1 0x401f833c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpi2c2_sda: IOMUXC_GPIO_AD_B1_09_LPI2C2_SDA {
 		pinmux = <0x401f8120 0 0x401f8388 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpspi3_pcs1: IOMUXC_GPIO_AD_B1_09_LPSPI3_PCS1 {
 		pinmux = <0x401f8120 6 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_lpuart2_rx: IOMUXC_GPIO_AD_B1_09_LPUART2_RX {
 		pinmux = <0x401f8120 2 0x401f83d0 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_tx_data3: IOMUXC_GPIO_AD_B1_09_SAI1_TX_DATA3 {
 		pinmux = <0x401f8120 3 0x401f843c 0 0x401f8294>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_in13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_xbar1_xbar_inout13: IOMUXC_GPIO_AD_B1_09_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8120 7 0x401f84b8 1 0x401f8294>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp3_in5: IOMUXC_GPIO_AD_B1_10_ACMP3_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in10: IOMUXC_GPIO_AD_B1_10_ADC1_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in10: IOMUXC_GPIO_AD_B1_10_ADC2_IN10 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio1_flexio05: IOMUXC_GPIO_AD_B1_10_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8124 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexpwm1_pwma2: IOMUXC_GPIO_AD_B1_10_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8124 1 0x401f8330 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpt2_capture1: IOMUXC_GPIO_AD_B1_10_GPT2_CAPTURE1 {
 		pinmux = <0x401f8124 6 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart4_tx: IOMUXC_GPIO_AD_B1_10_LPUART4_TX {
 		pinmux = <0x401f8124 2 0x401f83e8 1 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_10_USB_OTG1_PWR {
 		pinmux = <0x401f8124 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_10_USDHC1_CD_B {
 		pinmux = <0x401f8124 3 0x401f8490 2 0x401f8298>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp4_in5: IOMUXC_GPIO_AD_B1_11_ACMP4_IN5 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in11: IOMUXC_GPIO_AD_B1_11_ADC1_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in11: IOMUXC_GPIO_AD_B1_11_ADC2_IN11 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio1_flexio04: IOMUXC_GPIO_AD_B1_11_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8128 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexpwm1_pwmb2: IOMUXC_GPIO_AD_B1_11_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8128 1 0x401f8340 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpt2_compare1: IOMUXC_GPIO_AD_B1_11_GPT2_COMPARE1 {
 		pinmux = <0x401f8128 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart4_rx: IOMUXC_GPIO_AD_B1_11_LPUART4_RX {
 		pinmux = <0x401f8128 2 0x401f83e4 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usb_otg1_id: IOMUXC_GPIO_AD_B1_11_USB_OTG1_ID {
 		pinmux = <0x401f8128 0 0x401f82fc 1 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc1_wp: IOMUXC_GPIO_AD_B1_11_USDHC1_WP {
 		pinmux = <0x401f8128 3 0x401f8494 3 0x401f829c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_in6: IOMUXC_GPIO_AD_B1_12_ACMP1_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc1_in12: IOMUXC_GPIO_AD_B1_12_ADC1_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in12: IOMUXC_GPIO_AD_B1_12_ADC2_IN12 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio1_flexio03: IOMUXC_GPIO_AD_B1_12_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f812c 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexpwm1_pwma3: IOMUXC_GPIO_AD_B1_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f812c 6 0x401f8334 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_sck: IOMUXC_GPIO_AD_B1_12_LPSPI3_SCK {
 		pinmux = <0x401f812c 2 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usb_otg1_oc: IOMUXC_GPIO_AD_B1_12_USB_OTG1_OC {
 		pinmux = <0x401f812c 0 0x401f848c 1 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_12_USDHC2_CD_B {
 		pinmux = <0x401f812c 3 0x401f8498 2 0x401f82a0>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_in6: IOMUXC_GPIO_AD_B1_13_ACMP2_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc1_in13: IOMUXC_GPIO_AD_B1_13_ADC1_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in13: IOMUXC_GPIO_AD_B1_13_ADC2_IN13 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio1_flexio02: IOMUXC_GPIO_AD_B1_13_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f8130 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B1_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8130 6 0x401f8344 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpi2c1_hreq: IOMUXC_GPIO_AD_B1_13_LPI2C1_HREQ {
 		pinmux = <0x401f8130 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_13_LPSPI3_PCS0 {
 		pinmux = <0x401f8130 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_wp: IOMUXC_GPIO_AD_B1_13_USDHC2_WP {
 		pinmux = <0x401f8130 3 0x401f849c 0 0x401f82a4>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_in6: IOMUXC_GPIO_AD_B1_14_ACMP3_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc1_in14: IOMUXC_GPIO_AD_B1_14_ADC1_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in14: IOMUXC_GPIO_AD_B1_14_ADC2_IN14 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B1_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f8134 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio1_flexio01: IOMUXC_GPIO_AD_B1_14_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8134 4 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpi2c1_scl: IOMUXC_GPIO_AD_B1_14_LPI2C1_SCL {
 		pinmux = <0x401f8134 0 0x401f837c 1 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_in6: IOMUXC_GPIO_AD_B1_15_ACMP4_IN6 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc1_in15: IOMUXC_GPIO_AD_B1_15_ADC1_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in15: IOMUXC_GPIO_AD_B1_15_ADC2_IN15 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B1_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f8138 3 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio1_flexio00: IOMUXC_GPIO_AD_B1_15_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8138 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpi2c1_sda: IOMUXC_GPIO_AD_B1_15_LPI2C1_SDA {
 		pinmux = <0x401f8138 0 0x401f8380 1 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sdi: IOMUXC_GPIO_AD_B1_15_LPSPI3_SDI {
 		pinmux = <0x401f8138 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexcan1_tx: IOMUXC_GPIO_EMC_00_FLEXCAN1_TX {
 		pinmux = <0x401f8014 6 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio2_io00: IOMUXC_GPIO_EMC_00_GPIO2_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 4 0x401f83b0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpuart4_cts_b: IOMUXC_GPIO_EMC_00_LPUART4_CTS_B {
 		pinmux = <0x401f8014 2 0x401f83e0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_pit_trigger2: IOMUXC_GPIO_EMC_00_PIT_TRIGGER2 {
 		pinmux = <0x401f8014 7 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_qtimer2_timer0: IOMUXC_GPIO_EMC_00_QTIMER2_TIMER0 {
 		pinmux = <0x401f8014 1 0x401f8420 0 0x401f8188>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_spdif_sr_clk: IOMUXC_GPIO_EMC_00_SPDIF_SR_CLK {
 		pinmux = <0x401f8014 3 0x0 0 0x401f8188>;
 	};
-	iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexcan1_rx: IOMUXC_GPIO_EMC_01_FLEXCAN1_RX {
 		pinmux = <0x401f8018 6 0x401f8320 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio2_io01: IOMUXC_GPIO_EMC_01_GPIO2_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 4 0x401f83ac 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpuart4_rts_b: IOMUXC_GPIO_EMC_01_LPUART4_RTS_B {
 		pinmux = <0x401f8018 2 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_pit_trigger3: IOMUXC_GPIO_EMC_01_PIT_TRIGGER3 {
 		pinmux = <0x401f8018 7 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_qtimer2_timer1: IOMUXC_GPIO_EMC_01_QTIMER2_TIMER1 {
 		pinmux = <0x401f8018 1 0x401f8424 0 0x401f818c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_spdif_out: IOMUXC_GPIO_EMC_01_SPDIF_OUT {
 		pinmux = <0x401f8018 3 0x0 0 0x401f818c>;
 	};
-	iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio2_io02: IOMUXC_GPIO_EMC_02_GPIO2_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpi2c1_scl: IOMUXC_GPIO_EMC_02_LPI2C1_SCL {
 		pinmux = <0x401f801c 6 0x401f837c 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 4 0x401f83b8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpuart4_tx: IOMUXC_GPIO_EMC_02_LPUART4_TX {
 		pinmux = <0x401f801c 2 0x401f83e8 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_qtimer2_timer2: IOMUXC_GPIO_EMC_02_QTIMER2_TIMER2 {
 		pinmux = <0x401f801c 1 0x401f8428 0 0x401f8190>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_spdif_lock: IOMUXC_GPIO_EMC_02_SPDIF_LOCK {
 		pinmux = <0x401f801c 3 0x0 0 0x401f8190>;
 	};
-	iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio2_io03: IOMUXC_GPIO_EMC_03_GPIO2_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpi2c1_sda: IOMUXC_GPIO_EMC_03_LPI2C1_SDA {
 		pinmux = <0x401f8020 6 0x401f8380 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 4 0x401f83b4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpuart4_rx: IOMUXC_GPIO_EMC_03_LPUART4_RX {
 		pinmux = <0x401f8020 2 0x401f83e4 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_qtimer2_timer3: IOMUXC_GPIO_EMC_03_QTIMER2_TIMER3 {
 		pinmux = <0x401f8020 1 0x401f842c 0 0x401f8194>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_spdif_ext_clk: IOMUXC_GPIO_EMC_03_SPDIF_EXT_CLK {
 		pinmux = <0x401f8020 3 0x0 0 0x401f8194>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio16: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO16 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio2_io04: IOMUXC_GPIO_EMC_04_GPIO2_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_bclk: IOMUXC_GPIO_EMC_04_SAI2_TX_BCLK {
 		pinmux = <0x401f8024 3 0x401f8464 1 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_spdif_out: IOMUXC_GPIO_EMC_04_SPDIF_OUT {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8198>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f8024 1 0x0 0 0x401f8198>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio17: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO17 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio2_io05: IOMUXC_GPIO_EMC_05_GPIO2_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 3 0x401f8468 1 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_spdif_in: IOMUXC_GPIO_EMC_05_SPDIF_IN {
 		pinmux = <0x401f8028 2 0x401f8488 0 0x401f819c>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f819c>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio18: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO18 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio2_io06: IOMUXC_GPIO_EMC_06_GPIO2_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_lpuart3_tx: IOMUXC_GPIO_EMC_06_LPUART3_TX {
 		pinmux = <0x401f802c 2 0x401f83dc 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_data: IOMUXC_GPIO_EMC_06_SAI2_TX_DATA {
 		pinmux = <0x401f802c 3 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f81a0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f802c 1 0x0 0 0x401f81a0>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio19: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO19 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio2_io07: IOMUXC_GPIO_EMC_07_GPIO2_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_lpuart3_rx: IOMUXC_GPIO_EMC_07_LPUART3_RX {
 		pinmux = <0x401f8030 2 0x401f83d8 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_rx_sync: IOMUXC_GPIO_EMC_07_SAI2_RX_SYNC {
 		pinmux = <0x401f8030 3 0x401f8460 1 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f81a4>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8030 1 0x0 0 0x401f81a4>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexcan2_tx: IOMUXC_GPIO_EMC_08_FLEXCAN2_TX {
 		pinmux = <0x401f8034 2 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio20: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO20 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio2_io08: IOMUXC_GPIO_EMC_08_GPIO2_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 3 0x401f845c 1 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f81a8>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f8034 1 0x0 0 0x401f81a8>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_rx: IOMUXC_GPIO_EMC_09_FLEXCAN2_RX {
 		pinmux = <0x401f8038 2 0x401f8324 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio21: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO21 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio2_io09: IOMUXC_GPIO_EMC_09_GPIO2_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_bclk: IOMUXC_GPIO_EMC_09_SAI2_RX_BCLK {
 		pinmux = <0x401f8038 3 0x401f8458 1 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_we: IOMUXC_GPIO_EMC_09_SEMC_WE {
 		pinmux = <0x401f8038 0 0x0 0 0x401f81ac>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_in09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_09_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8038 1 0x0 0 0x401f81ac>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwmx0: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMX0 {
 		pinmux = <0x401f803c 6 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio2_io10: IOMUXC_GPIO_EMC_10_GPIO2_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpi2c4_sda: IOMUXC_GPIO_EMC_10_LPI2C4_SDA {
 		pinmux = <0x401f803c 2 0x401f8398 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_lpspi2_sck: IOMUXC_GPIO_EMC_10_LPSPI2_SCK {
 		pinmux = <0x401f803c 4 0x401f83b0 1 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai1_tx_sync: IOMUXC_GPIO_EMC_10_SAI1_TX_SYNC {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_cas: IOMUXC_GPIO_EMC_10_SEMC_CAS {
 		pinmux = <0x401f803c 0 0x0 0 0x401f81b0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_in10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_10_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f803c 1 0x401f84b0 0 0x401f81b0>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmx1: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMX1 {
 		pinmux = <0x401f8040 6 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio2_io11: IOMUXC_GPIO_EMC_11_GPIO2_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_scl: IOMUXC_GPIO_EMC_11_LPI2C4_SCL {
 		pinmux = <0x401f8040 2 0x401f8394 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpspi2_pcs0: IOMUXC_GPIO_EMC_11_LPSPI2_PCS0 {
 		pinmux = <0x401f8040 4 0x401f83ac 1 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_sai1_tx_bclk: IOMUXC_GPIO_EMC_11_SAI1_TX_BCLK {
 		pinmux = <0x401f8040 3 0x401f844c 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_ras: IOMUXC_GPIO_EMC_11_SEMC_RAS {
 		pinmux = <0x401f8040 0 0x0 0 0x401f81b4>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_in11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_11_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8040 1 0x0 0 0x401f81b4>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm2_pwmx2: IOMUXC_GPIO_EMC_12_FLEXPWM2_PWMX2 {
 		pinmux = <0x401f8044 6 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio2_io12: IOMUXC_GPIO_EMC_12_GPIO2_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpspi2_sdo: IOMUXC_GPIO_EMC_12_LPSPI2_SDO {
 		pinmux = <0x401f8044 4 0x401f83b8 1 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpuart6_tx: IOMUXC_GPIO_EMC_12_LPUART6_TX {
 		pinmux = <0x401f8044 2 0x401f83f8 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_sai1_tx_data0: IOMUXC_GPIO_EMC_12_SAI1_TX_DATA0 {
 		pinmux = <0x401f8044 3 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_cs0: IOMUXC_GPIO_EMC_12_SEMC_CS0 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f81b8>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8044 1 0x401f84b4 0 0x401f81b8>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_ccm_pmic_rdy: IOMUXC_GPIO_EMC_13_CCM_PMIC_RDY {
 		pinmux = <0x401f8048 7 0x401f8300 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm2_pwmx3: IOMUXC_GPIO_EMC_13_FLEXPWM2_PWMX3 {
 		pinmux = <0x401f8048 6 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio2_io13: IOMUXC_GPIO_EMC_13_GPIO2_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpspi2_sdi: IOMUXC_GPIO_EMC_13_LPSPI2_SDI {
 		pinmux = <0x401f8048 4 0x401f83b4 1 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart6_rx: IOMUXC_GPIO_EMC_13_LPUART6_RX {
 		pinmux = <0x401f8048 2 0x401f83f4 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_sai1_rx_data0: IOMUXC_GPIO_EMC_13_SAI1_RX_DATA0 {
 		pinmux = <0x401f8048 3 0x401f8438 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_ba0: IOMUXC_GPIO_EMC_13_SEMC_BA0 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f81bc>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8048 1 0x401f84b8 0 0x401f81bc>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexcan1_tx: IOMUXC_GPIO_EMC_14_FLEXCAN1_TX {
 		pinmux = <0x401f804c 6 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio2_io14: IOMUXC_GPIO_EMC_14_GPIO2_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart6_cts_b: IOMUXC_GPIO_EMC_14_LPUART6_CTS_B {
 		pinmux = <0x401f804c 2 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_sai1_rx_bclk: IOMUXC_GPIO_EMC_14_SAI1_RX_BCLK {
 		pinmux = <0x401f804c 3 0x401f8434 1 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_ba1: IOMUXC_GPIO_EMC_14_SEMC_BA1 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f81c0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f804c 1 0x401f84a0 1 0x401f81c0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexcan1_rx: IOMUXC_GPIO_EMC_15_FLEXCAN1_RX {
 		pinmux = <0x401f8050 6 0x401f8320 3 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio2_io15: IOMUXC_GPIO_EMC_15_GPIO2_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart6_rts_b: IOMUXC_GPIO_EMC_15_LPUART6_RTS_B {
 		pinmux = <0x401f8050 2 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_sai1_rx_sync: IOMUXC_GPIO_EMC_15_SAI1_RX_SYNC {
 		pinmux = <0x401f8050 3 0x401f8448 1 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr10: IOMUXC_GPIO_EMC_15_SEMC_ADDR10 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_wdog1_b: IOMUXC_GPIO_EMC_15_WDOG1_B {
 		pinmux = <0x401f8050 4 0x0 0 0x401f81c4>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8050 1 0x401f84a4 1 0x401f81c4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio2_io16: IOMUXC_GPIO_EMC_16_GPIO2_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_mqs_right: IOMUXC_GPIO_EMC_16_MQS_RIGHT {
 		pinmux = <0x401f8054 2 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_sai2_mclk: IOMUXC_GPIO_EMC_16_SAI2_MCLK {
 		pinmux = <0x401f8054 3 0x401f8454 1 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr00: IOMUXC_GPIO_EMC_16_SEMC_ADDR00 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_src_boot_mode0: IOMUXC_GPIO_EMC_16_SRC_BOOT_MODE0 {
 		pinmux = <0x401f8054 6 0x0 0 0x401f81c8>;
 	};
-	iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio2_io17: IOMUXC_GPIO_EMC_17_GPIO2_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_mqs_left: IOMUXC_GPIO_EMC_17_MQS_LEFT {
 		pinmux = <0x401f8058 2 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_sai3_mclk: IOMUXC_GPIO_EMC_17_SAI3_MCLK {
 		pinmux = <0x401f8058 3 0x401f846c 1 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr01: IOMUXC_GPIO_EMC_17_SEMC_ADDR01 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_src_boot_mode1: IOMUXC_GPIO_EMC_17_SRC_BOOT_MODE1 {
 		pinmux = <0x401f8058 6 0x0 0 0x401f81cc>;
 	};
-	iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexio1_flexio22: IOMUXC_GPIO_EMC_18_FLEXIO1_FLEXIO22 {
 		pinmux = <0x401f805c 4 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio2_io18: IOMUXC_GPIO_EMC_18_GPIO2_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpi2c2_sda: IOMUXC_GPIO_EMC_18_LPI2C2_SDA {
 		pinmux = <0x401f805c 2 0x401f8388 1 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_sai1_rx_sync: IOMUXC_GPIO_EMC_18_SAI1_RX_SYNC {
 		pinmux = <0x401f805c 3 0x401f8448 2 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr02: IOMUXC_GPIO_EMC_18_SEMC_ADDR02 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_src_bt_cfg0: IOMUXC_GPIO_EMC_18_SRC_BT_CFG0 {
 		pinmux = <0x401f805c 6 0x0 0 0x401f81d0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f805c 1 0x401f84a8 1 0x401f81d0>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexio1_flexio23: IOMUXC_GPIO_EMC_19_FLEXIO1_FLEXIO23 {
 		pinmux = <0x401f8060 4 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio2_io19: IOMUXC_GPIO_EMC_19_GPIO2_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpi2c2_scl: IOMUXC_GPIO_EMC_19_LPI2C2_SCL {
 		pinmux = <0x401f8060 2 0x401f8384 1 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_sai1_rx_bclk: IOMUXC_GPIO_EMC_19_SAI1_RX_BCLK {
 		pinmux = <0x401f8060 3 0x401f8434 2 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr03: IOMUXC_GPIO_EMC_19_SEMC_ADDR03 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_src_bt_cfg1: IOMUXC_GPIO_EMC_19_SRC_BT_CFG1 {
 		pinmux = <0x401f8060 6 0x0 0 0x401f81d4>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_in17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_19_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8060 1 0x401f84ac 1 0x401f81d4>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexio1_flexio24: IOMUXC_GPIO_EMC_20_FLEXIO1_FLEXIO24 {
 		pinmux = <0x401f8064 4 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm1_pwma3: IOMUXC_GPIO_EMC_20_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8064 1 0x401f8334 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio2_io20: IOMUXC_GPIO_EMC_20_GPIO2_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart2_cts_b: IOMUXC_GPIO_EMC_20_LPUART2_CTS_B {
 		pinmux = <0x401f8064 2 0x401f83cc 1 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_sai1_mclk: IOMUXC_GPIO_EMC_20_SAI1_MCLK {
 		pinmux = <0x401f8064 3 0x401f8430 3 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr04: IOMUXC_GPIO_EMC_20_SEMC_ADDR04 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_src_bt_cfg2: IOMUXC_GPIO_EMC_20_SRC_BT_CFG2 {
 		pinmux = <0x401f8064 6 0x0 0 0x401f81d8>;
 	};
-	iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexio1_flexio25: IOMUXC_GPIO_EMC_21_FLEXIO1_FLEXIO25 {
 		pinmux = <0x401f8068 4 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_21_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8068 1 0x401f8344 1 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio2_io21: IOMUXC_GPIO_EMC_21_GPIO2_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpuart2_rts_b: IOMUXC_GPIO_EMC_21_LPUART2_RTS_B {
 		pinmux = <0x401f8068 2 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_sai1_rx_data0: IOMUXC_GPIO_EMC_21_SAI1_RX_DATA0 {
 		pinmux = <0x401f8068 3 0x401f8438 2 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_addr05: IOMUXC_GPIO_EMC_21_SEMC_ADDR05 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_src_bt_cfg3: IOMUXC_GPIO_EMC_21_SRC_BT_CFG3 {
 		pinmux = <0x401f8068 6 0x0 0 0x401f81dc>;
 	};
-	iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexio1_flexio26: IOMUXC_GPIO_EMC_22_FLEXIO1_FLEXIO26 {
 		pinmux = <0x401f806c 4 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm1_pwma2: IOMUXC_GPIO_EMC_22_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f806c 1 0x401f8330 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio2_io22: IOMUXC_GPIO_EMC_22_GPIO2_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpuart2_tx: IOMUXC_GPIO_EMC_22_LPUART2_TX {
 		pinmux = <0x401f806c 2 0x401f83d4 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_sai1_tx_data3: IOMUXC_GPIO_EMC_22_SAI1_TX_DATA3 {
 		pinmux = <0x401f806c 3 0x401f843c 1 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_addr06: IOMUXC_GPIO_EMC_22_SEMC_ADDR06 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_src_bt_cfg4: IOMUXC_GPIO_EMC_22_SRC_BT_CFG4 {
 		pinmux = <0x401f806c 6 0x0 0 0x401f81e0>;
 	};
-	iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexio1_flexio27: IOMUXC_GPIO_EMC_23_FLEXIO1_FLEXIO27 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8070 1 0x401f8340 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio2_io23: IOMUXC_GPIO_EMC_23_GPIO2_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart2_rx: IOMUXC_GPIO_EMC_23_LPUART2_RX {
 		pinmux = <0x401f8070 2 0x401f83d0 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_sai1_tx_data2: IOMUXC_GPIO_EMC_23_SAI1_TX_DATA2 {
 		pinmux = <0x401f8070 3 0x401f8440 1 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr07: IOMUXC_GPIO_EMC_23_SEMC_ADDR07 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_src_bt_cfg5: IOMUXC_GPIO_EMC_23_SRC_BT_CFG5 {
 		pinmux = <0x401f8070 6 0x0 0 0x401f81e4>;
 	};
-	iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexio1_flexio28: IOMUXC_GPIO_EMC_24_FLEXIO1_FLEXIO28 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwma1: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8074 1 0x401f832c 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio2_io24: IOMUXC_GPIO_EMC_24_GPIO2_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart8_cts_b: IOMUXC_GPIO_EMC_24_LPUART8_CTS_B {
 		pinmux = <0x401f8074 2 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_sai1_tx_data1: IOMUXC_GPIO_EMC_24_SAI1_TX_DATA1 {
 		pinmux = <0x401f8074 3 0x401f8444 1 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_addr08: IOMUXC_GPIO_EMC_24_SEMC_ADDR08 {
 		pinmux = <0x401f8074 0 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_src_bt_cfg6: IOMUXC_GPIO_EMC_24_SRC_BT_CFG6 {
 		pinmux = <0x401f8074 6 0x0 0 0x401f81e8>;
 	};
-	iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexio1_flexio29: IOMUXC_GPIO_EMC_25_FLEXIO1_FLEXIO29 {
 		pinmux = <0x401f8078 4 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f8078 1 0x401f833c 1 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio2_io25: IOMUXC_GPIO_EMC_25_GPIO2_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart8_rts_b: IOMUXC_GPIO_EMC_25_LPUART8_RTS_B {
 		pinmux = <0x401f8078 2 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_sai1_tx_data0: IOMUXC_GPIO_EMC_25_SAI1_TX_DATA0 {
 		pinmux = <0x401f8078 3 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_addr09: IOMUXC_GPIO_EMC_25_SEMC_ADDR09 {
 		pinmux = <0x401f8078 0 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_src_bt_cfg7: IOMUXC_GPIO_EMC_25_SRC_BT_CFG7 {
 		pinmux = <0x401f8078 6 0x0 0 0x401f81ec>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio30: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO30 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwma0: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f807c 1 0x401f8328 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio2_io26: IOMUXC_GPIO_EMC_26_GPIO2_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart8_tx: IOMUXC_GPIO_EMC_26_LPUART8_TX {
 		pinmux = <0x401f807c 2 0x401f8408 1 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_sai1_tx_bclk: IOMUXC_GPIO_EMC_26_SAI1_TX_BCLK {
 		pinmux = <0x401f807c 3 0x401f844c 2 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_addr11: IOMUXC_GPIO_EMC_26_SEMC_ADDR11 {
 		pinmux = <0x401f807c 0 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_src_bt_cfg8: IOMUXC_GPIO_EMC_26_SRC_BT_CFG8 {
 		pinmux = <0x401f807c 6 0x0 0 0x401f81f0>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio31: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO31 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8080 1 0x401f8338 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio2_io27: IOMUXC_GPIO_EMC_27_GPIO2_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart8_rx: IOMUXC_GPIO_EMC_27_LPUART8_RX {
 		pinmux = <0x401f8080 2 0x401f8404 1 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_sai1_tx_sync: IOMUXC_GPIO_EMC_27_SAI1_TX_SYNC {
 		pinmux = <0x401f8080 3 0x401f8450 2 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_addr12: IOMUXC_GPIO_EMC_27_SEMC_ADDR12 {
 		pinmux = <0x401f8080 0 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_src_bt_cfg9: IOMUXC_GPIO_EMC_27_SRC_BT_CFG9 {
 		pinmux = <0x401f8080 6 0x0 0 0x401f81f4>;
 	};
-	iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_ewm_out_b: IOMUXC_GPIO_EMC_28_EWM_OUT_B {
 		pinmux = <0x401f8084 4 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmx0: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f8084 7 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm2_pwma3: IOMUXC_GPIO_EMC_28_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8084 1 0x401f8354 1 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio2_io28: IOMUXC_GPIO_EMC_28_GPIO2_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpt2_capture2: IOMUXC_GPIO_EMC_28_GPT2_CAPTURE2 {
 		pinmux = <0x401f8084 6 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_sai3_mclk: IOMUXC_GPIO_EMC_28_SAI3_MCLK {
 		pinmux = <0x401f8084 3 0x401f846c 2 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_dqs: IOMUXC_GPIO_EMC_28_SEMC_DQS {
 		pinmux = <0x401f8084 0 0x0 0 0x401f81f8>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_in18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_28_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f8084 2 0x401f84bc 0 0x401f81f8>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm1_pwmx1: IOMUXC_GPIO_EMC_29_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f8088 7 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_29_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8088 1 0x401f8364 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio2_io29: IOMUXC_GPIO_EMC_29_GPIO2_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpt2_compare2: IOMUXC_GPIO_EMC_29_GPT2_COMPARE2 {
 		pinmux = <0x401f8088 6 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_sai3_rx_bclk: IOMUXC_GPIO_EMC_29_SAI3_RX_BCLK {
 		pinmux = <0x401f8088 3 0x401f8470 1 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cke: IOMUXC_GPIO_EMC_29_SEMC_CKE {
 		pinmux = <0x401f8088 0 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_wdog2_rst_b_deb: IOMUXC_GPIO_EMC_29_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8088 4 0x0 0 0x401f81fc>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_in19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_29_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f8088 2 0x401f84c0 0 0x401f81fc>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm1_pwmx2: IOMUXC_GPIO_EMC_30_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f808c 7 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm2_pwma2: IOMUXC_GPIO_EMC_30_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f808c 1 0x401f8350 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio2_io30: IOMUXC_GPIO_EMC_30_GPIO2_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpt2_compare3: IOMUXC_GPIO_EMC_30_GPT2_COMPARE3 {
 		pinmux = <0x401f808c 6 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart4_cts_b: IOMUXC_GPIO_EMC_30_LPUART4_CTS_B {
 		pinmux = <0x401f808c 2 0x401f83e0 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_sai3_rx_sync: IOMUXC_GPIO_EMC_30_SAI3_RX_SYNC {
 		pinmux = <0x401f808c 3 0x401f8478 1 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_clk: IOMUXC_GPIO_EMC_30_SEMC_CLK {
 		pinmux = <0x401f808c 0 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_wdog1_rst_b_deb: IOMUXC_GPIO_EMC_30_WDOG1_RST_B_DEB {
 		pinmux = <0x401f808c 4 0x0 0 0x401f8200>;
 	};
-	iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm1_pwmx3: IOMUXC_GPIO_EMC_31_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f8090 7 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_31_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8090 1 0x401f8360 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio2_io31: IOMUXC_GPIO_EMC_31_GPIO2_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpt2_clk: IOMUXC_GPIO_EMC_31_GPT2_CLK {
 		pinmux = <0x401f8090 6 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart4_rts_b: IOMUXC_GPIO_EMC_31_LPUART4_RTS_B {
 		pinmux = <0x401f8090 2 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_sai3_rx_data: IOMUXC_GPIO_EMC_31_SAI3_RX_DATA {
 		pinmux = <0x401f8090 3 0x401f8474 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_dm1: IOMUXC_GPIO_EMC_31_SEMC_DM1 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_wdog2_b: IOMUXC_GPIO_EMC_31_WDOG2_B {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io00: IOMUXC_GPIO_EMC_32_GPIO3_IO00 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpspi4_sck: IOMUXC_GPIO_EMC_32_LPSPI4_SCK {
 		pinmux = <0x401f8094 4 0x401f83c0 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart4_tx: IOMUXC_GPIO_EMC_32_LPUART4_TX {
 		pinmux = <0x401f8094 2 0x401f83e8 2 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_qtimer1_timer0: IOMUXC_GPIO_EMC_32_QTIMER1_TIMER0 {
 		pinmux = <0x401f8094 1 0x401f8410 1 0x401f8208>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ref_24m_out: IOMUXC_GPIO_EMC_32_REF_24M_OUT {
 		pinmux = <0x401f8094 7 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_sai3_tx_data: IOMUXC_GPIO_EMC_32_SAI3_TX_DATA {
 		pinmux = <0x401f8094 3 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data08: IOMUXC_GPIO_EMC_32_SEMC_DATA08 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io01: IOMUXC_GPIO_EMC_33_GPIO3_IO01 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpspi4_pcs0: IOMUXC_GPIO_EMC_33_LPSPI4_PCS0 {
 		pinmux = <0x401f8098 4 0x401f83bc 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_lpuart4_rx: IOMUXC_GPIO_EMC_33_LPUART4_RX {
 		pinmux = <0x401f8098 2 0x401f83e4 2 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_qtimer1_timer1: IOMUXC_GPIO_EMC_33_QTIMER1_TIMER1 {
 		pinmux = <0x401f8098 1 0x401f8414 1 0x401f820c>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_tx_bclk: IOMUXC_GPIO_EMC_33_SAI3_TX_BCLK {
 		pinmux = <0x401f8098 3 0x401f847c 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data09: IOMUXC_GPIO_EMC_33_SEMC_DATA09 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet_crs: IOMUXC_GPIO_EMC_34_ENET_CRS {
 		pinmux = <0x401f809c 6 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io02: IOMUXC_GPIO_EMC_34_GPIO3_IO02 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpspi4_sdo: IOMUXC_GPIO_EMC_34_LPSPI4_SDO {
 		pinmux = <0x401f809c 4 0x401f83c8 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_lpuart7_tx: IOMUXC_GPIO_EMC_34_LPUART7_TX {
 		pinmux = <0x401f809c 2 0x401f8400 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_qtimer1_timer2: IOMUXC_GPIO_EMC_34_QTIMER1_TIMER2 {
 		pinmux = <0x401f809c 1 0x401f8418 1 0x401f8210>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_tx_sync: IOMUXC_GPIO_EMC_34_SAI3_TX_SYNC {
 		pinmux = <0x401f809c 3 0x401f8480 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data10: IOMUXC_GPIO_EMC_34_SEMC_DATA10 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet_col: IOMUXC_GPIO_EMC_35_ENET_COL {
 		pinmux = <0x401f80a0 6 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io03: IOMUXC_GPIO_EMC_35_GPIO3_IO03 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpspi4_sdi: IOMUXC_GPIO_EMC_35_LPSPI4_SDI {
 		pinmux = <0x401f80a0 4 0x401f83c4 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_lpuart7_rx: IOMUXC_GPIO_EMC_35_LPUART7_RX {
 		pinmux = <0x401f80a0 2 0x401f83fc 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_qtimer1_timer3: IOMUXC_GPIO_EMC_35_QTIMER1_TIMER3 {
 		pinmux = <0x401f80a0 1 0x401f841c 1 0x401f8214>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data11: IOMUXC_GPIO_EMC_35_SEMC_DATA11 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc2_wp: IOMUXC_GPIO_EMC_35_USDHC2_WP {
 		pinmux = <0x401f80a0 3 0x401f849c 1 0x401f8214>;
 	};
-	iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_ccm_pmic_rdy: IOMUXC_GPIO_EMC_36_CCM_PMIC_RDY {
 		pinmux = <0x401f80a4 3 0x401f8300 3 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet_rx_clk: IOMUXC_GPIO_EMC_36_ENET_RX_CLK {
 		pinmux = <0x401f80a4 6 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexpwm2_pwma1: IOMUXC_GPIO_EMC_36_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f80a4 1 0x401f834c 1 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io04: IOMUXC_GPIO_EMC_36_GPIO3_IO04 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpspi4_pcs1: IOMUXC_GPIO_EMC_36_LPSPI4_PCS1 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_lpuart5_cts_b: IOMUXC_GPIO_EMC_36_LPUART5_CTS_B {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data12: IOMUXC_GPIO_EMC_36_SEMC_DATA12 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 7 0x401f8494 4 0x401f8218>;
 	};
-	iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet_rx_data3: IOMUXC_GPIO_EMC_37_ENET_RX_DATA3 {
 		pinmux = <0x401f80a8 6 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_37_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f80a8 1 0x401f835c 1 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io05: IOMUXC_GPIO_EMC_37_GPIO3_IO05 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpspi4_pcs2: IOMUXC_GPIO_EMC_37_LPSPI4_PCS2 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_lpuart5_rts_b: IOMUXC_GPIO_EMC_37_LPUART5_RTS_B {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_mqs_right: IOMUXC_GPIO_EMC_37_MQS_RIGHT {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data13: IOMUXC_GPIO_EMC_37_SEMC_DATA13 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc1_vselect: IOMUXC_GPIO_EMC_37_USDHC1_VSELECT {
 		pinmux = <0x401f80a8 7 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet_rx_data2: IOMUXC_GPIO_EMC_38_ENET_RX_DATA2 {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm2_pwma0: IOMUXC_GPIO_EMC_38_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f80ac 1 0x401f8348 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io06: IOMUXC_GPIO_EMC_38_GPIO3_IO06 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpspi4_pcs3: IOMUXC_GPIO_EMC_38_LPSPI4_PCS3 {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart5_tx: IOMUXC_GPIO_EMC_38_LPUART5_TX {
 		pinmux = <0x401f80ac 2 0x401f83f0 1 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_mqs_left: IOMUXC_GPIO_EMC_38_MQS_LEFT {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_data14: IOMUXC_GPIO_EMC_38_SEMC_DATA14 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc1_cd_b: IOMUXC_GPIO_EMC_38_USDHC1_CD_B {
 		pinmux = <0x401f80ac 7 0x401f8490 3 0x401f8220>;
 	};
-	iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet_tx_er: IOMUXC_GPIO_EMC_39_ENET_TX_ER {
 		pinmux = <0x401f80b0 6 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_39_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f80b0 1 0x401f8358 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io07: IOMUXC_GPIO_EMC_39_GPIO3_IO07 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpt1_clk: IOMUXC_GPIO_EMC_39_GPT1_CLK {
 		pinmux = <0x401f80b0 7 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart5_rx: IOMUXC_GPIO_EMC_39_LPUART5_RX {
 		pinmux = <0x401f80b0 2 0x401f83ec 1 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_data15: IOMUXC_GPIO_EMC_39_SEMC_DATA15 {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usb_otg1_oc: IOMUXC_GPIO_EMC_39_USB_OTG1_OC {
 		pinmux = <0x401f80b0 3 0x401f848c 2 0x401f8224>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdio: IOMUXC_GPIO_EMC_40_ENET_MDIO {
 		pinmux = <0x401f80b4 4 0x401f8308 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_tx_data3: IOMUXC_GPIO_EMC_40_ENET_TX_DATA3 {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io08: IOMUXC_GPIO_EMC_40_GPIO3_IO08 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt1_compare3: IOMUXC_GPIO_EMC_40_GPT1_COMPARE3 {
 		pinmux = <0x401f80b4 7 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_csx0: IOMUXC_GPIO_EMC_40_SEMC_CSX0 {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_spdif_out: IOMUXC_GPIO_EMC_40_SPDIF_OUT {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg1_id: IOMUXC_GPIO_EMC_40_USB_OTG1_ID {
 		pinmux = <0x401f80b4 3 0x401f82fc 2 0x401f8228>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_in18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_40_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80b4 1 0x401f84bc 1 0x401f8228>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdc: IOMUXC_GPIO_EMC_41_ENET_MDC {
 		pinmux = <0x401f80b8 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_tx_data2: IOMUXC_GPIO_EMC_41_ENET_TX_DATA2 {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io09: IOMUXC_GPIO_EMC_41_GPIO3_IO09 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt1_compare2: IOMUXC_GPIO_EMC_41_GPT1_COMPARE2 {
 		pinmux = <0x401f80b8 7 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_rdy: IOMUXC_GPIO_EMC_41_SEMC_RDY {
 		pinmux = <0x401f80b8 0 0x401f8484 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_spdif_in: IOMUXC_GPIO_EMC_41_SPDIF_IN {
 		pinmux = <0x401f80b8 2 0x401f8488 1 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg1_pwr: IOMUXC_GPIO_EMC_41_USB_OTG1_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_in19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_41_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80b8 1 0x401f84c0 1 0x401f822c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f813c 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io13: IOMUXC_GPIO_SD_B0_00_GPIO3_IO13 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f813c 4 0x401f838c 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_qtimer1_timer0: IOMUXC_GPIO_SD_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x401f8410 0 0x401f82b0>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai1_mclk: IOMUXC_GPIO_SD_B0_00_SAI1_MCLK {
 		pinmux = <0x401f813c 2 0x401f8430 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_sai2_mclk: IOMUXC_GPIO_SD_B0_00_SAI2_MCLK {
 		pinmux = <0x401f813c 3 0x401f8454 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_data2: IOMUXC_GPIO_SD_B0_00_USDHC1_DATA2 {
 		pinmux = <0x401f813c 0 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f813c 7 0x401f84a0 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f8140 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io14: IOMUXC_GPIO_SD_B0_01_GPIO3_IO14 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f8140 4 0x401f8390 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_qtimer1_timer1: IOMUXC_GPIO_SD_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x401f8414 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_ref_24m_out: IOMUXC_GPIO_SD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_sai2_rx_sync: IOMUXC_GPIO_SD_B0_01_SAI2_RX_SYNC {
 		pinmux = <0x401f8140 3 0x401f8460 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_data3: IOMUXC_GPIO_SD_B0_01_USDHC1_DATA3 {
 		pinmux = <0x401f8140 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8140 7 0x401f84a4 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet_mdio: IOMUXC_GPIO_SD_B0_02_ENET_MDIO {
 		pinmux = <0x401f8144 6 0x401f8308 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io15: IOMUXC_GPIO_SD_B0_02_GPIO3_IO15 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sck: IOMUXC_GPIO_SD_B0_02_LPSPI1_SCK {
 		pinmux = <0x401f8144 4 0x401f83a0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart7_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART7_CTS_B {
 		pinmux = <0x401f8144 2 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_qtimer1_timer2: IOMUXC_GPIO_SD_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x401f8418 0 0x401f82b8>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_sai2_rx_bclk: IOMUXC_GPIO_SD_B0_02_SAI2_RX_BCLK {
 		pinmux = <0x401f8144 3 0x401f8458 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_cmd: IOMUXC_GPIO_SD_B0_02_USDHC1_CMD {
 		pinmux = <0x401f8144 0 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8144 7 0x401f84a8 0 0x401f82b8>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet_mdc: IOMUXC_GPIO_SD_B0_03_ENET_MDC {
 		pinmux = <0x401f8148 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io16: IOMUXC_GPIO_SD_B0_03_GPIO3_IO16 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_03_LPSPI1_PCS0 {
 		pinmux = <0x401f8148 4 0x401f839c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart7_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART7_RTS_B {
 		pinmux = <0x401f8148 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_qtimer1_timer3: IOMUXC_GPIO_SD_B0_03_QTIMER1_TIMER3 {
 		pinmux = <0x401f8148 1 0x401f841c 0 0x401f82bc>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_sai2_rx_data: IOMUXC_GPIO_SD_B0_03_SAI2_RX_DATA {
 		pinmux = <0x401f8148 3 0x401f845c 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_clk: IOMUXC_GPIO_SD_B0_03_USDHC1_CLK {
 		pinmux = <0x401f8148 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexcan2_tx: IOMUXC_GPIO_SD_B0_04_FLEXCAN2_TX {
 		pinmux = <0x401f814c 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f814c 6 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io17: IOMUXC_GPIO_SD_B0_04_GPIO3_IO17 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpspi1_sdo: IOMUXC_GPIO_SD_B0_04_LPSPI1_SDO {
 		pinmux = <0x401f814c 4 0x401f83a8 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart7_tx: IOMUXC_GPIO_SD_B0_04_LPUART7_TX {
 		pinmux = <0x401f814c 2 0x401f8400 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_sai2_tx_data: IOMUXC_GPIO_SD_B0_04_SAI2_TX_DATA {
 		pinmux = <0x401f814c 3 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data0: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA0 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexcan2_rx: IOMUXC_GPIO_SD_B0_05_FLEXCAN2_RX {
 		pinmux = <0x401f8150 1 0x401f8324 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f8150 6 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io18: IOMUXC_GPIO_SD_B0_05_GPIO3_IO18 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpspi1_sdi: IOMUXC_GPIO_SD_B0_05_LPSPI1_SDI {
 		pinmux = <0x401f8150 4 0x401f83a4 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart7_rx: IOMUXC_GPIO_SD_B0_05_LPUART7_RX {
 		pinmux = <0x401f8150 2 0x401f83fc 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_sai2_tx_bclk: IOMUXC_GPIO_SD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f8150 3 0x401f8464 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data1: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA1 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_gpio3_io19: IOMUXC_GPIO_SD_B0_06_GPIO3_IO19 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_ref_32k_out: IOMUXC_GPIO_SD_B0_06_REF_32K_OUT {
 		pinmux = <0x401f8154 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_sai2_tx_sync: IOMUXC_GPIO_SD_B0_06_SAI2_TX_SYNC {
 		pinmux = <0x401f8154 3 0x401f8468 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_cd_b: IOMUXC_GPIO_SD_B0_06_USDHC1_CD_B {
 		pinmux = <0x401f8154 0 0x401f8490 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_usdhc1_reset_b: IOMUXC_GPIO_SD_B0_06_USDHC1_RESET_B {
 		pinmux = <0x401f8154 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_wdog1_b: IOMUXC_GPIO_SD_B0_06_WDOG1_B {
 		pinmux = <0x401f8154 4 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_in17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_06_xbar1_xbar_inout17: IOMUXC_GPIO_SD_B0_06_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8154 6 0x401f84ac 0 0x401f82c8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexcan1_tx: IOMUXC_GPIO_SD_B1_00_FLEXCAN1_TX {
 		pinmux = <0x401f8158 4 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f8158 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io20: IOMUXC_GPIO_SD_B1_00_GPIO3_IO20 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart6_tx: IOMUXC_GPIO_SD_B1_00_LPUART6_TX {
 		pinmux = <0x401f8158 2 0x401f83f8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data2: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA2 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout10: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f8158 3 0x401f84b0 1 0x401f82cc>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexcan1_rx: IOMUXC_GPIO_SD_B1_01_FLEXCAN1_RX {
 		pinmux = <0x401f815c 4 0x401f8320 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_01_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f815c 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_SCLK {
 		pinmux = <0x401f815c 1 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io21: IOMUXC_GPIO_SD_B1_01_GPIO3_IO21 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart6_rx: IOMUXC_GPIO_SD_B1_01_LPUART6_RX {
 		pinmux = <0x401f815c 2 0x401f83f4 1 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data3: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA3 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_clko1: IOMUXC_GPIO_SD_B1_02_CCM_CLKO1 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_enet_1588_event1_out: IOMUXC_GPIO_SD_B1_02_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f8160 4 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data0: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io22: IOMUXC_GPIO_SD_B1_02_GPIO3_IO22 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpi2c4_scl: IOMUXC_GPIO_SD_B1_02_LPI2C4_SCL {
 		pinmux = <0x401f8160 3 0x401f8394 1 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_lpuart8_tx: IOMUXC_GPIO_SD_B1_02_LPUART8_TX {
 		pinmux = <0x401f8160 2 0x401f8408 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_cmd: IOMUXC_GPIO_SD_B1_02_USDHC2_CMD {
 		pinmux = <0x401f8160 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_clko2: IOMUXC_GPIO_SD_B1_03_CCM_CLKO2 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_enet_1588_event1_in: IOMUXC_GPIO_SD_B1_03_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f8164 4 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data2: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io23: IOMUXC_GPIO_SD_B1_03_GPIO3_IO23 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpi2c4_sda: IOMUXC_GPIO_SD_B1_03_LPI2C4_SDA {
 		pinmux = <0x401f8164 3 0x401f8398 1 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_lpuart8_rx: IOMUXC_GPIO_SD_B1_03_LPUART8_RX {
 		pinmux = <0x401f8164 2 0x401f8404 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_clk: IOMUXC_GPIO_SD_B1_03_USDHC2_CLK {
 		pinmux = <0x401f8164 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_wait: IOMUXC_GPIO_SD_B1_04_CCM_WAIT {
 		pinmux = <0x401f8168 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_ref_clk: IOMUXC_GPIO_SD_B1_04_ENET_REF_CLK {
 		pinmux = <0x401f8168 3 0x401f8304 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_tx_clk: IOMUXC_GPIO_SD_B1_04_ENET_TX_CLK {
 		pinmux = <0x401f8168 2 0x401f831c 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ewm_out_b: IOMUXC_GPIO_SD_B1_04_EWM_OUT_B {
 		pinmux = <0x401f8168 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_data1: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io24: IOMUXC_GPIO_SD_B1_04_GPIO3_IO24 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_data0: IOMUXC_GPIO_SD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_05_CCM_PMIC_RDY {
 		pinmux = <0x401f816c 6 0x401f8300 1 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_rx_data1: IOMUXC_GPIO_SD_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f816c 2 0x401f8310 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f816c 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f816c 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io25: IOMUXC_GPIO_SD_B1_05_GPIO3_IO25 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_mclk: IOMUXC_GPIO_SD_B1_05_SAI3_MCLK {
 		pinmux = <0x401f816c 3 0x401f846c 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_data1: IOMUXC_GPIO_SD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_ccm_stop: IOMUXC_GPIO_SD_B1_06_CCM_STOP {
 		pinmux = <0x401f8170 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_enet_rx_data0: IOMUXC_GPIO_SD_B1_06_ENET_RX_DATA0 {
 		pinmux = <0x401f8170 2 0x401f830c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_data3: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8170 1 0x401f8374 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io26: IOMUXC_GPIO_SD_B1_06_GPIO3_IO26 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f8170 4 0x401f83ac 2 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_TX_BCLK {
 		pinmux = <0x401f8170 3 0x401f847c 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_cd_b: IOMUXC_GPIO_SD_B1_06_USDHC2_CD_B {
 		pinmux = <0x401f8170 0 0x401f8498 0 0x401f82e4>;
 	};
-	iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_enet_rx_en: IOMUXC_GPIO_SD_B1_07_ENET_RX_EN {
 		pinmux = <0x401f8174 2 0x401f8314 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8174 1 0x401f8378 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io27: IOMUXC_GPIO_SD_B1_07_GPIO3_IO27 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f8174 4 0x401f83b0 2 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai3_tx_sync: IOMUXC_GPIO_SD_B1_07_SAI3_TX_SYNC {
 		pinmux = <0x401f8174 3 0x401f8480 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_07_USDHC2_RESET_B {
 		pinmux = <0x401f8174 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_enet_rx_er: IOMUXC_GPIO_SD_B1_08_ENET_RX_ER {
 		pinmux = <0x401f8178 2 0x401f8318 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8178 1 0x401f8368 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io28: IOMUXC_GPIO_SD_B1_08_GPIO3_IO28 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f8178 4 0x401f83b8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai3_tx_data: IOMUXC_GPIO_SD_B1_08_SAI3_TX_DATA {
 		pinmux = <0x401f8178 3 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_enet_tx_en: IOMUXC_GPIO_SD_B1_09_ENET_TX_EN {
 		pinmux = <0x401f817c 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data2: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f817c 1 0x401f8370 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io29: IOMUXC_GPIO_SD_B1_09_GPIO3_IO29 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f817c 4 0x401f83b4 2 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_09_SAI3_RX_BCLK {
 		pinmux = <0x401f817c 3 0x401f8470 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_enet_tx_data0: IOMUXC_GPIO_SD_B1_10_ENET_TX_DATA0 {
 		pinmux = <0x401f8180 2 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data1: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f8180 1 0x401f836c 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io30: IOMUXC_GPIO_SD_B1_10_GPIO3_IO30 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_sai3_rx_sync: IOMUXC_GPIO_SD_B1_10_SAI3_RX_SYNC {
 		pinmux = <0x401f8180 3 0x401f8478 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_enet_tx_data1: IOMUXC_GPIO_SD_B1_11_ENET_TX_DATA1 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8184 1 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io31: IOMUXC_GPIO_SD_B1_11_GPIO3_IO31 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_sai3_rx_data: IOMUXC_GPIO_SD_B1_11_SAI3_RX_DATA {
 		pinmux = <0x401f8184 3 0x401f8474 0 0x401f82f8>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f82f8>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f840c 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1052cvj5b-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1052cvj5b-pinctrl.dtsi
@@ -18,2942 +18,2942 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x401f8568 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f8568 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1052cvl5b-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1052cvl5b-pinctrl.dtsi
@@ -18,2942 +18,2942 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x401f8568 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f8568 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1052dvj6b-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1052dvj6b-pinctrl.dtsi
@@ -18,2942 +18,2942 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x401f8568 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f8568 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1052dvl6b-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1052dvl6b-pinctrl.dtsi
@@ -18,2942 +18,2942 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x401f8568 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_cm7_txev: IOMUXC_GPIO_B0_14_ARM_CM7_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_cm7_rxev: IOMUXC_GPIO_B0_15_ARM_CM7_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x401f8568 1 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1062cvj5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1062cvj5a-pinctrl.dtsi
@@ -18,3955 +18,3955 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
 		pinmux = <0x401f8038 8 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
 		pinmux = <0x401f803c 8 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
 		pinmux = <0x401f8040 8 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
 		pinmux = <0x401f8044 8 0x401f8754 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
 		pinmux = <0x401f8048 8 0x401f8740 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
 		pinmux = <0x401f804c 8 0x401f8744 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
 		pinmux = <0x401f8050 8 0x401f8748 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
 		pinmux = <0x401f8054 8 0x401f874c 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
 		pinmux = <0x401f806c 8 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
 		pinmux = <0x401f8070 8 0x401f872c 1 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
 		pinmux = <0x401f8074 8 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
 		pinmux = <0x401f8078 8 0x401f8750 1 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
 		pinmux = <0x401f807c 8 0x401f8730 1 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
 		pinmux = <0x401f8080 8 0x401f8734 1 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
 		pinmux = <0x401f8084 8 0x401f8738 1 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
 		pinmux = <0x401f8088 8 0x401f873c 1 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1062cvl5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1062cvl5a-pinctrl.dtsi
@@ -18,3955 +18,3955 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
 		pinmux = <0x401f8038 8 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
 		pinmux = <0x401f803c 8 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
 		pinmux = <0x401f8040 8 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
 		pinmux = <0x401f8044 8 0x401f8754 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
 		pinmux = <0x401f8048 8 0x401f8740 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
 		pinmux = <0x401f804c 8 0x401f8744 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
 		pinmux = <0x401f8050 8 0x401f8748 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
 		pinmux = <0x401f8054 8 0x401f874c 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
 		pinmux = <0x401f806c 8 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
 		pinmux = <0x401f8070 8 0x401f872c 1 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
 		pinmux = <0x401f8074 8 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
 		pinmux = <0x401f8078 8 0x401f8750 1 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
 		pinmux = <0x401f807c 8 0x401f8730 1 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
 		pinmux = <0x401f8080 8 0x401f8734 1 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
 		pinmux = <0x401f8084 8 0x401f8738 1 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
 		pinmux = <0x401f8088 8 0x401f873c 1 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1062dvj6a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1062dvj6a-pinctrl.dtsi
@@ -18,3955 +18,3955 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
 		pinmux = <0x401f8038 8 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
 		pinmux = <0x401f803c 8 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
 		pinmux = <0x401f8040 8 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
 		pinmux = <0x401f8044 8 0x401f8754 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
 		pinmux = <0x401f8048 8 0x401f8740 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
 		pinmux = <0x401f804c 8 0x401f8744 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
 		pinmux = <0x401f8050 8 0x401f8748 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
 		pinmux = <0x401f8054 8 0x401f874c 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
 		pinmux = <0x401f806c 8 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
 		pinmux = <0x401f8070 8 0x401f872c 1 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
 		pinmux = <0x401f8074 8 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
 		pinmux = <0x401f8078 8 0x401f8750 1 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
 		pinmux = <0x401f807c 8 0x401f8730 1 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
 		pinmux = <0x401f8080 8 0x401f8734 1 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
 		pinmux = <0x401f8084 8 0x401f8738 1 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
 		pinmux = <0x401f8088 8 0x401f873c 1 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1062dvl6a-pinctrl.dtsi
@@ -18,3955 +18,3955 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexspi2_b_ss1_b: IOMUXC_GPIO_EMC_09_FLEXSPI2_B_SS1_B {
 		pinmux = <0x401f8038 8 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_10_FLEXSPI2_B_SS0_B {
 		pinmux = <0x401f803c 8 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexspi2_b_dqs: IOMUXC_GPIO_EMC_11_FLEXSPI2_B_DQS {
 		pinmux = <0x401f8040 8 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexspi2_b_sclk: IOMUXC_GPIO_EMC_12_FLEXSPI2_B_SCLK {
 		pinmux = <0x401f8044 8 0x401f8754 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexspi2_b_data0: IOMUXC_GPIO_EMC_13_FLEXSPI2_B_DATA0 {
 		pinmux = <0x401f8048 8 0x401f8740 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_flexspi2_b_data1: IOMUXC_GPIO_EMC_14_FLEXSPI2_B_DATA1 {
 		pinmux = <0x401f804c 8 0x401f8744 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_flexspi2_b_data2: IOMUXC_GPIO_EMC_15_FLEXSPI2_B_DATA2 {
 		pinmux = <0x401f8050 8 0x401f8748 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_flexspi2_b_data3: IOMUXC_GPIO_EMC_16_FLEXSPI2_B_DATA3 {
 		pinmux = <0x401f8054 8 0x401f874c 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexspi2_a_ss1_b: IOMUXC_GPIO_EMC_22_FLEXSPI2_A_SS1_B {
 		pinmux = <0x401f806c 8 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexspi2_a_dqs: IOMUXC_GPIO_EMC_23_FLEXSPI2_A_DQS {
 		pinmux = <0x401f8070 8 0x401f872c 1 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_24_FLEXSPI2_A_SS0_B {
 		pinmux = <0x401f8074 8 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexspi2_a_sclk: IOMUXC_GPIO_EMC_25_FLEXSPI2_A_SCLK {
 		pinmux = <0x401f8078 8 0x401f8750 1 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexspi2_a_data0: IOMUXC_GPIO_EMC_26_FLEXSPI2_A_DATA0 {
 		pinmux = <0x401f807c 8 0x401f8730 1 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexspi2_a_data1: IOMUXC_GPIO_EMC_27_FLEXSPI2_A_DATA1 {
 		pinmux = <0x401f8080 8 0x401f8734 1 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexspi2_a_data2: IOMUXC_GPIO_EMC_28_FLEXSPI2_A_DATA2 {
 		pinmux = <0x401f8084 8 0x401f8738 1 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexspi2_a_data3: IOMUXC_GPIO_EMC_29_FLEXSPI2_A_DATA3 {
 		pinmux = <0x401f8088 8 0x401f873c 1 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1064cvj5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1064cvj5a-pinctrl.dtsi
@@ -18,3907 +18,3907 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1064cvl5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1064cvl5a-pinctrl.dtsi
@@ -18,3907 +18,3907 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1064dvj6a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1064dvj6a-pinctrl.dtsi
@@ -18,3907 +18,3907 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1064dvl6a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1064dvl6a-pinctrl.dtsi
@@ -18,3907 +18,3907 @@
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_acmp1_in4: IOMUXC_GPIO_AD_B0_00_ACMP1_IN4 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_00_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80bc 0 0x401f8474 2 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio1_io00: IOMUXC_GPIO_AD_B0_00_GPIO1_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_gpio6_io00: IOMUXC_GPIO_AD_B0_00_GPIO6_IO00 {
 		pinmux = <0x401f80bc 5 0x0 0 0x401f82ac>;
 		gpr = <0x400ac068 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpi2c1_scls: IOMUXC_GPIO_AD_B0_00_LPI2C1_SCLS {
 		pinmux = <0x401f80bc 4 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_lpspi3_sck: IOMUXC_GPIO_AD_B0_00_LPSPI3_SCK {
 		pinmux = <0x401f80bc 7 0x401f8510 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_ref_32k_out: IOMUXC_GPIO_AD_B0_00_REF_32K_OUT {
 		pinmux = <0x401f80bc 2 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usb_otg2_id: IOMUXC_GPIO_AD_B0_00_USB_OTG2_ID {
 		pinmux = <0x401f80bc 3 0x401f83f8 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_usdhc1_reset_b: IOMUXC_GPIO_AD_B0_00_USDHC1_RESET_B {
 		pinmux = <0x401f80bc 6 0x0 0 0x401f82ac>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_in14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_00_xbar1_xbar_inout14: IOMUXC_GPIO_AD_B0_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f80bc 1 0x401f8644 0 0x401f82ac>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_acmp2_in4: IOMUXC_GPIO_AD_B0_01_ACMP2_IN4 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ewm_out_b: IOMUXC_GPIO_AD_B0_01_EWM_OUT_B {
 		pinmux = <0x401f80c0 6 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_flexpwm2_pwmb3: IOMUXC_GPIO_AD_B0_01_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f80c0 0 0x401f8484 2 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio1_io01: IOMUXC_GPIO_AD_B0_01_GPIO1_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_gpio6_io01: IOMUXC_GPIO_AD_B0_01_GPIO6_IO01 {
 		pinmux = <0x401f80c0 5 0x0 0 0x401f82b0>;
 		gpr = <0x400ac068 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpi2c1_sdas: IOMUXC_GPIO_AD_B0_01_LPI2C1_SDAS {
 		pinmux = <0x401f80c0 4 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_lpspi3_sdo: IOMUXC_GPIO_AD_B0_01_LPSPI3_SDO {
 		pinmux = <0x401f80c0 7 0x401f8518 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_ref_24m_out: IOMUXC_GPIO_AD_B0_01_REF_24M_OUT {
 		pinmux = <0x401f80c0 2 0x0 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_usb_otg1_id: IOMUXC_GPIO_AD_B0_01_USB_OTG1_ID {
 		pinmux = <0x401f80c0 3 0x401f83f4 0 0x401f82b0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_in15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_01_xbar1_xbar_inout15: IOMUXC_GPIO_AD_B0_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f80c0 1 0x401f8648 0 0x401f82b0>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_acmp3_in4: IOMUXC_GPIO_AD_B0_02_ACMP3_IN4 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexcan2_tx: IOMUXC_GPIO_AD_B0_02_FLEXCAN2_TX {
 		pinmux = <0x401f80c4 0 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_flexpwm1_pwmx0: IOMUXC_GPIO_AD_B0_02_FLEXPWM1_PWMX0 {
 		pinmux = <0x401f80c4 4 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio1_io02: IOMUXC_GPIO_AD_B0_02_GPIO1_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_gpio6_io02: IOMUXC_GPIO_AD_B0_02_GPIO6_IO02 {
 		pinmux = <0x401f80c4 5 0x0 0 0x401f82b4>;
 		gpr = <0x400ac068 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpi2c1_hreq: IOMUXC_GPIO_AD_B0_02_LPI2C1_HREQ {
 		pinmux = <0x401f80c4 6 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpspi3_sdi: IOMUXC_GPIO_AD_B0_02_LPSPI3_SDI {
 		pinmux = <0x401f80c4 7 0x401f8514 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_lpuart6_tx: IOMUXC_GPIO_AD_B0_02_LPUART6_TX {
 		pinmux = <0x401f80c4 2 0x401f8554 1 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_usb_otg1_pwr: IOMUXC_GPIO_AD_B0_02_USB_OTG1_PWR {
 		pinmux = <0x401f80c4 3 0x0 0 0x401f82b4>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_in16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_02_xbar1_xbar_inout16: IOMUXC_GPIO_AD_B0_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f80c4 1 0x401f864c 0 0x401f82b4>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_acmp4_in4: IOMUXC_GPIO_AD_B0_03_ACMP4_IN4 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexcan2_rx: IOMUXC_GPIO_AD_B0_03_FLEXCAN2_RX {
 		pinmux = <0x401f80c8 0 0x401f8450 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_flexpwm1_pwmx1: IOMUXC_GPIO_AD_B0_03_FLEXPWM1_PWMX1 {
 		pinmux = <0x401f80c8 4 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio1_io03: IOMUXC_GPIO_AD_B0_03_GPIO1_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_gpio6_io03: IOMUXC_GPIO_AD_B0_03_GPIO6_IO03 {
 		pinmux = <0x401f80c8 5 0x0 0 0x401f82b8>;
 		gpr = <0x400ac068 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpspi3_pcs0: IOMUXC_GPIO_AD_B0_03_LPSPI3_PCS0 {
 		pinmux = <0x401f80c8 7 0x401f850c 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_lpuart6_rx: IOMUXC_GPIO_AD_B0_03_LPUART6_RX {
 		pinmux = <0x401f80c8 2 0x401f8550 1 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_ref_24m_out: IOMUXC_GPIO_AD_B0_03_REF_24M_OUT {
 		pinmux = <0x401f80c8 6 0x0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_usb_otg1_oc: IOMUXC_GPIO_AD_B0_03_USB_OTG1_OC {
 		pinmux = <0x401f80c8 3 0x401f85d0 0 0x401f82b8>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_03_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80c8 1 0x401f862c 1 0x401f82b8>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_csi_data09: IOMUXC_GPIO_AD_B0_04_CSI_DATA09 {
 		pinmux = <0x401f80cc 4 0x401f841c 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_enet_tx_data3: IOMUXC_GPIO_AD_B0_04_ENET_TX_DATA3 {
 		pinmux = <0x401f80cc 2 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio1_io04: IOMUXC_GPIO_AD_B0_04_GPIO1_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_gpio6_io04: IOMUXC_GPIO_AD_B0_04_GPIO6_IO04 {
 		pinmux = <0x401f80cc 5 0x0 0 0x401f82bc>;
 		gpr = <0x400ac068 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_lpspi3_pcs1: IOMUXC_GPIO_AD_B0_04_LPSPI3_PCS1 {
 		pinmux = <0x401f80cc 7 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_mqs_right: IOMUXC_GPIO_AD_B0_04_MQS_RIGHT {
 		pinmux = <0x401f80cc 1 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_pit_trigger0: IOMUXC_GPIO_AD_B0_04_PIT_TRIGGER0 {
 		pinmux = <0x401f80cc 6 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_sai2_tx_sync: IOMUXC_GPIO_AD_B0_04_SAI2_TX_SYNC {
 		pinmux = <0x401f80cc 3 0x401f85c4 1 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_04_src_boot_mode0: IOMUXC_GPIO_AD_B0_04_SRC_BOOT_MODE0 {
 		pinmux = <0x401f80cc 0 0x0 0 0x401f82bc>;
 	};
-	iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_csi_data08: IOMUXC_GPIO_AD_B0_05_CSI_DATA08 {
 		pinmux = <0x401f80d0 4 0x401f8418 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_enet_tx_data2: IOMUXC_GPIO_AD_B0_05_ENET_TX_DATA2 {
 		pinmux = <0x401f80d0 2 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio1_io05: IOMUXC_GPIO_AD_B0_05_GPIO1_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_gpio6_io05: IOMUXC_GPIO_AD_B0_05_GPIO6_IO05 {
 		pinmux = <0x401f80d0 5 0x0 0 0x401f82c0>;
 		gpr = <0x400ac068 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_lpspi3_pcs2: IOMUXC_GPIO_AD_B0_05_LPSPI3_PCS2 {
 		pinmux = <0x401f80d0 7 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_mqs_left: IOMUXC_GPIO_AD_B0_05_MQS_LEFT {
 		pinmux = <0x401f80d0 1 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_sai2_tx_bclk: IOMUXC_GPIO_AD_B0_05_SAI2_TX_BCLK {
 		pinmux = <0x401f80d0 3 0x401f85c0 1 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_src_boot_mode1: IOMUXC_GPIO_AD_B0_05_SRC_BOOT_MODE1 {
 		pinmux = <0x401f80d0 0 0x0 0 0x401f82c0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_in17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_05_xbar1_xbar_inout17: IOMUXC_GPIO_AD_B0_05_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f80d0 6 0x401f862c 2 0x401f82c0>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_csi_data07: IOMUXC_GPIO_AD_B0_06_CSI_DATA07 {
 		pinmux = <0x401f80d4 4 0x401f8414 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_enet_rx_clk: IOMUXC_GPIO_AD_B0_06_ENET_RX_CLK {
 		pinmux = <0x401f80d4 2 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio1_io06: IOMUXC_GPIO_AD_B0_06_GPIO1_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpio6_io06: IOMUXC_GPIO_AD_B0_06_GPIO6_IO06 {
 		pinmux = <0x401f80d4 5 0x0 0 0x401f82c4>;
 		gpr = <0x400ac068 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_gpt2_compare1: IOMUXC_GPIO_AD_B0_06_GPT2_COMPARE1 {
 		pinmux = <0x401f80d4 1 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_jtag_tms: IOMUXC_GPIO_AD_B0_06_JTAG_TMS {
 		pinmux = <0x401f80d4 0 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_lpspi3_pcs3: IOMUXC_GPIO_AD_B0_06_LPSPI3_PCS3 {
 		pinmux = <0x401f80d4 7 0x0 0 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_sai2_rx_bclk: IOMUXC_GPIO_AD_B0_06_SAI2_RX_BCLK {
 		pinmux = <0x401f80d4 3 0x401f85b4 1 0x401f82c4>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_in18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_06_xbar1_xbar_inout18: IOMUXC_GPIO_AD_B0_06_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80d4 6 0x401f8630 1 0x401f82c4>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_csi_data06: IOMUXC_GPIO_AD_B0_07_CSI_DATA06 {
 		pinmux = <0x401f80d8 4 0x401f8410 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_1588_event3_out: IOMUXC_GPIO_AD_B0_07_ENET_1588_EVENT3_OUT {
 		pinmux = <0x401f80d8 7 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_enet_tx_er: IOMUXC_GPIO_AD_B0_07_ENET_TX_ER {
 		pinmux = <0x401f80d8 2 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio1_io07: IOMUXC_GPIO_AD_B0_07_GPIO1_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpio6_io07: IOMUXC_GPIO_AD_B0_07_GPIO6_IO07 {
 		pinmux = <0x401f80d8 5 0x0 0 0x401f82c8>;
 		gpr = <0x400ac068 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_gpt2_compare2: IOMUXC_GPIO_AD_B0_07_GPT2_COMPARE2 {
 		pinmux = <0x401f80d8 1 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_jtag_tck: IOMUXC_GPIO_AD_B0_07_JTAG_TCK {
 		pinmux = <0x401f80d8 0 0x0 0 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_sai2_rx_sync: IOMUXC_GPIO_AD_B0_07_SAI2_RX_SYNC {
 		pinmux = <0x401f80d8 3 0x401f85bc 1 0x401f82c8>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_in19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_07_xbar1_xbar_inout19: IOMUXC_GPIO_AD_B0_07_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f80d8 6 0x401f8654 1 0x401f82c8>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_csi_data05: IOMUXC_GPIO_AD_B0_08_CSI_DATA05 {
 		pinmux = <0x401f80dc 4 0x401f840c 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_1588_event3_in: IOMUXC_GPIO_AD_B0_08_ENET_1588_EVENT3_IN {
 		pinmux = <0x401f80dc 7 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_enet_rx_data3: IOMUXC_GPIO_AD_B0_08_ENET_RX_DATA3 {
 		pinmux = <0x401f80dc 2 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio1_io08: IOMUXC_GPIO_AD_B0_08_GPIO1_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpio6_io08: IOMUXC_GPIO_AD_B0_08_GPIO6_IO08 {
 		pinmux = <0x401f80dc 5 0x0 0 0x401f82cc>;
 		gpr = <0x400ac068 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_gpt2_compare3: IOMUXC_GPIO_AD_B0_08_GPT2_COMPARE3 {
 		pinmux = <0x401f80dc 1 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_jtag_mod: IOMUXC_GPIO_AD_B0_08_JTAG_MOD {
 		pinmux = <0x401f80dc 0 0x0 0 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_sai2_rx_data: IOMUXC_GPIO_AD_B0_08_SAI2_RX_DATA {
 		pinmux = <0x401f80dc 3 0x401f85b8 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_08_xbar1_xbar_in20: IOMUXC_GPIO_AD_B0_08_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f80dc 6 0x401f8634 1 0x401f82cc>;
 	};
-	iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_csi_data04: IOMUXC_GPIO_AD_B0_09_CSI_DATA04 {
 		pinmux = <0x401f80e0 4 0x401f8408 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_enet_rx_data2: IOMUXC_GPIO_AD_B0_09_ENET_RX_DATA2 {
 		pinmux = <0x401f80e0 2 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_flexpwm2_pwma3: IOMUXC_GPIO_AD_B0_09_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f80e0 1 0x401f8474 3 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio1_io09: IOMUXC_GPIO_AD_B0_09_GPIO1_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpio6_io09: IOMUXC_GPIO_AD_B0_09_GPIO6_IO09 {
 		pinmux = <0x401f80e0 5 0x0 0 0x401f82d0>;
 		gpr = <0x400ac068 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_gpt2_clk: IOMUXC_GPIO_AD_B0_09_GPT2_CLK {
 		pinmux = <0x401f80e0 7 0x401f876c 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_jtag_tdi: IOMUXC_GPIO_AD_B0_09_JTAG_TDI {
 		pinmux = <0x401f80e0 0 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_sai2_tx_data: IOMUXC_GPIO_AD_B0_09_SAI2_TX_DATA {
 		pinmux = <0x401f80e0 3 0x0 0 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_semc_dqs4: IOMUXC_GPIO_AD_B0_09_SEMC_DQS4 {
 		pinmux = <0x401f80e0 9 0x401f8788 2 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_09_xbar1_xbar_in21: IOMUXC_GPIO_AD_B0_09_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f80e0 6 0x401f8658 1 0x401f82d0>;
 	};
-	iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_arm_trace_swo: IOMUXC_GPIO_AD_B0_10_ARM_TRACE_SWO {
 		pinmux = <0x401f80e4 9 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_csi_data03: IOMUXC_GPIO_AD_B0_10_CSI_DATA03 {
 		pinmux = <0x401f80e4 4 0x401f8404 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_10_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80e4 7 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_enet_crs: IOMUXC_GPIO_AD_B0_10_ENET_CRS {
 		pinmux = <0x401f80e4 2 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexcan3_tx: IOMUXC_GPIO_AD_B0_10_FLEXCAN3_TX {
 		pinmux = <0x401f80e4 8 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_flexpwm1_pwma3: IOMUXC_GPIO_AD_B0_10_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80e4 1 0x401f8454 3 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio1_io10: IOMUXC_GPIO_AD_B0_10_GPIO1_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_gpio6_io10: IOMUXC_GPIO_AD_B0_10_GPIO6_IO10 {
 		pinmux = <0x401f80e4 5 0x0 0 0x401f82d4>;
 		gpr = <0x400ac068 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_jtag_tdo: IOMUXC_GPIO_AD_B0_10_JTAG_TDO {
 		pinmux = <0x401f80e4 0 0x0 0 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_sai2_mclk: IOMUXC_GPIO_AD_B0_10_SAI2_MCLK {
 		pinmux = <0x401f80e4 3 0x401f85b0 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_10_xbar1_xbar_in22: IOMUXC_GPIO_AD_B0_10_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80e4 6 0x401f8638 1 0x401f82d4>;
 	};
-	iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_csi_data02: IOMUXC_GPIO_AD_B0_11_CSI_DATA02 {
 		pinmux = <0x401f80e8 4 0x401f8400 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_11_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80e8 7 0x401f8444 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_enet_col: IOMUXC_GPIO_AD_B0_11_ENET_COL {
 		pinmux = <0x401f80e8 2 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexcan3_rx: IOMUXC_GPIO_AD_B0_11_FLEXCAN3_RX {
 		pinmux = <0x401f80e8 8 0x401f878c 2 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_flexpwm1_pwmb3: IOMUXC_GPIO_AD_B0_11_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80e8 1 0x401f8464 3 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio1_io11: IOMUXC_GPIO_AD_B0_11_GPIO1_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_gpio6_io11: IOMUXC_GPIO_AD_B0_11_GPIO6_IO11 {
 		pinmux = <0x401f80e8 5 0x0 0 0x401f82d8>;
 		gpr = <0x400ac068 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_jtag_trstb: IOMUXC_GPIO_AD_B0_11_JTAG_TRSTB {
 		pinmux = <0x401f80e8 0 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_semc_clk6: IOMUXC_GPIO_AD_B0_11_SEMC_CLK6 {
 		pinmux = <0x401f80e8 9 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_wdog1_b: IOMUXC_GPIO_AD_B0_11_WDOG1_B {
 		pinmux = <0x401f80e8 3 0x0 0 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_11_xbar1_xbar_in23: IOMUXC_GPIO_AD_B0_11_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80e8 6 0x401f863c 1 0x401f82d8>;
 	};
-	iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_adc1_in1: IOMUXC_GPIO_AD_B0_12_ADC1_IN1 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_arm_nmi: IOMUXC_GPIO_AD_B0_12_ARM_NMI {
 		pinmux = <0x401f80ec 7 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_ccm_pmic_rdy: IOMUXC_GPIO_AD_B0_12_CCM_PMIC_RDY {
 		pinmux = <0x401f80ec 1 0x401f83fc 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_enet_1588_event1_out: IOMUXC_GPIO_AD_B0_12_ENET_1588_EVENT1_OUT {
 		pinmux = <0x401f80ec 6 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_flexpwm1_pwmx2: IOMUXC_GPIO_AD_B0_12_FLEXPWM1_PWMX2 {
 		pinmux = <0x401f80ec 4 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio1_io12: IOMUXC_GPIO_AD_B0_12_GPIO1_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_gpio6_io12: IOMUXC_GPIO_AD_B0_12_GPIO6_IO12 {
 		pinmux = <0x401f80ec 5 0x0 0 0x401f82dc>;
 		gpr = <0x400ac068 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpi2c4_scl: IOMUXC_GPIO_AD_B0_12_LPI2C4_SCL {
 		pinmux = <0x401f80ec 0 0x401f84e4 1 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_lpuart1_tx: IOMUXC_GPIO_AD_B0_12_LPUART1_TX {
 		pinmux = <0x401f80ec 2 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_12_wdog2_b: IOMUXC_GPIO_AD_B0_12_WDOG2_B {
 		pinmux = <0x401f80ec 3 0x0 0 0x401f82dc>;
 	};
-	iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_acmp1_in2: IOMUXC_GPIO_AD_B0_13_ACMP1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_adc1_in2: IOMUXC_GPIO_AD_B0_13_ADC1_IN2 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_enet_1588_event1_in: IOMUXC_GPIO_AD_B0_13_ENET_1588_EVENT1_IN {
 		pinmux = <0x401f80f0 6 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ewm_out_b: IOMUXC_GPIO_AD_B0_13_EWM_OUT_B {
 		pinmux = <0x401f80f0 3 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_flexpwm1_pwmx3: IOMUXC_GPIO_AD_B0_13_FLEXPWM1_PWMX3 {
 		pinmux = <0x401f80f0 4 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio1_io13: IOMUXC_GPIO_AD_B0_13_GPIO1_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpio6_io13: IOMUXC_GPIO_AD_B0_13_GPIO6_IO13 {
 		pinmux = <0x401f80f0 5 0x0 0 0x401f82e0>;
 		gpr = <0x400ac068 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_gpt1_clk: IOMUXC_GPIO_AD_B0_13_GPT1_CLK {
 		pinmux = <0x401f80f0 1 0x401f8760 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpi2c4_sda: IOMUXC_GPIO_AD_B0_13_LPI2C4_SDA {
 		pinmux = <0x401f80f0 0 0x401f84e8 1 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_lpuart1_rx: IOMUXC_GPIO_AD_B0_13_LPUART1_RX {
 		pinmux = <0x401f80f0 2 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_13_ref_24m_out: IOMUXC_GPIO_AD_B0_13_REF_24M_OUT {
 		pinmux = <0x401f80f0 7 0x0 0 0x401f82e0>;
 	};
-	iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_acmp2_in2: IOMUXC_GPIO_AD_B0_14_ACMP2_IN2 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_adc1_in3: IOMUXC_GPIO_AD_B0_14_ADC1_IN3 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_csi_vsync: IOMUXC_GPIO_AD_B0_14_CSI_VSYNC {
 		pinmux = <0x401f80f4 4 0x401f8428 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_enet_1588_event0_out: IOMUXC_GPIO_AD_B0_14_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f80f4 3 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan2_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN2_TX {
 		pinmux = <0x401f80f4 6 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_flexcan3_tx: IOMUXC_GPIO_AD_B0_14_FLEXCAN3_TX {
 		pinmux = <0x401f80f4 8 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio1_io14: IOMUXC_GPIO_AD_B0_14_GPIO1_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_gpio6_io14: IOMUXC_GPIO_AD_B0_14_GPIO6_IO14 {
 		pinmux = <0x401f80f4 5 0x0 0 0x401f82e4>;
 		gpr = <0x400ac068 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_lpuart1_cts_b: IOMUXC_GPIO_AD_B0_14_LPUART1_CTS_B {
 		pinmux = <0x401f80f4 2 0x0 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_usb_otg2_oc: IOMUXC_GPIO_AD_B0_14_USB_OTG2_OC {
 		pinmux = <0x401f80f4 0 0x401f85cc 0 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_14_xbar1_xbar_in24: IOMUXC_GPIO_AD_B0_14_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f80f4 1 0x401f8640 1 0x401f82e4>;
 	};
-	iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_acmp3_in2: IOMUXC_GPIO_AD_B0_15_ACMP3_IN2 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_adc1_in4: IOMUXC_GPIO_AD_B0_15_ADC1_IN4 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_csi_hsync: IOMUXC_GPIO_AD_B0_15_CSI_HSYNC {
 		pinmux = <0x401f80f8 4 0x401f8420 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_enet_1588_event0_in: IOMUXC_GPIO_AD_B0_15_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f80f8 3 0x401f8444 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan2_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN2_RX {
 		pinmux = <0x401f80f8 6 0x401f8450 2 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_flexcan3_rx: IOMUXC_GPIO_AD_B0_15_FLEXCAN3_RX {
 		pinmux = <0x401f80f8 8 0x401f878c 1 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio1_io15: IOMUXC_GPIO_AD_B0_15_GPIO1_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_gpio6_io15: IOMUXC_GPIO_AD_B0_15_GPIO6_IO15 {
 		pinmux = <0x401f80f8 5 0x0 0 0x401f82e8>;
 		gpr = <0x400ac068 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_lpuart1_rts_b: IOMUXC_GPIO_AD_B0_15_LPUART1_RTS_B {
 		pinmux = <0x401f80f8 2 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_usb_otg2_pwr: IOMUXC_GPIO_AD_B0_15_USB_OTG2_PWR {
 		pinmux = <0x401f80f8 0 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb: IOMUXC_GPIO_AD_B0_15_WDOG1_RST_B_DEB {
 		pinmux = <0x401f80f8 7 0x0 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b0_15_xbar1_xbar_in25: IOMUXC_GPIO_AD_B0_15_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f80f8 1 0x401f8650 0 0x401f82e8>;
 	};
-	iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_acmp4_in2: IOMUXC_GPIO_AD_B1_00_ACMP4_IN2 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc1_in5: IOMUXC_GPIO_AD_B1_00_ADC1_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_adc2_in5: IOMUXC_GPIO_AD_B1_00_ADC2_IN5 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_enet2_1588_event0_out: IOMUXC_GPIO_AD_B1_00_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f80fc 8 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_flexio3_flexio00: IOMUXC_GPIO_AD_B1_00_FLEXIO3_FLEXIO00 {
 		pinmux = <0x401f80fc 9 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio1_io16: IOMUXC_GPIO_AD_B1_00_GPIO1_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_gpio6_io16: IOMUXC_GPIO_AD_B1_00_GPIO6_IO16 {
 		pinmux = <0x401f80fc 5 0x0 0 0x401f82ec>;
 		gpr = <0x400ac068 0x10 0x1>;
 	};
-	iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_kpp_row7: IOMUXC_GPIO_AD_B1_00_KPP_ROW7 {
 		pinmux = <0x401f80fc 7 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpi2c1_scl: IOMUXC_GPIO_AD_B1_00_LPI2C1_SCL {
 		pinmux = <0x401f80fc 3 0x401f84cc 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_lpuart2_cts_b: IOMUXC_GPIO_AD_B1_00_LPUART2_CTS_B {
 		pinmux = <0x401f80fc 2 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_qtimer3_timer0: IOMUXC_GPIO_AD_B1_00_QTIMER3_TIMER0 {
 		pinmux = <0x401f80fc 1 0x401f857c 1 0x401f82ec>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usb_otg2_id: IOMUXC_GPIO_AD_B1_00_USB_OTG2_ID {
 		pinmux = <0x401f80fc 0 0x401f83f8 1 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_usdhc1_wp: IOMUXC_GPIO_AD_B1_00_USDHC1_WP {
 		pinmux = <0x401f80fc 6 0x401f85d8 2 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_00_wdog1_b: IOMUXC_GPIO_AD_B1_00_WDOG1_B {
 		pinmux = <0x401f80fc 4 0x0 0 0x401f82ec>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp1_in0: IOMUXC_GPIO_AD_B1_01_ACMP1_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp2_in0: IOMUXC_GPIO_AD_B1_01_ACMP2_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp3_in0: IOMUXC_GPIO_AD_B1_01_ACMP3_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_acmp4_in0: IOMUXC_GPIO_AD_B1_01_ACMP4_IN0 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc1_in6: IOMUXC_GPIO_AD_B1_01_ADC1_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_adc2_in6: IOMUXC_GPIO_AD_B1_01_ADC2_IN6 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_01_CCM_PMIC_RDY {
 		pinmux = <0x401f8100 4 0x401f83fc 2 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_enet2_1588_event0_in: IOMUXC_GPIO_AD_B1_01_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8100 8 0x401f8724 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_flexio3_flexio01: IOMUXC_GPIO_AD_B1_01_FLEXIO3_FLEXIO01 {
 		pinmux = <0x401f8100 9 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio1_io17: IOMUXC_GPIO_AD_B1_01_GPIO1_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_gpio6_io17: IOMUXC_GPIO_AD_B1_01_GPIO6_IO17 {
 		pinmux = <0x401f8100 5 0x0 0 0x401f82f0>;
 		gpr = <0x400ac068 0x11 0x1>;
 	};
-	iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_kpp_col7: IOMUXC_GPIO_AD_B1_01_KPP_COL7 {
 		pinmux = <0x401f8100 7 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpi2c1_sda: IOMUXC_GPIO_AD_B1_01_LPI2C1_SDA {
 		pinmux = <0x401f8100 3 0x401f84d0 1 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_lpuart2_rts_b: IOMUXC_GPIO_AD_B1_01_LPUART2_RTS_B {
 		pinmux = <0x401f8100 2 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_qtimer3_timer1: IOMUXC_GPIO_AD_B1_01_QTIMER3_TIMER1 {
 		pinmux = <0x401f8100 1 0x401f8580 0 0x401f82f0>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usb_otg1_pwr: IOMUXC_GPIO_AD_B1_01_USB_OTG1_PWR {
 		pinmux = <0x401f8100 0 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_01_usdhc1_vselect: IOMUXC_GPIO_AD_B1_01_USDHC1_VSELECT {
 		pinmux = <0x401f8100 6 0x0 0 0x401f82f0>;
 	};
-	iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_acmp1_in3: IOMUXC_GPIO_AD_B1_02_ACMP1_IN3 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc1_in7: IOMUXC_GPIO_AD_B1_02_ADC1_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_adc2_in7: IOMUXC_GPIO_AD_B1_02_ADC2_IN7 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_enet_1588_event2_out: IOMUXC_GPIO_AD_B1_02_ENET_1588_EVENT2_OUT {
 		pinmux = <0x401f8104 4 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_flexio3_flexio02: IOMUXC_GPIO_AD_B1_02_FLEXIO3_FLEXIO02 {
 		pinmux = <0x401f8104 9 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio1_io18: IOMUXC_GPIO_AD_B1_02_GPIO1_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpio6_io18: IOMUXC_GPIO_AD_B1_02_GPIO6_IO18 {
 		pinmux = <0x401f8104 5 0x0 0 0x401f82f4>;
 		gpr = <0x400ac068 0x12 0x1>;
 	};
-	iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_gpt2_clk: IOMUXC_GPIO_AD_B1_02_GPT2_CLK {
 		pinmux = <0x401f8104 8 0x401f876c 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_kpp_row6: IOMUXC_GPIO_AD_B1_02_KPP_ROW6 {
 		pinmux = <0x401f8104 7 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_lpuart2_tx: IOMUXC_GPIO_AD_B1_02_LPUART2_TX {
 		pinmux = <0x401f8104 2 0x401f8530 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_qtimer3_timer2: IOMUXC_GPIO_AD_B1_02_QTIMER3_TIMER2 {
 		pinmux = <0x401f8104 1 0x401f8584 1 0x401f82f4>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_spdif_out: IOMUXC_GPIO_AD_B1_02_SPDIF_OUT {
 		pinmux = <0x401f8104 3 0x0 0 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usb_otg1_id: IOMUXC_GPIO_AD_B1_02_USB_OTG1_ID {
 		pinmux = <0x401f8104 0 0x401f83f4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_02_usdhc1_cd_b: IOMUXC_GPIO_AD_B1_02_USDHC1_CD_B {
 		pinmux = <0x401f8104 6 0x401f85d4 1 0x401f82f4>;
 	};
-	iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_acmp2_in3: IOMUXC_GPIO_AD_B1_03_ACMP2_IN3 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc1_in8: IOMUXC_GPIO_AD_B1_03_ADC1_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_adc2_in8: IOMUXC_GPIO_AD_B1_03_ADC2_IN8 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_enet_1588_event2_in: IOMUXC_GPIO_AD_B1_03_ENET_1588_EVENT2_IN {
 		pinmux = <0x401f8108 4 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_flexio3_flexio03: IOMUXC_GPIO_AD_B1_03_FLEXIO3_FLEXIO03 {
 		pinmux = <0x401f8108 9 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio1_io19: IOMUXC_GPIO_AD_B1_03_GPIO1_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpio6_io19: IOMUXC_GPIO_AD_B1_03_GPIO6_IO19 {
 		pinmux = <0x401f8108 5 0x0 0 0x401f82f8>;
 		gpr = <0x400ac068 0x13 0x1>;
 	};
-	iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_gpt2_capture1: IOMUXC_GPIO_AD_B1_03_GPT2_CAPTURE1 {
 		pinmux = <0x401f8108 8 0x401f8764 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_kpp_col6: IOMUXC_GPIO_AD_B1_03_KPP_COL6 {
 		pinmux = <0x401f8108 7 0x0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_lpuart2_rx: IOMUXC_GPIO_AD_B1_03_LPUART2_RX {
 		pinmux = <0x401f8108 2 0x401f852c 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_qtimer3_timer3: IOMUXC_GPIO_AD_B1_03_QTIMER3_TIMER3 {
 		pinmux = <0x401f8108 1 0x401f8588 1 0x401f82f8>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_spdif_in: IOMUXC_GPIO_AD_B1_03_SPDIF_IN {
 		pinmux = <0x401f8108 3 0x401f85c8 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usb_otg1_oc: IOMUXC_GPIO_AD_B1_03_USB_OTG1_OC {
 		pinmux = <0x401f8108 0 0x401f85d0 1 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_03_usdhc2_cd_b: IOMUXC_GPIO_AD_B1_03_USDHC2_CD_B {
 		pinmux = <0x401f8108 6 0x401f85e0 0 0x401f82f8>;
 	};
-	iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_acmp3_in3: IOMUXC_GPIO_AD_B1_04_ACMP3_IN3 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc1_in9: IOMUXC_GPIO_AD_B1_04_ADC1_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_adc2_in9: IOMUXC_GPIO_AD_B1_04_ADC2_IN9 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_csi_pixclk: IOMUXC_GPIO_AD_B1_04_CSI_PIXCLK {
 		pinmux = <0x401f810c 4 0x401f8424 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_enet_mdc: IOMUXC_GPIO_AD_B1_04_ENET_MDC {
 		pinmux = <0x401f810c 1 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexio3_flexio04: IOMUXC_GPIO_AD_B1_04_FLEXIO3_FLEXIO04 {
 		pinmux = <0x401f810c 9 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_flexspi_b_data3: IOMUXC_GPIO_AD_B1_04_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f810c 0 0x401f84c4 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio1_io20: IOMUXC_GPIO_AD_B1_04_GPIO1_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x0>;
 	};
-	iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpio6_io20: IOMUXC_GPIO_AD_B1_04_GPIO6_IO20 {
 		pinmux = <0x401f810c 5 0x0 0 0x401f82fc>;
 		gpr = <0x400ac068 0x14 0x1>;
 	};
-	iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_gpt2_capture2: IOMUXC_GPIO_AD_B1_04_GPT2_CAPTURE2 {
 		pinmux = <0x401f810c 8 0x401f8768 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_kpp_row5: IOMUXC_GPIO_AD_B1_04_KPP_ROW5 {
 		pinmux = <0x401f810c 7 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_lpuart3_cts_b: IOMUXC_GPIO_AD_B1_04_LPUART3_CTS_B {
 		pinmux = <0x401f810c 2 0x401f8534 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_spdif_sr_clk: IOMUXC_GPIO_AD_B1_04_SPDIF_SR_CLK {
 		pinmux = <0x401f810c 3 0x0 0 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_04_usdhc2_data0: IOMUXC_GPIO_AD_B1_04_USDHC2_DATA0 {
 		pinmux = <0x401f810c 6 0x401f85e8 1 0x401f82fc>;
 	};
-	iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_acmp4_in3: IOMUXC_GPIO_AD_B1_05_ACMP4_IN3 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc1_in10: IOMUXC_GPIO_AD_B1_05_ADC1_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_adc2_in10: IOMUXC_GPIO_AD_B1_05_ADC2_IN10 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_csi_mclk: IOMUXC_GPIO_AD_B1_05_CSI_MCLK {
 		pinmux = <0x401f8110 4 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_enet_mdio: IOMUXC_GPIO_AD_B1_05_ENET_MDIO {
 		pinmux = <0x401f8110 1 0x401f8430 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexio3_flexio05: IOMUXC_GPIO_AD_B1_05_FLEXIO3_FLEXIO05 {
 		pinmux = <0x401f8110 9 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_flexspi_b_data2: IOMUXC_GPIO_AD_B1_05_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f8110 0 0x401f84c0 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio1_io21: IOMUXC_GPIO_AD_B1_05_GPIO1_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x0>;
 	};
-	iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpio6_io21: IOMUXC_GPIO_AD_B1_05_GPIO6_IO21 {
 		pinmux = <0x401f8110 5 0x0 0 0x401f8300>;
 		gpr = <0x400ac068 0x15 0x1>;
 	};
-	iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_gpt2_compare1: IOMUXC_GPIO_AD_B1_05_GPT2_COMPARE1 {
 		pinmux = <0x401f8110 8 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_kpp_col5: IOMUXC_GPIO_AD_B1_05_KPP_COL5 {
 		pinmux = <0x401f8110 7 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_lpuart3_rts_b: IOMUXC_GPIO_AD_B1_05_LPUART3_RTS_B {
 		pinmux = <0x401f8110 2 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_spdif_out: IOMUXC_GPIO_AD_B1_05_SPDIF_OUT {
 		pinmux = <0x401f8110 3 0x0 0 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_05_usdhc2_data1: IOMUXC_GPIO_AD_B1_05_USDHC2_DATA1 {
 		pinmux = <0x401f8110 6 0x401f85ec 1 0x401f8300>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp1_in1: IOMUXC_GPIO_AD_B1_06_ACMP1_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp2_in1: IOMUXC_GPIO_AD_B1_06_ACMP2_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp3_in1: IOMUXC_GPIO_AD_B1_06_ACMP3_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_acmp4_in1: IOMUXC_GPIO_AD_B1_06_ACMP4_IN1 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc1_in11: IOMUXC_GPIO_AD_B1_06_ADC1_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_adc2_in11: IOMUXC_GPIO_AD_B1_06_ADC2_IN11 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_csi_vsync: IOMUXC_GPIO_AD_B1_06_CSI_VSYNC {
 		pinmux = <0x401f8114 4 0x401f8428 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexio3_flexio06: IOMUXC_GPIO_AD_B1_06_FLEXIO3_FLEXIO06 {
 		pinmux = <0x401f8114 9 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_flexspi_b_data1: IOMUXC_GPIO_AD_B1_06_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f8114 0 0x401f84bc 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio1_io22: IOMUXC_GPIO_AD_B1_06_GPIO1_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x0>;
 	};
-	iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpio6_io22: IOMUXC_GPIO_AD_B1_06_GPIO6_IO22 {
 		pinmux = <0x401f8114 5 0x0 0 0x401f8304>;
 		gpr = <0x400ac068 0x16 0x1>;
 	};
-	iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_gpt2_compare2: IOMUXC_GPIO_AD_B1_06_GPT2_COMPARE2 {
 		pinmux = <0x401f8114 8 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_kpp_row4: IOMUXC_GPIO_AD_B1_06_KPP_ROW4 {
 		pinmux = <0x401f8114 7 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpi2c3_sda: IOMUXC_GPIO_AD_B1_06_LPI2C3_SDA {
 		pinmux = <0x401f8114 1 0x401f84e0 2 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_lpuart3_tx: IOMUXC_GPIO_AD_B1_06_LPUART3_TX {
 		pinmux = <0x401f8114 2 0x401f853c 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_spdif_lock: IOMUXC_GPIO_AD_B1_06_SPDIF_LOCK {
 		pinmux = <0x401f8114 3 0x0 0 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_06_usdhc2_data2: IOMUXC_GPIO_AD_B1_06_USDHC2_DATA2 {
 		pinmux = <0x401f8114 6 0x401f85f0 1 0x401f8304>;
 	};
-	iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_acmp1_in5: IOMUXC_GPIO_AD_B1_07_ACMP1_IN5 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc1_in12: IOMUXC_GPIO_AD_B1_07_ADC1_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_adc2_in12: IOMUXC_GPIO_AD_B1_07_ADC2_IN12 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_csi_hsync: IOMUXC_GPIO_AD_B1_07_CSI_HSYNC {
 		pinmux = <0x401f8118 4 0x401f8420 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexio3_flexio07: IOMUXC_GPIO_AD_B1_07_FLEXIO3_FLEXIO07 {
 		pinmux = <0x401f8118 9 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_flexspi_b_data0: IOMUXC_GPIO_AD_B1_07_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f8118 0 0x401f84b8 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio1_io23: IOMUXC_GPIO_AD_B1_07_GPIO1_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x0>;
 	};
-	iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpio6_io23: IOMUXC_GPIO_AD_B1_07_GPIO6_IO23 {
 		pinmux = <0x401f8118 5 0x0 0 0x401f8308>;
 		gpr = <0x400ac068 0x17 0x1>;
 	};
-	iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_gpt2_compare3: IOMUXC_GPIO_AD_B1_07_GPT2_COMPARE3 {
 		pinmux = <0x401f8118 8 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_kpp_col4: IOMUXC_GPIO_AD_B1_07_KPP_COL4 {
 		pinmux = <0x401f8118 7 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpi2c3_scl: IOMUXC_GPIO_AD_B1_07_LPI2C3_SCL {
 		pinmux = <0x401f8118 1 0x401f84dc 2 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_lpuart3_rx: IOMUXC_GPIO_AD_B1_07_LPUART3_RX {
 		pinmux = <0x401f8118 2 0x401f8538 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_spdif_ext_clk: IOMUXC_GPIO_AD_B1_07_SPDIF_EXT_CLK {
 		pinmux = <0x401f8118 3 0x0 0 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_07_usdhc2_data3: IOMUXC_GPIO_AD_B1_07_USDHC2_DATA3 {
 		pinmux = <0x401f8118 6 0x401f85f4 1 0x401f8308>;
 	};
-	iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_acmp2_in5: IOMUXC_GPIO_AD_B1_08_ACMP2_IN5 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc1_in13: IOMUXC_GPIO_AD_B1_08_ADC1_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_adc2_in13: IOMUXC_GPIO_AD_B1_08_ADC2_IN13 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_ccm_pmic_rdy: IOMUXC_GPIO_AD_B1_08_CCM_PMIC_RDY {
 		pinmux = <0x401f811c 3 0x401f83fc 3 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_csi_data09: IOMUXC_GPIO_AD_B1_08_CSI_DATA09 {
 		pinmux = <0x401f811c 4 0x401f841c 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexcan1_tx: IOMUXC_GPIO_AD_B1_08_FLEXCAN1_TX {
 		pinmux = <0x401f811c 2 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexio3_flexio08: IOMUXC_GPIO_AD_B1_08_FLEXIO3_FLEXIO08 {
 		pinmux = <0x401f811c 9 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexpwm4_pwma0: IOMUXC_GPIO_AD_B1_08_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f811c 1 0x401f8494 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_flexspi_a_ss1_b: IOMUXC_GPIO_AD_B1_08_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f811c 0 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio1_io24: IOMUXC_GPIO_AD_B1_08_GPIO1_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x0>;
 	};
-	iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_gpio6_io24: IOMUXC_GPIO_AD_B1_08_GPIO6_IO24 {
 		pinmux = <0x401f811c 5 0x0 0 0x401f830c>;
 		gpr = <0x400ac068 0x18 0x1>;
 	};
-	iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_kpp_row3: IOMUXC_GPIO_AD_B1_08_KPP_ROW3 {
 		pinmux = <0x401f811c 7 0x0 0 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_08_usdhc2_cmd: IOMUXC_GPIO_AD_B1_08_USDHC2_CMD {
 		pinmux = <0x401f811c 6 0x401f85e4 1 0x401f830c>;
 	};
-	iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_acmp3_in5: IOMUXC_GPIO_AD_B1_09_ACMP3_IN5 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc1_in14: IOMUXC_GPIO_AD_B1_09_ADC1_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_adc2_in14: IOMUXC_GPIO_AD_B1_09_ADC2_IN14 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_csi_data08: IOMUXC_GPIO_AD_B1_09_CSI_DATA08 {
 		pinmux = <0x401f8120 4 0x401f8418 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexcan1_rx: IOMUXC_GPIO_AD_B1_09_FLEXCAN1_RX {
 		pinmux = <0x401f8120 2 0x401f844c 2 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexio3_flexio09: IOMUXC_GPIO_AD_B1_09_FLEXIO3_FLEXIO09 {
 		pinmux = <0x401f8120 9 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexpwm4_pwma1: IOMUXC_GPIO_AD_B1_09_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f8120 1 0x401f8498 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_flexspi_a_dqs: IOMUXC_GPIO_AD_B1_09_FLEXSPI_A_DQS {
 		pinmux = <0x401f8120 0 0x401f84a4 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio1_io25: IOMUXC_GPIO_AD_B1_09_GPIO1_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x0>;
 	};
-	iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_gpio6_io25: IOMUXC_GPIO_AD_B1_09_GPIO6_IO25 {
 		pinmux = <0x401f8120 5 0x0 0 0x401f8310>;
 		gpr = <0x400ac068 0x19 0x1>;
 	};
-	iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_kpp_col3: IOMUXC_GPIO_AD_B1_09_KPP_COL3 {
 		pinmux = <0x401f8120 7 0x0 0 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_sai1_mclk: IOMUXC_GPIO_AD_B1_09_SAI1_MCLK {
 		pinmux = <0x401f8120 3 0x401f858c 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_09_usdhc2_clk: IOMUXC_GPIO_AD_B1_09_USDHC2_CLK {
 		pinmux = <0x401f8120 6 0x401f85dc 1 0x401f8310>;
 	};
-	iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_acmp4_in5: IOMUXC_GPIO_AD_B1_10_ACMP4_IN5 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc1_in15: IOMUXC_GPIO_AD_B1_10_ADC1_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_adc2_in15: IOMUXC_GPIO_AD_B1_10_ADC2_IN15 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_csi_data07: IOMUXC_GPIO_AD_B1_10_CSI_DATA07 {
 		pinmux = <0x401f8124 4 0x401f8414 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_enet2_1588_event1_out: IOMUXC_GPIO_AD_B1_10_ENET2_1588_EVENT1_OUT {
 		pinmux = <0x401f8124 8 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexio3_flexio10: IOMUXC_GPIO_AD_B1_10_FLEXIO3_FLEXIO10 {
 		pinmux = <0x401f8124 9 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_flexspi_a_data3: IOMUXC_GPIO_AD_B1_10_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8124 0 0x401f84b4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio1_io26: IOMUXC_GPIO_AD_B1_10_GPIO1_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x0>;
 	};
-	iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_gpio6_io26: IOMUXC_GPIO_AD_B1_10_GPIO6_IO26 {
 		pinmux = <0x401f8124 5 0x0 0 0x401f8314>;
 		gpr = <0x400ac068 0x1a 0x1>;
 	};
-	iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_kpp_row2: IOMUXC_GPIO_AD_B1_10_KPP_ROW2 {
 		pinmux = <0x401f8124 7 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_lpuart8_tx: IOMUXC_GPIO_AD_B1_10_LPUART8_TX {
 		pinmux = <0x401f8124 2 0x401f8564 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_sai1_rx_sync: IOMUXC_GPIO_AD_B1_10_SAI1_RX_SYNC {
 		pinmux = <0x401f8124 3 0x401f85a4 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_usdhc2_wp: IOMUXC_GPIO_AD_B1_10_USDHC2_WP {
 		pinmux = <0x401f8124 6 0x401f8608 1 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_10_wdog1_b: IOMUXC_GPIO_AD_B1_10_WDOG1_B {
 		pinmux = <0x401f8124 1 0x0 0 0x401f8314>;
 	};
-	iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_acmp1_in6: IOMUXC_GPIO_AD_B1_11_ACMP1_IN6 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc1_in0: IOMUXC_GPIO_AD_B1_11_ADC1_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_adc2_in0: IOMUXC_GPIO_AD_B1_11_ADC2_IN0 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_csi_data06: IOMUXC_GPIO_AD_B1_11_CSI_DATA06 {
 		pinmux = <0x401f8128 4 0x401f8410 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_enet2_1588_event1_in: IOMUXC_GPIO_AD_B1_11_ENET2_1588_EVENT1_IN {
 		pinmux = <0x401f8128 8 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_ewm_out_b: IOMUXC_GPIO_AD_B1_11_EWM_OUT_B {
 		pinmux = <0x401f8128 1 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexio3_flexio11: IOMUXC_GPIO_AD_B1_11_FLEXIO3_FLEXIO11 {
 		pinmux = <0x401f8128 9 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_flexspi_a_data2: IOMUXC_GPIO_AD_B1_11_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f8128 0 0x401f84b0 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio1_io27: IOMUXC_GPIO_AD_B1_11_GPIO1_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x0>;
 	};
-	iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_gpio6_io27: IOMUXC_GPIO_AD_B1_11_GPIO6_IO27 {
 		pinmux = <0x401f8128 5 0x0 0 0x401f8318>;
 		gpr = <0x400ac068 0x1b 0x1>;
 	};
-	iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_kpp_col2: IOMUXC_GPIO_AD_B1_11_KPP_COL2 {
 		pinmux = <0x401f8128 7 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_lpuart8_rx: IOMUXC_GPIO_AD_B1_11_LPUART8_RX {
 		pinmux = <0x401f8128 2 0x401f8560 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_sai1_rx_bclk: IOMUXC_GPIO_AD_B1_11_SAI1_RX_BCLK {
 		pinmux = <0x401f8128 3 0x401f8590 1 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_11_usdhc2_reset_b: IOMUXC_GPIO_AD_B1_11_USDHC2_RESET_B {
 		pinmux = <0x401f8128 6 0x0 0 0x401f8318>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp1_out: IOMUXC_GPIO_AD_B1_12_ACMP1_OUT {
 		pinmux = <0x401f812c 1 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_acmp2_in6: IOMUXC_GPIO_AD_B1_12_ACMP2_IN6 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_adc2_in1: IOMUXC_GPIO_AD_B1_12_ADC2_IN1 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_csi_data05: IOMUXC_GPIO_AD_B1_12_CSI_DATA05 {
 		pinmux = <0x401f812c 4 0x401f840c 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_enet2_1588_event2_out: IOMUXC_GPIO_AD_B1_12_ENET2_1588_EVENT2_OUT {
 		pinmux = <0x401f812c 8 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexio3_flexio12: IOMUXC_GPIO_AD_B1_12_FLEXIO3_FLEXIO12 {
 		pinmux = <0x401f812c 9 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_flexspi_a_data1: IOMUXC_GPIO_AD_B1_12_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f812c 0 0x401f84ac 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio1_io28: IOMUXC_GPIO_AD_B1_12_GPIO1_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x0>;
 	};
-	iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_gpio6_io28: IOMUXC_GPIO_AD_B1_12_GPIO6_IO28 {
 		pinmux = <0x401f812c 5 0x0 0 0x401f831c>;
 		gpr = <0x400ac068 0x1c 0x1>;
 	};
-	iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_kpp_row1: IOMUXC_GPIO_AD_B1_12_KPP_ROW1 {
 		pinmux = <0x401f812c 7 0x0 0 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_lpspi3_pcs0: IOMUXC_GPIO_AD_B1_12_LPSPI3_PCS0 {
 		pinmux = <0x401f812c 2 0x401f850c 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_sai1_rx_data0: IOMUXC_GPIO_AD_B1_12_SAI1_RX_DATA0 {
 		pinmux = <0x401f812c 3 0x401f8594 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_12_usdhc2_data4: IOMUXC_GPIO_AD_B1_12_USDHC2_DATA4 {
 		pinmux = <0x401f812c 6 0x401f85f8 1 0x401f831c>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp2_out: IOMUXC_GPIO_AD_B1_13_ACMP2_OUT {
 		pinmux = <0x401f8130 1 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_acmp3_in6: IOMUXC_GPIO_AD_B1_13_ACMP3_IN6 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_adc2_in2: IOMUXC_GPIO_AD_B1_13_ADC2_IN2 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_csi_data04: IOMUXC_GPIO_AD_B1_13_CSI_DATA04 {
 		pinmux = <0x401f8130 4 0x401f8408 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_enet2_1588_event2_in: IOMUXC_GPIO_AD_B1_13_ENET2_1588_EVENT2_IN {
 		pinmux = <0x401f8130 8 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexio3_flexio13: IOMUXC_GPIO_AD_B1_13_FLEXIO3_FLEXIO13 {
 		pinmux = <0x401f8130 9 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_flexspi_a_data0: IOMUXC_GPIO_AD_B1_13_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f8130 0 0x401f84a8 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio1_io29: IOMUXC_GPIO_AD_B1_13_GPIO1_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x0>;
 	};
-	iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_gpio6_io29: IOMUXC_GPIO_AD_B1_13_GPIO6_IO29 {
 		pinmux = <0x401f8130 5 0x0 0 0x401f8320>;
 		gpr = <0x400ac068 0x1d 0x1>;
 	};
-	iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_kpp_col1: IOMUXC_GPIO_AD_B1_13_KPP_COL1 {
 		pinmux = <0x401f8130 7 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_lpspi3_sdi: IOMUXC_GPIO_AD_B1_13_LPSPI3_SDI {
 		pinmux = <0x401f8130 2 0x401f8514 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_sai1_tx_data0: IOMUXC_GPIO_AD_B1_13_SAI1_TX_DATA0 {
 		pinmux = <0x401f8130 3 0x0 0 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_13_usdhc2_data5: IOMUXC_GPIO_AD_B1_13_USDHC2_DATA5 {
 		pinmux = <0x401f8130 6 0x401f85fc 1 0x401f8320>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp3_out: IOMUXC_GPIO_AD_B1_14_ACMP3_OUT {
 		pinmux = <0x401f8134 1 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_acmp4_in6: IOMUXC_GPIO_AD_B1_14_ACMP4_IN6 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_adc2_in3: IOMUXC_GPIO_AD_B1_14_ADC2_IN3 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_csi_data03: IOMUXC_GPIO_AD_B1_14_CSI_DATA03 {
 		pinmux = <0x401f8134 4 0x401f8404 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_enet2_1588_event3_out: IOMUXC_GPIO_AD_B1_14_ENET2_1588_EVENT3_OUT {
 		pinmux = <0x401f8134 8 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexio3_flexio14: IOMUXC_GPIO_AD_B1_14_FLEXIO3_FLEXIO14 {
 		pinmux = <0x401f8134 9 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_flexspi_a_sclk: IOMUXC_GPIO_AD_B1_14_FLEXSPI_A_SCLK {
 		pinmux = <0x401f8134 0 0x401f84c8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio1_io30: IOMUXC_GPIO_AD_B1_14_GPIO1_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x0>;
 	};
-	iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_gpio6_io30: IOMUXC_GPIO_AD_B1_14_GPIO6_IO30 {
 		pinmux = <0x401f8134 5 0x0 0 0x401f8324>;
 		gpr = <0x400ac068 0x1e 0x1>;
 	};
-	iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_kpp_row0: IOMUXC_GPIO_AD_B1_14_KPP_ROW0 {
 		pinmux = <0x401f8134 7 0x0 0 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_lpspi3_sdo: IOMUXC_GPIO_AD_B1_14_LPSPI3_SDO {
 		pinmux = <0x401f8134 2 0x401f8518 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_sai1_tx_bclk: IOMUXC_GPIO_AD_B1_14_SAI1_TX_BCLK {
 		pinmux = <0x401f8134 3 0x401f85a8 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_14_usdhc2_data6: IOMUXC_GPIO_AD_B1_14_USDHC2_DATA6 {
 		pinmux = <0x401f8134 6 0x401f8600 1 0x401f8324>;
 	};
-	iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_acmp4_out: IOMUXC_GPIO_AD_B1_15_ACMP4_OUT {
 		pinmux = <0x401f8138 1 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_adc2_in4: IOMUXC_GPIO_AD_B1_15_ADC2_IN4 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_csi_data02: IOMUXC_GPIO_AD_B1_15_CSI_DATA02 {
 		pinmux = <0x401f8138 4 0x401f8400 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_enet2_1588_event3_in: IOMUXC_GPIO_AD_B1_15_ENET2_1588_EVENT3_IN {
 		pinmux = <0x401f8138 8 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexio3_flexio15: IOMUXC_GPIO_AD_B1_15_FLEXIO3_FLEXIO15 {
 		pinmux = <0x401f8138 9 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_flexspi_a_ss0_b: IOMUXC_GPIO_AD_B1_15_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f8138 0 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio1_io31: IOMUXC_GPIO_AD_B1_15_GPIO1_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x0>;
 	};
-	iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_gpio6_io31: IOMUXC_GPIO_AD_B1_15_GPIO6_IO31 {
 		pinmux = <0x401f8138 5 0x0 0 0x401f8328>;
 		gpr = <0x400ac068 0x1f 0x1>;
 	};
-	iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_kpp_col0: IOMUXC_GPIO_AD_B1_15_KPP_COL0 {
 		pinmux = <0x401f8138 7 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_lpspi3_sck: IOMUXC_GPIO_AD_B1_15_LPSPI3_SCK {
 		pinmux = <0x401f8138 2 0x0 0 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_sai1_tx_sync: IOMUXC_GPIO_AD_B1_15_SAI1_TX_SYNC {
 		pinmux = <0x401f8138 3 0x401f85ac 1 0x401f8328>;
 	};
-	iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_b1_15_usdhc2_data7: IOMUXC_GPIO_AD_B1_15_USDHC2_DATA7 {
 		pinmux = <0x401f8138 6 0x401f8604 1 0x401f8328>;
 	};
-	iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_enet2_mdc: IOMUXC_GPIO_B0_00_ENET2_MDC {
 		pinmux = <0x401f813c 8 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_flexio2_flexio00: IOMUXC_GPIO_B0_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x401f813c 4 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio2_io00: IOMUXC_GPIO_B0_00_GPIO2_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_gpio7_io00: IOMUXC_GPIO_B0_00_GPIO7_IO00 {
 		pinmux = <0x401f813c 5 0x0 0 0x401f832c>;
 		gpr = <0x400ac06c 0x0 0x1>;
 	};
-	iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lcdif_clk: IOMUXC_GPIO_B0_00_LCDIF_CLK {
 		pinmux = <0x401f813c 0 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_lpspi4_pcs0: IOMUXC_GPIO_B0_00_LPSPI4_PCS0 {
 		pinmux = <0x401f813c 3 0x401f851c 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_mqs_right: IOMUXC_GPIO_B0_00_MQS_RIGHT {
 		pinmux = <0x401f813c 2 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_qtimer1_timer0: IOMUXC_GPIO_B0_00_QTIMER1_TIMER0 {
 		pinmux = <0x401f813c 1 0x0 0 0x401f832c>;
 		gpr = <0x400ac018 0x0 0x0>;
 	};
-	iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_00_semc_csx1: IOMUXC_GPIO_B0_00_SEMC_CSX1 {
 		pinmux = <0x401f813c 6 0x0 0 0x401f832c>;
 	};
-	iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_enet2_mdio: IOMUXC_GPIO_B0_01_ENET2_MDIO {
 		pinmux = <0x401f8140 8 0x401f8710 1 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_flexio2_flexio01: IOMUXC_GPIO_B0_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x401f8140 4 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio2_io01: IOMUXC_GPIO_B0_01_GPIO2_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_gpio7_io01: IOMUXC_GPIO_B0_01_GPIO7_IO01 {
 		pinmux = <0x401f8140 5 0x0 0 0x401f8330>;
 		gpr = <0x400ac06c 0x1 0x1>;
 	};
-	iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lcdif_enable: IOMUXC_GPIO_B0_01_LCDIF_ENABLE {
 		pinmux = <0x401f8140 0 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_lpspi4_sdi: IOMUXC_GPIO_B0_01_LPSPI4_SDI {
 		pinmux = <0x401f8140 3 0x401f8524 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_mqs_left: IOMUXC_GPIO_B0_01_MQS_LEFT {
 		pinmux = <0x401f8140 2 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_qtimer1_timer1: IOMUXC_GPIO_B0_01_QTIMER1_TIMER1 {
 		pinmux = <0x401f8140 1 0x0 0 0x401f8330>;
 		gpr = <0x400ac018 0x1 0x0>;
 	};
-	iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_01_semc_csx2: IOMUXC_GPIO_B0_01_SEMC_CSX2 {
 		pinmux = <0x401f8140 6 0x0 0 0x401f8330>;
 	};
-	iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_enet2_1588_event0_out: IOMUXC_GPIO_B0_02_ENET2_1588_EVENT0_OUT {
 		pinmux = <0x401f8144 8 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexcan1_tx: IOMUXC_GPIO_B0_02_FLEXCAN1_TX {
 		pinmux = <0x401f8144 2 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_flexio2_flexio02: IOMUXC_GPIO_B0_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x401f8144 4 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio2_io02: IOMUXC_GPIO_B0_02_GPIO2_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_gpio7_io02: IOMUXC_GPIO_B0_02_GPIO7_IO02 {
 		pinmux = <0x401f8144 5 0x0 0 0x401f8334>;
 		gpr = <0x400ac06c 0x2 0x1>;
 	};
-	iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lcdif_hsync: IOMUXC_GPIO_B0_02_LCDIF_HSYNC {
 		pinmux = <0x401f8144 0 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_lpspi4_sdo: IOMUXC_GPIO_B0_02_LPSPI4_SDO {
 		pinmux = <0x401f8144 3 0x401f8528 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_qtimer1_timer2: IOMUXC_GPIO_B0_02_QTIMER1_TIMER2 {
 		pinmux = <0x401f8144 1 0x0 0 0x401f8334>;
 		gpr = <0x400ac018 0x2 0x0>;
 	};
-	iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_02_semc_csx3: IOMUXC_GPIO_B0_02_SEMC_CSX3 {
 		pinmux = <0x401f8144 6 0x0 0 0x401f8334>;
 	};
-	iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_enet2_1588_event0_in: IOMUXC_GPIO_B0_03_ENET2_1588_EVENT0_IN {
 		pinmux = <0x401f8148 8 0x401f8724 1 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexcan1_rx: IOMUXC_GPIO_B0_03_FLEXCAN1_RX {
 		pinmux = <0x401f8148 2 0x401f844c 3 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_flexio2_flexio03: IOMUXC_GPIO_B0_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x401f8148 4 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio2_io03: IOMUXC_GPIO_B0_03_GPIO2_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x0>;
 	};
-	iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_gpio7_io03: IOMUXC_GPIO_B0_03_GPIO7_IO03 {
 		pinmux = <0x401f8148 5 0x0 0 0x401f8338>;
 		gpr = <0x400ac06c 0x3 0x1>;
 	};
-	iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lcdif_vsync: IOMUXC_GPIO_B0_03_LCDIF_VSYNC {
 		pinmux = <0x401f8148 0 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_lpspi4_sck: IOMUXC_GPIO_B0_03_LPSPI4_SCK {
 		pinmux = <0x401f8148 3 0x401f8520 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_qtimer2_timer0: IOMUXC_GPIO_B0_03_QTIMER2_TIMER0 {
 		pinmux = <0x401f8148 1 0x401f856c 1 0x401f8338>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_b0_03_wdog2_rst_b_deb: IOMUXC_GPIO_B0_03_WDOG2_RST_B_DEB {
 		pinmux = <0x401f8148 6 0x0 0 0x401f8338>;
 	};
-	iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_arm_trace0: IOMUXC_GPIO_B0_04_ARM_TRACE0 {
 		pinmux = <0x401f814c 3 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_enet2_tx_data3: IOMUXC_GPIO_B0_04_ENET2_TX_DATA3 {
 		pinmux = <0x401f814c 8 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_flexio2_flexio04: IOMUXC_GPIO_B0_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x401f814c 4 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio2_io04: IOMUXC_GPIO_B0_04_GPIO2_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x0>;
 	};
-	iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_gpio7_io04: IOMUXC_GPIO_B0_04_GPIO7_IO04 {
 		pinmux = <0x401f814c 5 0x0 0 0x401f833c>;
 		gpr = <0x400ac06c 0x4 0x1>;
 	};
-	iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lcdif_data00: IOMUXC_GPIO_B0_04_LCDIF_DATA00 {
 		pinmux = <0x401f814c 0 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_lpi2c2_scl: IOMUXC_GPIO_B0_04_LPI2C2_SCL {
 		pinmux = <0x401f814c 2 0x401f84d4 1 0x401f833c>;
 	};
-	iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_qtimer2_timer1: IOMUXC_GPIO_B0_04_QTIMER2_TIMER1 {
 		pinmux = <0x401f814c 1 0x401f8570 1 0x401f833c>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_04_src_bt_cfg0: IOMUXC_GPIO_B0_04_SRC_BT_CFG0 {
 		pinmux = <0x401f814c 6 0x0 0 0x401f833c>;
 	};
-	iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_arm_trace1: IOMUXC_GPIO_B0_05_ARM_TRACE1 {
 		pinmux = <0x401f8150 3 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_enet2_tx_data2: IOMUXC_GPIO_B0_05_ENET2_TX_DATA2 {
 		pinmux = <0x401f8150 8 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_flexio2_flexio05: IOMUXC_GPIO_B0_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x401f8150 4 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio2_io05: IOMUXC_GPIO_B0_05_GPIO2_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x0>;
 	};
-	iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_gpio7_io05: IOMUXC_GPIO_B0_05_GPIO7_IO05 {
 		pinmux = <0x401f8150 5 0x0 0 0x401f8340>;
 		gpr = <0x400ac06c 0x5 0x1>;
 	};
-	iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lcdif_data01: IOMUXC_GPIO_B0_05_LCDIF_DATA01 {
 		pinmux = <0x401f8150 0 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_lpi2c2_sda: IOMUXC_GPIO_B0_05_LPI2C2_SDA {
 		pinmux = <0x401f8150 2 0x401f84d8 1 0x401f8340>;
 	};
-	iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_qtimer2_timer2: IOMUXC_GPIO_B0_05_QTIMER2_TIMER2 {
 		pinmux = <0x401f8150 1 0x401f8574 1 0x401f8340>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_05_src_bt_cfg1: IOMUXC_GPIO_B0_05_SRC_BT_CFG1 {
 		pinmux = <0x401f8150 6 0x0 0 0x401f8340>;
 	};
-	iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_arm_trace2: IOMUXC_GPIO_B0_06_ARM_TRACE2 {
 		pinmux = <0x401f8154 3 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_enet2_rx_clk: IOMUXC_GPIO_B0_06_ENET2_RX_CLK {
 		pinmux = <0x401f8154 8 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexio2_flexio06: IOMUXC_GPIO_B0_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x401f8154 4 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_flexpwm2_pwma0: IOMUXC_GPIO_B0_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f8154 2 0x401f8478 1 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio2_io06: IOMUXC_GPIO_B0_06_GPIO2_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x0>;
 	};
-	iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_gpio7_io06: IOMUXC_GPIO_B0_06_GPIO7_IO06 {
 		pinmux = <0x401f8154 5 0x0 0 0x401f8344>;
 		gpr = <0x400ac06c 0x6 0x1>;
 	};
-	iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_lcdif_data02: IOMUXC_GPIO_B0_06_LCDIF_DATA02 {
 		pinmux = <0x401f8154 0 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_qtimer3_timer0: IOMUXC_GPIO_B0_06_QTIMER3_TIMER0 {
 		pinmux = <0x401f8154 1 0x401f857c 2 0x401f8344>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_06_src_bt_cfg2: IOMUXC_GPIO_B0_06_SRC_BT_CFG2 {
 		pinmux = <0x401f8154 6 0x0 0 0x401f8344>;
 	};
-	iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_arm_trace3: IOMUXC_GPIO_B0_07_ARM_TRACE3 {
 		pinmux = <0x401f8158 3 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_enet2_tx_er: IOMUXC_GPIO_B0_07_ENET2_TX_ER {
 		pinmux = <0x401f8158 8 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexio2_flexio07: IOMUXC_GPIO_B0_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x401f8158 4 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_flexpwm2_pwmb0: IOMUXC_GPIO_B0_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8158 2 0x401f8488 1 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio2_io07: IOMUXC_GPIO_B0_07_GPIO2_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x0>;
 	};
-	iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_gpio7_io07: IOMUXC_GPIO_B0_07_GPIO7_IO07 {
 		pinmux = <0x401f8158 5 0x0 0 0x401f8348>;
 		gpr = <0x400ac06c 0x7 0x1>;
 	};
-	iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_lcdif_data03: IOMUXC_GPIO_B0_07_LCDIF_DATA03 {
 		pinmux = <0x401f8158 0 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_qtimer3_timer1: IOMUXC_GPIO_B0_07_QTIMER3_TIMER1 {
 		pinmux = <0x401f8158 1 0x401f8580 2 0x401f8348>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_07_src_bt_cfg3: IOMUXC_GPIO_B0_07_SRC_BT_CFG3 {
 		pinmux = <0x401f8158 6 0x0 0 0x401f8348>;
 	};
-	iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_enet2_rx_data3: IOMUXC_GPIO_B0_08_ENET2_RX_DATA3 {
 		pinmux = <0x401f815c 8 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexio2_flexio08: IOMUXC_GPIO_B0_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x401f815c 4 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_flexpwm2_pwma1: IOMUXC_GPIO_B0_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f815c 2 0x401f847c 1 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio2_io08: IOMUXC_GPIO_B0_08_GPIO2_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x0>;
 	};
-	iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_gpio7_io08: IOMUXC_GPIO_B0_08_GPIO7_IO08 {
 		pinmux = <0x401f815c 5 0x0 0 0x401f834c>;
 		gpr = <0x400ac06c 0x8 0x1>;
 	};
-	iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lcdif_data04: IOMUXC_GPIO_B0_08_LCDIF_DATA04 {
 		pinmux = <0x401f815c 0 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_lpuart3_tx: IOMUXC_GPIO_B0_08_LPUART3_TX {
 		pinmux = <0x401f815c 3 0x401f853c 2 0x401f834c>;
 	};
-	iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_qtimer3_timer2: IOMUXC_GPIO_B0_08_QTIMER3_TIMER2 {
 		pinmux = <0x401f815c 1 0x401f8584 2 0x401f834c>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_08_src_bt_cfg4: IOMUXC_GPIO_B0_08_SRC_BT_CFG4 {
 		pinmux = <0x401f815c 6 0x0 0 0x401f834c>;
 	};
-	iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_enet2_rx_data2: IOMUXC_GPIO_B0_09_ENET2_RX_DATA2 {
 		pinmux = <0x401f8160 8 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexio2_flexio09: IOMUXC_GPIO_B0_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x401f8160 4 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_flexpwm2_pwmb1: IOMUXC_GPIO_B0_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8160 2 0x401f848c 1 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio2_io09: IOMUXC_GPIO_B0_09_GPIO2_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x0>;
 	};
-	iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_gpio7_io09: IOMUXC_GPIO_B0_09_GPIO7_IO09 {
 		pinmux = <0x401f8160 5 0x0 0 0x401f8350>;
 		gpr = <0x400ac06c 0x9 0x1>;
 	};
-	iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lcdif_data05: IOMUXC_GPIO_B0_09_LCDIF_DATA05 {
 		pinmux = <0x401f8160 0 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_lpuart3_rx: IOMUXC_GPIO_B0_09_LPUART3_RX {
 		pinmux = <0x401f8160 3 0x401f8538 2 0x401f8350>;
 	};
-	iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_qtimer4_timer0: IOMUXC_GPIO_B0_09_QTIMER4_TIMER0 {
 		pinmux = <0x401f8160 1 0x0 0 0x401f8350>;
 		gpr = <0x400ac018 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_09_src_bt_cfg5: IOMUXC_GPIO_B0_09_SRC_BT_CFG5 {
 		pinmux = <0x401f8160 6 0x0 0 0x401f8350>;
 	};
-	iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_enet2_crs: IOMUXC_GPIO_B0_10_ENET2_CRS {
 		pinmux = <0x401f8164 8 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexio2_flexio10: IOMUXC_GPIO_B0_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x401f8164 4 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_flexpwm2_pwma2: IOMUXC_GPIO_B0_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f8164 2 0x401f8480 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio2_io10: IOMUXC_GPIO_B0_10_GPIO2_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x0>;
 	};
-	iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_gpio7_io10: IOMUXC_GPIO_B0_10_GPIO7_IO10 {
 		pinmux = <0x401f8164 5 0x0 0 0x401f8354>;
 		gpr = <0x400ac06c 0xa 0x1>;
 	};
-	iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_lcdif_data06: IOMUXC_GPIO_B0_10_LCDIF_DATA06 {
 		pinmux = <0x401f8164 0 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_qtimer4_timer1: IOMUXC_GPIO_B0_10_QTIMER4_TIMER1 {
 		pinmux = <0x401f8164 1 0x0 0 0x401f8354>;
 		gpr = <0x400ac018 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_sai1_tx_data3: IOMUXC_GPIO_B0_10_SAI1_TX_DATA3 {
 		pinmux = <0x401f8164 3 0x401f8598 1 0x401f8354>;
 	};
-	iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_10_src_bt_cfg6: IOMUXC_GPIO_B0_10_SRC_BT_CFG6 {
 		pinmux = <0x401f8164 6 0x0 0 0x401f8354>;
 	};
-	iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_enet2_col: IOMUXC_GPIO_B0_11_ENET2_COL {
 		pinmux = <0x401f8168 8 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexio2_flexio11: IOMUXC_GPIO_B0_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x401f8168 4 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_flexpwm2_pwmb2: IOMUXC_GPIO_B0_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8168 2 0x401f8490 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio2_io11: IOMUXC_GPIO_B0_11_GPIO2_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x0>;
 	};
-	iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_gpio7_io11: IOMUXC_GPIO_B0_11_GPIO7_IO11 {
 		pinmux = <0x401f8168 5 0x0 0 0x401f8358>;
 		gpr = <0x400ac06c 0xb 0x1>;
 	};
-	iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_lcdif_data07: IOMUXC_GPIO_B0_11_LCDIF_DATA07 {
 		pinmux = <0x401f8168 0 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_qtimer4_timer2: IOMUXC_GPIO_B0_11_QTIMER4_TIMER2 {
 		pinmux = <0x401f8168 1 0x0 0 0x401f8358>;
 		gpr = <0x400ac018 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_sai1_tx_data2: IOMUXC_GPIO_B0_11_SAI1_TX_DATA2 {
 		pinmux = <0x401f8168 3 0x401f859c 1 0x401f8358>;
 	};
-	iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_11_src_bt_cfg7: IOMUXC_GPIO_B0_11_SRC_BT_CFG7 {
 		pinmux = <0x401f8168 6 0x0 0 0x401f8358>;
 	};
-	iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_arm_trace_clk: IOMUXC_GPIO_B0_12_ARM_TRACE_CLK {
 		pinmux = <0x401f816c 2 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_enet2_tx_data0: IOMUXC_GPIO_B0_12_ENET2_TX_DATA0 {
 		pinmux = <0x401f816c 8 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_flexio2_flexio12: IOMUXC_GPIO_B0_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x401f816c 4 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio2_io12: IOMUXC_GPIO_B0_12_GPIO2_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x0>;
 	};
-	iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_gpio7_io12: IOMUXC_GPIO_B0_12_GPIO7_IO12 {
 		pinmux = <0x401f816c 5 0x0 0 0x401f835c>;
 		gpr = <0x400ac06c 0xc 0x1>;
 	};
-	iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_lcdif_data08: IOMUXC_GPIO_B0_12_LCDIF_DATA08 {
 		pinmux = <0x401f816c 0 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_sai1_tx_data1: IOMUXC_GPIO_B0_12_SAI1_TX_DATA1 {
 		pinmux = <0x401f816c 3 0x401f85a0 1 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_src_bt_cfg8: IOMUXC_GPIO_B0_12_SRC_BT_CFG8 {
 		pinmux = <0x401f816c 6 0x0 0 0x401f835c>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_in10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_IN10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_12_xbar1_xbar_inout10: IOMUXC_GPIO_B0_12_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x401f816c 1 0x0 0 0x401f835c>;
 		gpr = <0x400ac018 0x16 0x0>;
 	};
-	iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_arm_trace_swo: IOMUXC_GPIO_B0_13_ARM_TRACE_SWO {
 		pinmux = <0x401f8170 2 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_enet2_tx_data1: IOMUXC_GPIO_B0_13_ENET2_TX_DATA1 {
 		pinmux = <0x401f8170 8 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_flexio2_flexio13: IOMUXC_GPIO_B0_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x401f8170 4 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio2_io13: IOMUXC_GPIO_B0_13_GPIO2_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x0>;
 	};
-	iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_gpio7_io13: IOMUXC_GPIO_B0_13_GPIO7_IO13 {
 		pinmux = <0x401f8170 5 0x0 0 0x401f8360>;
 		gpr = <0x400ac06c 0xd 0x1>;
 	};
-	iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_lcdif_data09: IOMUXC_GPIO_B0_13_LCDIF_DATA09 {
 		pinmux = <0x401f8170 0 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_sai1_mclk: IOMUXC_GPIO_B0_13_SAI1_MCLK {
 		pinmux = <0x401f8170 3 0x401f858c 2 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_src_bt_cfg9: IOMUXC_GPIO_B0_13_SRC_BT_CFG9 {
 		pinmux = <0x401f8170 6 0x0 0 0x401f8360>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_in11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_IN11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_13_xbar1_xbar_inout11: IOMUXC_GPIO_B0_13_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x401f8170 1 0x0 0 0x401f8360>;
 		gpr = <0x400ac018 0x17 0x0>;
 	};
-	iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_arm_txev: IOMUXC_GPIO_B0_14_ARM_TXEV {
 		pinmux = <0x401f8174 2 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_enet2_tx_en: IOMUXC_GPIO_B0_14_ENET2_TX_EN {
 		pinmux = <0x401f8174 8 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_flexio2_flexio14: IOMUXC_GPIO_B0_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x401f8174 4 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio2_io14: IOMUXC_GPIO_B0_14_GPIO2_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x0>;
 	};
-	iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_gpio7_io14: IOMUXC_GPIO_B0_14_GPIO7_IO14 {
 		pinmux = <0x401f8174 5 0x0 0 0x401f8364>;
 		gpr = <0x400ac06c 0xe 0x1>;
 	};
-	iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_lcdif_data10: IOMUXC_GPIO_B0_14_LCDIF_DATA10 {
 		pinmux = <0x401f8174 0 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_sai1_rx_sync: IOMUXC_GPIO_B0_14_SAI1_RX_SYNC {
 		pinmux = <0x401f8174 3 0x401f85a4 2 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_src_bt_cfg10: IOMUXC_GPIO_B0_14_SRC_BT_CFG10 {
 		pinmux = <0x401f8174 6 0x0 0 0x401f8364>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_in12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_IN12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_14_xbar1_xbar_inout12: IOMUXC_GPIO_B0_14_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x401f8174 1 0x0 0 0x401f8364>;
 		gpr = <0x400ac018 0x18 0x0>;
 	};
-	iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_arm_rxev: IOMUXC_GPIO_B0_15_ARM_RXEV {
 		pinmux = <0x401f8178 2 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_ref_clk2: IOMUXC_GPIO_B0_15_ENET2_REF_CLK2 {
 		pinmux = <0x401f8178 9 0x401f870c 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_enet2_tx_clk: IOMUXC_GPIO_B0_15_ENET2_TX_CLK {
 		pinmux = <0x401f8178 8 0x401f8728 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_flexio2_flexio15: IOMUXC_GPIO_B0_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x401f8178 4 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio2_io15: IOMUXC_GPIO_B0_15_GPIO2_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x0>;
 	};
-	iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_gpio7_io15: IOMUXC_GPIO_B0_15_GPIO7_IO15 {
 		pinmux = <0x401f8178 5 0x0 0 0x401f8368>;
 		gpr = <0x400ac06c 0xf 0x1>;
 	};
-	iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_lcdif_data11: IOMUXC_GPIO_B0_15_LCDIF_DATA11 {
 		pinmux = <0x401f8178 0 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_sai1_rx_bclk: IOMUXC_GPIO_B0_15_SAI1_RX_BCLK {
 		pinmux = <0x401f8178 3 0x401f8590 2 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_src_bt_cfg11: IOMUXC_GPIO_B0_15_SRC_BT_CFG11 {
 		pinmux = <0x401f8178 6 0x0 0 0x401f8368>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_in13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_IN13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_b0_15_xbar1_xbar_inout13: IOMUXC_GPIO_B0_15_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x401f8178 1 0x0 0 0x401f8368>;
 		gpr = <0x400ac018 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_enet2_rx_er: IOMUXC_GPIO_B1_00_ENET2_RX_ER {
 		pinmux = <0x401f817c 8 0x401f8720 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio2_flexio16: IOMUXC_GPIO_B1_00_FLEXIO2_FLEXIO16 {
 		pinmux = <0x401f817c 4 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexio3_flexio16: IOMUXC_GPIO_B1_00_FLEXIO3_FLEXIO16 {
 		pinmux = <0x401f817c 9 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f817c 6 0x401f8454 4 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio2_io16: IOMUXC_GPIO_B1_00_GPIO2_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x0>;
 	};
-	iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_gpio7_io16: IOMUXC_GPIO_B1_00_GPIO7_IO16 {
 		pinmux = <0x401f817c 5 0x0 0 0x401f836c>;
 		gpr = <0x400ac06c 0x10 0x1>;
 	};
-	iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lcdif_data12: IOMUXC_GPIO_B1_00_LCDIF_DATA12 {
 		pinmux = <0x401f817c 0 0x0 0 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_lpuart4_tx: IOMUXC_GPIO_B1_00_LPUART4_TX {
 		pinmux = <0x401f817c 2 0x401f8544 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_sai1_rx_data0: IOMUXC_GPIO_B1_00_SAI1_RX_DATA0 {
 		pinmux = <0x401f817c 3 0x401f8594 2 0x401f836c>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_in14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_IN14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_00_xbar1_xbar_inout14: IOMUXC_GPIO_B1_00_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x401f817c 1 0x401f8644 1 0x401f836c>;
 		gpr = <0x400ac018 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_enet2_rx_data0: IOMUXC_GPIO_B1_01_ENET2_RX_DATA0 {
 		pinmux = <0x401f8180 8 0x401f8714 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio2_flexio17: IOMUXC_GPIO_B1_01_FLEXIO2_FLEXIO17 {
 		pinmux = <0x401f8180 4 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexio3_flexio17: IOMUXC_GPIO_B1_01_FLEXIO3_FLEXIO17 {
 		pinmux = <0x401f8180 9 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8180 6 0x401f8464 4 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio2_io17: IOMUXC_GPIO_B1_01_GPIO2_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x0>;
 	};
-	iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_gpio7_io17: IOMUXC_GPIO_B1_01_GPIO7_IO17 {
 		pinmux = <0x401f8180 5 0x0 0 0x401f8370>;
 		gpr = <0x400ac06c 0x11 0x1>;
 	};
-	iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lcdif_data13: IOMUXC_GPIO_B1_01_LCDIF_DATA13 {
 		pinmux = <0x401f8180 0 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_lpuart4_rx: IOMUXC_GPIO_B1_01_LPUART4_RX {
 		pinmux = <0x401f8180 2 0x401f8540 2 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_sai1_tx_data0: IOMUXC_GPIO_B1_01_SAI1_TX_DATA0 {
 		pinmux = <0x401f8180 3 0x0 0 0x401f8370>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_in15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_IN15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_01_xbar1_xbar_inout15: IOMUXC_GPIO_B1_01_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x401f8180 1 0x401f8648 1 0x401f8370>;
 		gpr = <0x400ac018 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_enet2_rx_data1: IOMUXC_GPIO_B1_02_ENET2_RX_DATA1 {
 		pinmux = <0x401f8184 8 0x401f8718 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio2_flexio18: IOMUXC_GPIO_B1_02_FLEXIO2_FLEXIO18 {
 		pinmux = <0x401f8184 4 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexio3_flexio18: IOMUXC_GPIO_B1_02_FLEXIO3_FLEXIO18 {
 		pinmux = <0x401f8184 9 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8184 6 0x401f8474 4 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio2_io18: IOMUXC_GPIO_B1_02_GPIO2_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x0>;
 	};
-	iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_gpio7_io18: IOMUXC_GPIO_B1_02_GPIO7_IO18 {
 		pinmux = <0x401f8184 5 0x0 0 0x401f8374>;
 		gpr = <0x400ac06c 0x12 0x1>;
 	};
-	iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lcdif_data14: IOMUXC_GPIO_B1_02_LCDIF_DATA14 {
 		pinmux = <0x401f8184 0 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_lpspi4_pcs2: IOMUXC_GPIO_B1_02_LPSPI4_PCS2 {
 		pinmux = <0x401f8184 2 0x0 0 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_sai1_tx_bclk: IOMUXC_GPIO_B1_02_SAI1_TX_BCLK {
 		pinmux = <0x401f8184 3 0x401f85a8 2 0x401f8374>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_in16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_IN16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_02_xbar1_xbar_inout16: IOMUXC_GPIO_B1_02_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x401f8184 1 0x401f864c 1 0x401f8374>;
 		gpr = <0x400ac018 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_enet2_rx_en: IOMUXC_GPIO_B1_03_ENET2_RX_EN {
 		pinmux = <0x401f8188 8 0x401f871c 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio2_flexio19: IOMUXC_GPIO_B1_03_FLEXIO2_FLEXIO19 {
 		pinmux = <0x401f8188 4 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexio3_flexio19: IOMUXC_GPIO_B1_03_FLEXIO3_FLEXIO19 {
 		pinmux = <0x401f8188 9 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8188 6 0x401f8484 3 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio2_io19: IOMUXC_GPIO_B1_03_GPIO2_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x0>;
 	};
-	iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_gpio7_io19: IOMUXC_GPIO_B1_03_GPIO7_IO19 {
 		pinmux = <0x401f8188 5 0x0 0 0x401f8378>;
 		gpr = <0x400ac06c 0x13 0x1>;
 	};
-	iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lcdif_data15: IOMUXC_GPIO_B1_03_LCDIF_DATA15 {
 		pinmux = <0x401f8188 0 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_lpspi4_pcs1: IOMUXC_GPIO_B1_03_LPSPI4_PCS1 {
 		pinmux = <0x401f8188 2 0x0 0 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_sai1_tx_sync: IOMUXC_GPIO_B1_03_SAI1_TX_SYNC {
 		pinmux = <0x401f8188 3 0x401f85ac 2 0x401f8378>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_in17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_03_xbar1_xbar_inout17: IOMUXC_GPIO_B1_03_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8188 1 0x401f862c 3 0x401f8378>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_csi_data15: IOMUXC_GPIO_B1_04_CSI_DATA15 {
 		pinmux = <0x401f818c 2 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_enet_rx_data0: IOMUXC_GPIO_B1_04_ENET_RX_DATA0 {
 		pinmux = <0x401f818c 3 0x401f8434 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio2_flexio20: IOMUXC_GPIO_B1_04_FLEXIO2_FLEXIO20 {
 		pinmux = <0x401f818c 4 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_flexio3_flexio20: IOMUXC_GPIO_B1_04_FLEXIO3_FLEXIO20 {
 		pinmux = <0x401f818c 9 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio2_io20: IOMUXC_GPIO_B1_04_GPIO2_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x0>;
 	};
-	iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpio7_io20: IOMUXC_GPIO_B1_04_GPIO7_IO20 {
 		pinmux = <0x401f818c 5 0x0 0 0x401f837c>;
 		gpr = <0x400ac06c 0x14 0x1>;
 	};
-	iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_gpt1_clk: IOMUXC_GPIO_B1_04_GPT1_CLK {
 		pinmux = <0x401f818c 8 0x401f8760 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lcdif_data16: IOMUXC_GPIO_B1_04_LCDIF_DATA16 {
 		pinmux = <0x401f818c 0 0x0 0 0x401f837c>;
 	};
-	iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_04_lpspi4_pcs0: IOMUXC_GPIO_B1_04_LPSPI4_PCS0 {
 		pinmux = <0x401f818c 1 0x401f851c 1 0x401f837c>;
 	};
-	iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_csi_data14: IOMUXC_GPIO_B1_05_CSI_DATA14 {
 		pinmux = <0x401f8190 2 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_enet_rx_data1: IOMUXC_GPIO_B1_05_ENET_RX_DATA1 {
 		pinmux = <0x401f8190 3 0x401f8438 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio2_flexio21: IOMUXC_GPIO_B1_05_FLEXIO2_FLEXIO21 {
 		pinmux = <0x401f8190 4 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_flexio3_flexio21: IOMUXC_GPIO_B1_05_FLEXIO3_FLEXIO21 {
 		pinmux = <0x401f8190 9 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio2_io21: IOMUXC_GPIO_B1_05_GPIO2_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x0>;
 	};
-	iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpio7_io21: IOMUXC_GPIO_B1_05_GPIO7_IO21 {
 		pinmux = <0x401f8190 5 0x0 0 0x401f8380>;
 		gpr = <0x400ac06c 0x15 0x1>;
 	};
-	iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_gpt1_capture1: IOMUXC_GPIO_B1_05_GPT1_CAPTURE1 {
 		pinmux = <0x401f8190 8 0x401f8758 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lcdif_data17: IOMUXC_GPIO_B1_05_LCDIF_DATA17 {
 		pinmux = <0x401f8190 0 0x0 0 0x401f8380>;
 	};
-	iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_b1_05_lpspi4_sdi: IOMUXC_GPIO_B1_05_LPSPI4_SDI {
 		pinmux = <0x401f8190 1 0x401f8524 1 0x401f8380>;
 	};
-	iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_csi_data13: IOMUXC_GPIO_B1_06_CSI_DATA13 {
 		pinmux = <0x401f8194 2 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_enet_rx_en: IOMUXC_GPIO_B1_06_ENET_RX_EN {
 		pinmux = <0x401f8194 3 0x401f843c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio2_flexio22: IOMUXC_GPIO_B1_06_FLEXIO2_FLEXIO22 {
 		pinmux = <0x401f8194 4 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_flexio3_flexio22: IOMUXC_GPIO_B1_06_FLEXIO3_FLEXIO22 {
 		pinmux = <0x401f8194 9 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio2_io22: IOMUXC_GPIO_B1_06_GPIO2_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x0>;
 	};
-	iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpio7_io22: IOMUXC_GPIO_B1_06_GPIO7_IO22 {
 		pinmux = <0x401f8194 5 0x0 0 0x401f8384>;
 		gpr = <0x400ac06c 0x16 0x1>;
 	};
-	iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_gpt1_capture2: IOMUXC_GPIO_B1_06_GPT1_CAPTURE2 {
 		pinmux = <0x401f8194 8 0x401f875c 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lcdif_data18: IOMUXC_GPIO_B1_06_LCDIF_DATA18 {
 		pinmux = <0x401f8194 0 0x0 0 0x401f8384>;
 	};
-	iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_06_lpspi4_sdo: IOMUXC_GPIO_B1_06_LPSPI4_SDO {
 		pinmux = <0x401f8194 1 0x401f8528 1 0x401f8384>;
 	};
-	iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_csi_data12: IOMUXC_GPIO_B1_07_CSI_DATA12 {
 		pinmux = <0x401f8198 2 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_enet_tx_data0: IOMUXC_GPIO_B1_07_ENET_TX_DATA0 {
 		pinmux = <0x401f8198 3 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio2_flexio23: IOMUXC_GPIO_B1_07_FLEXIO2_FLEXIO23 {
 		pinmux = <0x401f8198 4 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_flexio3_flexio23: IOMUXC_GPIO_B1_07_FLEXIO3_FLEXIO23 {
 		pinmux = <0x401f8198 9 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio2_io23: IOMUXC_GPIO_B1_07_GPIO2_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x0>;
 	};
-	iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpio7_io23: IOMUXC_GPIO_B1_07_GPIO7_IO23 {
 		pinmux = <0x401f8198 5 0x0 0 0x401f8388>;
 		gpr = <0x400ac06c 0x17 0x1>;
 	};
-	iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_gpt1_compare1: IOMUXC_GPIO_B1_07_GPT1_COMPARE1 {
 		pinmux = <0x401f8198 8 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lcdif_data19: IOMUXC_GPIO_B1_07_LCDIF_DATA19 {
 		pinmux = <0x401f8198 0 0x0 0 0x401f8388>;
 	};
-	iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_07_lpspi4_sck: IOMUXC_GPIO_B1_07_LPSPI4_SCK {
 		pinmux = <0x401f8198 1 0x401f8520 1 0x401f8388>;
 	};
-	iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_csi_data11: IOMUXC_GPIO_B1_08_CSI_DATA11 {
 		pinmux = <0x401f819c 2 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_enet_tx_data1: IOMUXC_GPIO_B1_08_ENET_TX_DATA1 {
 		pinmux = <0x401f819c 3 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexcan2_tx: IOMUXC_GPIO_B1_08_FLEXCAN2_TX {
 		pinmux = <0x401f819c 6 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio2_flexio24: IOMUXC_GPIO_B1_08_FLEXIO2_FLEXIO24 {
 		pinmux = <0x401f819c 4 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_flexio3_flexio24: IOMUXC_GPIO_B1_08_FLEXIO3_FLEXIO24 {
 		pinmux = <0x401f819c 9 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio2_io24: IOMUXC_GPIO_B1_08_GPIO2_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x0>;
 	};
-	iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpio7_io24: IOMUXC_GPIO_B1_08_GPIO7_IO24 {
 		pinmux = <0x401f819c 5 0x0 0 0x401f838c>;
 		gpr = <0x400ac06c 0x18 0x1>;
 	};
-	iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_gpt1_compare2: IOMUXC_GPIO_B1_08_GPT1_COMPARE2 {
 		pinmux = <0x401f819c 8 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_lcdif_data20: IOMUXC_GPIO_B1_08_LCDIF_DATA20 {
 		pinmux = <0x401f819c 0 0x0 0 0x401f838c>;
 	};
-	iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_08_qtimer1_timer3: IOMUXC_GPIO_B1_08_QTIMER1_TIMER3 {
 		pinmux = <0x401f819c 1 0x0 0 0x401f838c>;
 		gpr = <0x400ac018 0x3 0x0>;
 	};
-	iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_csi_data10: IOMUXC_GPIO_B1_09_CSI_DATA10 {
 		pinmux = <0x401f81a0 2 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_enet_tx_en: IOMUXC_GPIO_B1_09_ENET_TX_EN {
 		pinmux = <0x401f81a0 3 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexcan2_rx: IOMUXC_GPIO_B1_09_FLEXCAN2_RX {
 		pinmux = <0x401f81a0 6 0x401f8450 3 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio2_flexio25: IOMUXC_GPIO_B1_09_FLEXIO2_FLEXIO25 {
 		pinmux = <0x401f81a0 4 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_flexio3_flexio25: IOMUXC_GPIO_B1_09_FLEXIO3_FLEXIO25 {
 		pinmux = <0x401f81a0 9 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio2_io25: IOMUXC_GPIO_B1_09_GPIO2_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x0>;
 	};
-	iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpio7_io25: IOMUXC_GPIO_B1_09_GPIO7_IO25 {
 		pinmux = <0x401f81a0 5 0x0 0 0x401f8390>;
 		gpr = <0x400ac06c 0x19 0x1>;
 	};
-	iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_gpt1_compare3: IOMUXC_GPIO_B1_09_GPT1_COMPARE3 {
 		pinmux = <0x401f81a0 8 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_lcdif_data21: IOMUXC_GPIO_B1_09_LCDIF_DATA21 {
 		pinmux = <0x401f81a0 0 0x0 0 0x401f8390>;
 	};
-	iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_09_qtimer2_timer3: IOMUXC_GPIO_B1_09_QTIMER2_TIMER3 {
 		pinmux = <0x401f81a0 1 0x401f8578 1 0x401f8390>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_csi_data00: IOMUXC_GPIO_B1_10_CSI_DATA00 {
 		pinmux = <0x401f81a4 2 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_ref_clk: IOMUXC_GPIO_B1_10_ENET_REF_CLK {
 		pinmux = <0x401f81a4 6 0x401f842c 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_enet_tx_clk: IOMUXC_GPIO_B1_10_ENET_TX_CLK {
 		pinmux = <0x401f81a4 3 0x401f8448 1 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio2_flexio26: IOMUXC_GPIO_B1_10_FLEXIO2_FLEXIO26 {
 		pinmux = <0x401f81a4 4 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_flexio3_flexio26: IOMUXC_GPIO_B1_10_FLEXIO3_FLEXIO26 {
 		pinmux = <0x401f81a4 9 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio2_io26: IOMUXC_GPIO_B1_10_GPIO2_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x0>;
 	};
-	iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_gpio7_io26: IOMUXC_GPIO_B1_10_GPIO7_IO26 {
 		pinmux = <0x401f81a4 5 0x0 0 0x401f8394>;
 		gpr = <0x400ac06c 0x1a 0x1>;
 	};
-	iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_lcdif_data22: IOMUXC_GPIO_B1_10_LCDIF_DATA22 {
 		pinmux = <0x401f81a4 0 0x0 0 0x401f8394>;
 	};
-	iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_10_qtimer3_timer3: IOMUXC_GPIO_B1_10_QTIMER3_TIMER3 {
 		pinmux = <0x401f81a4 1 0x401f8588 2 0x401f8394>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_csi_data01: IOMUXC_GPIO_B1_11_CSI_DATA01 {
 		pinmux = <0x401f81a8 2 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_enet_rx_er: IOMUXC_GPIO_B1_11_ENET_RX_ER {
 		pinmux = <0x401f81a8 3 0x401f8440 1 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio2_flexio27: IOMUXC_GPIO_B1_11_FLEXIO2_FLEXIO27 {
 		pinmux = <0x401f81a8 4 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_flexio3_flexio27: IOMUXC_GPIO_B1_11_FLEXIO3_FLEXIO27 {
 		pinmux = <0x401f81a8 9 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio2_io27: IOMUXC_GPIO_B1_11_GPIO2_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x0>;
 	};
-	iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_gpio7_io27: IOMUXC_GPIO_B1_11_GPIO7_IO27 {
 		pinmux = <0x401f81a8 5 0x0 0 0x401f8398>;
 		gpr = <0x400ac06c 0x1b 0x1>;
 	};
-	iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lcdif_data23: IOMUXC_GPIO_B1_11_LCDIF_DATA23 {
 		pinmux = <0x401f81a8 0 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_lpspi4_pcs3: IOMUXC_GPIO_B1_11_LPSPI4_PCS3 {
 		pinmux = <0x401f81a8 6 0x0 0 0x401f8398>;
 	};
-	iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_11_qtimer4_timer3: IOMUXC_GPIO_B1_11_QTIMER4_TIMER3 {
 		pinmux = <0x401f81a8 1 0x0 0 0x401f8398>;
 		gpr = <0x400ac018 0xf 0x0>;
 	};
-	iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_csi_pixclk: IOMUXC_GPIO_B1_12_CSI_PIXCLK {
 		pinmux = <0x401f81ac 2 0x401f8424 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_enet_1588_event0_in: IOMUXC_GPIO_B1_12_ENET_1588_EVENT0_IN {
 		pinmux = <0x401f81ac 3 0x401f8444 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio2_flexio28: IOMUXC_GPIO_B1_12_FLEXIO2_FLEXIO28 {
 		pinmux = <0x401f81ac 4 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_flexio3_flexio28: IOMUXC_GPIO_B1_12_FLEXIO3_FLEXIO28 {
 		pinmux = <0x401f81ac 9 0x0 0 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio2_io28: IOMUXC_GPIO_B1_12_GPIO2_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x0>;
 	};
-	iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_gpio7_io28: IOMUXC_GPIO_B1_12_GPIO7_IO28 {
 		pinmux = <0x401f81ac 5 0x0 0 0x401f839c>;
 		gpr = <0x400ac06c 0x1c 0x1>;
 	};
-	iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_lpuart5_tx: IOMUXC_GPIO_B1_12_LPUART5_TX {
 		pinmux = <0x401f81ac 1 0x401f854c 1 0x401f839c>;
 	};
-	iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_12_usdhc1_cd_b: IOMUXC_GPIO_B1_12_USDHC1_CD_B {
 		pinmux = <0x401f81ac 6 0x401f85d4 2 0x401f839c>;
 	};
-	iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_csi_vsync: IOMUXC_GPIO_B1_13_CSI_VSYNC {
 		pinmux = <0x401f81b0 2 0x401f8428 2 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_enet_1588_event0_out: IOMUXC_GPIO_B1_13_ENET_1588_EVENT0_OUT {
 		pinmux = <0x401f81b0 3 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio2_flexio29: IOMUXC_GPIO_B1_13_FLEXIO2_FLEXIO29 {
 		pinmux = <0x401f81b0 4 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_flexio3_flexio29: IOMUXC_GPIO_B1_13_FLEXIO3_FLEXIO29 {
 		pinmux = <0x401f81b0 9 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio2_io29: IOMUXC_GPIO_B1_13_GPIO2_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x0>;
 	};
-	iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_gpio7_io29: IOMUXC_GPIO_B1_13_GPIO7_IO29 {
 		pinmux = <0x401f81b0 5 0x0 0 0x401f83a0>;
 		gpr = <0x400ac06c 0x1d 0x1>;
 	};
-	iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_lpuart5_rx: IOMUXC_GPIO_B1_13_LPUART5_RX {
 		pinmux = <0x401f81b0 1 0x401f8548 1 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_semc_dqs4: IOMUXC_GPIO_B1_13_SEMC_DQS4 {
 		pinmux = <0x401f81b0 8 0x401f8788 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_usdhc1_wp: IOMUXC_GPIO_B1_13_USDHC1_WP {
 		pinmux = <0x401f81b0 6 0x401f85d8 3 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_13_wdog1_b: IOMUXC_GPIO_B1_13_WDOG1_B {
 		pinmux = <0x401f81b0 0 0x0 0 0x401f83a0>;
 	};
-	iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_csi_hsync: IOMUXC_GPIO_B1_14_CSI_HSYNC {
 		pinmux = <0x401f81b4 2 0x401f8420 2 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet2_tx_data0: IOMUXC_GPIO_B1_14_ENET2_TX_DATA0 {
 		pinmux = <0x401f81b4 8 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_enet_mdc: IOMUXC_GPIO_B1_14_ENET_MDC {
 		pinmux = <0x401f81b4 0 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio2_flexio30: IOMUXC_GPIO_B1_14_FLEXIO2_FLEXIO30 {
 		pinmux = <0x401f81b4 4 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexio3_flexio30: IOMUXC_GPIO_B1_14_FLEXIO3_FLEXIO30 {
 		pinmux = <0x401f81b4 9 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_flexpwm4_pwma2: IOMUXC_GPIO_B1_14_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f81b4 1 0x401f849c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio2_io30: IOMUXC_GPIO_B1_14_GPIO2_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x0>;
 	};
-	iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_gpio7_io30: IOMUXC_GPIO_B1_14_GPIO7_IO30 {
 		pinmux = <0x401f81b4 5 0x0 0 0x401f83a4>;
 		gpr = <0x400ac06c 0x1e 0x1>;
 	};
-	iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_usdhc1_vselect: IOMUXC_GPIO_B1_14_USDHC1_VSELECT {
 		pinmux = <0x401f81b4 6 0x0 0 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_14_xbar1_xbar_in02: IOMUXC_GPIO_B1_14_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f81b4 3 0x401f860c 1 0x401f83a4>;
 	};
-	iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_csi_mclk: IOMUXC_GPIO_B1_15_CSI_MCLK {
 		pinmux = <0x401f81b8 2 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet2_tx_data1: IOMUXC_GPIO_B1_15_ENET2_TX_DATA1 {
 		pinmux = <0x401f81b8 8 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_enet_mdio: IOMUXC_GPIO_B1_15_ENET_MDIO {
 		pinmux = <0x401f81b8 0 0x401f8430 2 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio2_flexio31: IOMUXC_GPIO_B1_15_FLEXIO2_FLEXIO31 {
 		pinmux = <0x401f81b8 4 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexio3_flexio31: IOMUXC_GPIO_B1_15_FLEXIO3_FLEXIO31 {
 		pinmux = <0x401f81b8 9 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_flexpwm4_pwma3: IOMUXC_GPIO_B1_15_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f81b8 1 0x401f84a0 1 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio2_io31: IOMUXC_GPIO_B1_15_GPIO2_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x0>;
 	};
-	iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_gpio7_io31: IOMUXC_GPIO_B1_15_GPIO7_IO31 {
 		pinmux = <0x401f81b8 5 0x0 0 0x401f83a8>;
 		gpr = <0x400ac06c 0x1f 0x1>;
 	};
-	iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_usdhc1_reset_b: IOMUXC_GPIO_B1_15_USDHC1_RESET_B {
 		pinmux = <0x401f81b8 6 0x0 0 0x401f83a8>;
 	};
-	iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_b1_15_xbar1_xbar_in03: IOMUXC_GPIO_B1_15_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f81b8 3 0x401f8610 1 0x401f83a8>;
 	};
-	iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexio1_flexio00: IOMUXC_GPIO_EMC_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x401f8014 4 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_flexpwm4_pwma0: IOMUXC_GPIO_EMC_00_FLEXPWM4_PWMA0 {
 		pinmux = <0x401f8014 1 0x401f8494 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio4_io00: IOMUXC_GPIO_EMC_00_GPIO4_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_gpio9_io00: IOMUXC_GPIO_EMC_00_GPIO9_IO00 {
 		pinmux = <0x401f8014 5 0x0 0 0x401f8204>;
 		gpr = <0x400ac074 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_lpspi2_sck: IOMUXC_GPIO_EMC_00_LPSPI2_SCK {
 		pinmux = <0x401f8014 2 0x401f8500 1 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_semc_data00: IOMUXC_GPIO_EMC_00_SEMC_DATA00 {
 		pinmux = <0x401f8014 0 0x0 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_00_xbar1_xbar_in02: IOMUXC_GPIO_EMC_00_XBAR1_XBAR_IN02 {
 		pinmux = <0x401f8014 3 0x401f860c 0 0x401f8204>;
 	};
-	iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexio1_flexio01: IOMUXC_GPIO_EMC_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x401f8018 4 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_flexpwm4_pwmb0: IOMUXC_GPIO_EMC_01_FLEXPWM4_PWMB0 {
 		pinmux = <0x401f8018 1 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio4_io01: IOMUXC_GPIO_EMC_01_GPIO4_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_gpio9_io01: IOMUXC_GPIO_EMC_01_GPIO9_IO01 {
 		pinmux = <0x401f8018 5 0x0 0 0x401f8208>;
 		gpr = <0x400ac074 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_lpspi2_pcs0: IOMUXC_GPIO_EMC_01_LPSPI2_PCS0 {
 		pinmux = <0x401f8018 2 0x401f84fc 1 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_semc_data01: IOMUXC_GPIO_EMC_01_SEMC_DATA01 {
 		pinmux = <0x401f8018 0 0x0 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_01_xbar1_xbar_in03: IOMUXC_GPIO_EMC_01_XBAR1_XBAR_IN03 {
 		pinmux = <0x401f8018 3 0x401f8610 0 0x401f8208>;
 	};
-	iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexio1_flexio02: IOMUXC_GPIO_EMC_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x401f801c 4 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_flexpwm4_pwma1: IOMUXC_GPIO_EMC_02_FLEXPWM4_PWMA1 {
 		pinmux = <0x401f801c 1 0x401f8498 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio4_io02: IOMUXC_GPIO_EMC_02_GPIO4_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_gpio9_io02: IOMUXC_GPIO_EMC_02_GPIO9_IO02 {
 		pinmux = <0x401f801c 5 0x0 0 0x401f820c>;
 		gpr = <0x400ac074 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_lpspi2_sdo: IOMUXC_GPIO_EMC_02_LPSPI2_SDO {
 		pinmux = <0x401f801c 2 0x401f8508 1 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_semc_data02: IOMUXC_GPIO_EMC_02_SEMC_DATA02 {
 		pinmux = <0x401f801c 0 0x0 0 0x401f820c>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_in04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_02_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_02_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f801c 3 0x401f8614 0 0x401f820c>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexio1_flexio03: IOMUXC_GPIO_EMC_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x401f8020 4 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_flexpwm4_pwmb1: IOMUXC_GPIO_EMC_03_FLEXPWM4_PWMB1 {
 		pinmux = <0x401f8020 1 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio4_io03: IOMUXC_GPIO_EMC_03_GPIO4_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_gpio9_io03: IOMUXC_GPIO_EMC_03_GPIO9_IO03 {
 		pinmux = <0x401f8020 5 0x0 0 0x401f8210>;
 		gpr = <0x400ac074 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_lpspi2_sdi: IOMUXC_GPIO_EMC_03_LPSPI2_SDI {
 		pinmux = <0x401f8020 2 0x401f8504 1 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_semc_data03: IOMUXC_GPIO_EMC_03_SEMC_DATA03 {
 		pinmux = <0x401f8020 0 0x0 0 0x401f8210>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_in05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_03_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_03_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f8020 3 0x401f8618 0 0x401f8210>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexio1_flexio04: IOMUXC_GPIO_EMC_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x401f8024 4 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_flexpwm4_pwma2: IOMUXC_GPIO_EMC_04_FLEXPWM4_PWMA2 {
 		pinmux = <0x401f8024 1 0x401f849c 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio4_io04: IOMUXC_GPIO_EMC_04_GPIO4_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_gpio9_io04: IOMUXC_GPIO_EMC_04_GPIO9_IO04 {
 		pinmux = <0x401f8024 5 0x0 0 0x401f8214>;
 		gpr = <0x400ac074 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_sai2_tx_data: IOMUXC_GPIO_EMC_04_SAI2_TX_DATA {
 		pinmux = <0x401f8024 2 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_semc_data04: IOMUXC_GPIO_EMC_04_SEMC_DATA04 {
 		pinmux = <0x401f8024 0 0x0 0 0x401f8214>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_in06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_04_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_04_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f8024 3 0x401f861c 0 0x401f8214>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexio1_flexio05: IOMUXC_GPIO_EMC_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x401f8028 4 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_flexpwm4_pwmb2: IOMUXC_GPIO_EMC_05_FLEXPWM4_PWMB2 {
 		pinmux = <0x401f8028 1 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio4_io05: IOMUXC_GPIO_EMC_05_GPIO4_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_gpio9_io05: IOMUXC_GPIO_EMC_05_GPIO9_IO05 {
 		pinmux = <0x401f8028 5 0x0 0 0x401f8218>;
 		gpr = <0x400ac074 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_sai2_tx_sync: IOMUXC_GPIO_EMC_05_SAI2_TX_SYNC {
 		pinmux = <0x401f8028 2 0x401f85c4 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_semc_data05: IOMUXC_GPIO_EMC_05_SEMC_DATA05 {
 		pinmux = <0x401f8028 0 0x0 0 0x401f8218>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_in07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_05_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_05_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f8028 3 0x401f8620 0 0x401f8218>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexio1_flexio06: IOMUXC_GPIO_EMC_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x401f802c 4 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_flexpwm2_pwma0: IOMUXC_GPIO_EMC_06_FLEXPWM2_PWMA0 {
 		pinmux = <0x401f802c 1 0x401f8478 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio4_io06: IOMUXC_GPIO_EMC_06_GPIO4_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_gpio9_io06: IOMUXC_GPIO_EMC_06_GPIO9_IO06 {
 		pinmux = <0x401f802c 5 0x0 0 0x401f821c>;
 		gpr = <0x400ac074 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_sai2_tx_bclk: IOMUXC_GPIO_EMC_06_SAI2_TX_BCLK {
 		pinmux = <0x401f802c 2 0x401f85c0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_semc_data06: IOMUXC_GPIO_EMC_06_SEMC_DATA06 {
 		pinmux = <0x401f802c 0 0x0 0 0x401f821c>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_in08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_06_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_06_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f802c 3 0x401f8624 0 0x401f821c>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexio1_flexio07: IOMUXC_GPIO_EMC_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x401f8030 4 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_flexpwm2_pwmb0: IOMUXC_GPIO_EMC_07_FLEXPWM2_PWMB0 {
 		pinmux = <0x401f8030 1 0x401f8488 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio4_io07: IOMUXC_GPIO_EMC_07_GPIO4_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_gpio9_io07: IOMUXC_GPIO_EMC_07_GPIO9_IO07 {
 		pinmux = <0x401f8030 5 0x0 0 0x401f8220>;
 		gpr = <0x400ac074 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_sai2_mclk: IOMUXC_GPIO_EMC_07_SAI2_MCLK {
 		pinmux = <0x401f8030 2 0x401f85b0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_semc_data07: IOMUXC_GPIO_EMC_07_SEMC_DATA07 {
 		pinmux = <0x401f8030 0 0x0 0 0x401f8220>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_in09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_07_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_07_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f8030 3 0x401f8628 0 0x401f8220>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexio1_flexio08: IOMUXC_GPIO_EMC_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x401f8034 4 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_flexpwm2_pwma1: IOMUXC_GPIO_EMC_08_FLEXPWM2_PWMA1 {
 		pinmux = <0x401f8034 1 0x401f847c 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio4_io08: IOMUXC_GPIO_EMC_08_GPIO4_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_gpio9_io08: IOMUXC_GPIO_EMC_08_GPIO9_IO08 {
 		pinmux = <0x401f8034 5 0x0 0 0x401f8224>;
 		gpr = <0x400ac074 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_sai2_rx_data: IOMUXC_GPIO_EMC_08_SAI2_RX_DATA {
 		pinmux = <0x401f8034 2 0x401f85b8 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_semc_dm0: IOMUXC_GPIO_EMC_08_SEMC_DM0 {
 		pinmux = <0x401f8034 0 0x0 0 0x401f8224>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_in17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_IN17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_08_xbar1_xbar_inout17: IOMUXC_GPIO_EMC_08_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x401f8034 3 0x401f862c 0 0x401f8224>;
 		gpr = <0x400ac018 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexcan2_tx: IOMUXC_GPIO_EMC_09_FLEXCAN2_TX {
 		pinmux = <0x401f8038 3 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexio1_flexio09: IOMUXC_GPIO_EMC_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x401f8038 4 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_flexpwm2_pwmb1: IOMUXC_GPIO_EMC_09_FLEXPWM2_PWMB1 {
 		pinmux = <0x401f8038 1 0x401f848c 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio4_io09: IOMUXC_GPIO_EMC_09_GPIO4_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_gpio9_io09: IOMUXC_GPIO_EMC_09_GPIO9_IO09 {
 		pinmux = <0x401f8038 5 0x0 0 0x401f8228>;
 		gpr = <0x400ac074 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_sai2_rx_sync: IOMUXC_GPIO_EMC_09_SAI2_RX_SYNC {
 		pinmux = <0x401f8038 2 0x401f85bc 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_09_semc_addr00: IOMUXC_GPIO_EMC_09_SEMC_ADDR00 {
 		pinmux = <0x401f8038 0 0x0 0 0x401f8228>;
 	};
-	iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexcan2_rx: IOMUXC_GPIO_EMC_10_FLEXCAN2_RX {
 		pinmux = <0x401f803c 3 0x401f8450 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexio1_flexio10: IOMUXC_GPIO_EMC_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x401f803c 4 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_flexpwm2_pwma2: IOMUXC_GPIO_EMC_10_FLEXPWM2_PWMA2 {
 		pinmux = <0x401f803c 1 0x401f8480 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio4_io10: IOMUXC_GPIO_EMC_10_GPIO4_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_gpio9_io10: IOMUXC_GPIO_EMC_10_GPIO9_IO10 {
 		pinmux = <0x401f803c 5 0x0 0 0x401f822c>;
 		gpr = <0x400ac074 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_sai2_rx_bclk: IOMUXC_GPIO_EMC_10_SAI2_RX_BCLK {
 		pinmux = <0x401f803c 2 0x401f85b4 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_10_semc_addr01: IOMUXC_GPIO_EMC_10_SEMC_ADDR01 {
 		pinmux = <0x401f803c 0 0x0 0 0x401f822c>;
 	};
-	iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexio1_flexio11: IOMUXC_GPIO_EMC_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x401f8040 4 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_flexpwm2_pwmb2: IOMUXC_GPIO_EMC_11_FLEXPWM2_PWMB2 {
 		pinmux = <0x401f8040 1 0x401f8490 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio4_io11: IOMUXC_GPIO_EMC_11_GPIO4_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_gpio9_io11: IOMUXC_GPIO_EMC_11_GPIO9_IO11 {
 		pinmux = <0x401f8040 5 0x0 0 0x401f8230>;
 		gpr = <0x400ac074 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_lpi2c4_sda: IOMUXC_GPIO_EMC_11_LPI2C4_SDA {
 		pinmux = <0x401f8040 2 0x401f84e8 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_semc_addr02: IOMUXC_GPIO_EMC_11_SEMC_ADDR02 {
 		pinmux = <0x401f8040 0 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_11_usdhc2_reset_b: IOMUXC_GPIO_EMC_11_USDHC2_RESET_B {
 		pinmux = <0x401f8040 3 0x0 0 0x401f8230>;
 	};
-	iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_flexpwm1_pwma3: IOMUXC_GPIO_EMC_12_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f8044 4 0x401f8454 1 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio4_io12: IOMUXC_GPIO_EMC_12_GPIO4_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_gpio9_io12: IOMUXC_GPIO_EMC_12_GPIO9_IO12 {
 		pinmux = <0x401f8044 5 0x0 0 0x401f8234>;
 		gpr = <0x400ac074 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_lpi2c4_scl: IOMUXC_GPIO_EMC_12_LPI2C4_SCL {
 		pinmux = <0x401f8044 2 0x401f84e4 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_semc_addr03: IOMUXC_GPIO_EMC_12_SEMC_ADDR03 {
 		pinmux = <0x401f8044 0 0x0 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_usdhc1_wp: IOMUXC_GPIO_EMC_12_USDHC1_WP {
 		pinmux = <0x401f8044 3 0x401f85d8 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_12_xbar1_xbar_in24: IOMUXC_GPIO_EMC_12_XBAR1_XBAR_IN24 {
 		pinmux = <0x401f8044 1 0x401f8640 0 0x401f8234>;
 	};
-	iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_13_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f8048 4 0x401f8464 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio4_io13: IOMUXC_GPIO_EMC_13_GPIO4_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_gpio9_io13: IOMUXC_GPIO_EMC_13_GPIO9_IO13 {
 		pinmux = <0x401f8048 5 0x0 0 0x401f8238>;
 		gpr = <0x400ac074 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_lpuart3_tx: IOMUXC_GPIO_EMC_13_LPUART3_TX {
 		pinmux = <0x401f8048 2 0x401f853c 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_mqs_right: IOMUXC_GPIO_EMC_13_MQS_RIGHT {
 		pinmux = <0x401f8048 3 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_semc_addr04: IOMUXC_GPIO_EMC_13_SEMC_ADDR04 {
 		pinmux = <0x401f8048 0 0x0 0 0x401f8238>;
 	};
-	iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_13_xbar1_xbar_in25: IOMUXC_GPIO_EMC_13_XBAR1_XBAR_IN25 {
 		pinmux = <0x401f8048 1 0x401f8650 1 0x401f8238>;
 	};
-	iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio4_io14: IOMUXC_GPIO_EMC_14_GPIO4_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_gpio9_io14: IOMUXC_GPIO_EMC_14_GPIO9_IO14 {
 		pinmux = <0x401f804c 5 0x0 0 0x401f823c>;
 		gpr = <0x400ac074 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpspi2_pcs1: IOMUXC_GPIO_EMC_14_LPSPI2_PCS1 {
 		pinmux = <0x401f804c 4 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_lpuart3_rx: IOMUXC_GPIO_EMC_14_LPUART3_RX {
 		pinmux = <0x401f804c 2 0x401f8538 1 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_mqs_left: IOMUXC_GPIO_EMC_14_MQS_LEFT {
 		pinmux = <0x401f804c 3 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_semc_addr05: IOMUXC_GPIO_EMC_14_SEMC_ADDR05 {
 		pinmux = <0x401f804c 0 0x0 0 0x401f823c>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_in19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_IN19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_14_xbar1_xbar_inout19: IOMUXC_GPIO_EMC_14_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x401f804c 1 0x401f8654 0 0x401f823c>;
 		gpr = <0x400ac018 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio4_io15: IOMUXC_GPIO_EMC_15_GPIO4_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_gpio9_io15: IOMUXC_GPIO_EMC_15_GPIO9_IO15 {
 		pinmux = <0x401f8050 5 0x0 0 0x401f8240>;
 		gpr = <0x400ac074 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_lpuart3_cts_b: IOMUXC_GPIO_EMC_15_LPUART3_CTS_B {
 		pinmux = <0x401f8050 2 0x401f8534 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_qtimer3_timer0: IOMUXC_GPIO_EMC_15_QTIMER3_TIMER0 {
 		pinmux = <0x401f8050 4 0x401f857c 0 0x401f8240>;
 		gpr = <0x400ac018 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_semc_addr06: IOMUXC_GPIO_EMC_15_SEMC_ADDR06 {
 		pinmux = <0x401f8050 0 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_spdif_out: IOMUXC_GPIO_EMC_15_SPDIF_OUT {
 		pinmux = <0x401f8050 3 0x0 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_15_xbar1_xbar_in20: IOMUXC_GPIO_EMC_15_XBAR1_XBAR_IN20 {
 		pinmux = <0x401f8050 1 0x401f8634 0 0x401f8240>;
 	};
-	iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio4_io16: IOMUXC_GPIO_EMC_16_GPIO4_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_gpio9_io16: IOMUXC_GPIO_EMC_16_GPIO9_IO16 {
 		pinmux = <0x401f8054 5 0x0 0 0x401f8244>;
 		gpr = <0x400ac074 0x10 0x1>;
 	};
-	iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_lpuart3_rts_b: IOMUXC_GPIO_EMC_16_LPUART3_RTS_B {
 		pinmux = <0x401f8054 2 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_qtimer3_timer1: IOMUXC_GPIO_EMC_16_QTIMER3_TIMER1 {
 		pinmux = <0x401f8054 4 0x401f8580 1 0x401f8244>;
 		gpr = <0x400ac018 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_semc_addr07: IOMUXC_GPIO_EMC_16_SEMC_ADDR07 {
 		pinmux = <0x401f8054 0 0x0 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_spdif_in: IOMUXC_GPIO_EMC_16_SPDIF_IN {
 		pinmux = <0x401f8054 3 0x401f85c8 1 0x401f8244>;
 	};
-	iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_16_xbar1_xbar_in21: IOMUXC_GPIO_EMC_16_XBAR1_XBAR_IN21 {
 		pinmux = <0x401f8054 1 0x401f8658 0 0x401f8244>;
 	};
-	iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexcan1_tx: IOMUXC_GPIO_EMC_17_FLEXCAN1_TX {
 		pinmux = <0x401f8058 3 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_flexpwm4_pwma3: IOMUXC_GPIO_EMC_17_FLEXPWM4_PWMA3 {
 		pinmux = <0x401f8058 1 0x401f84a0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio4_io17: IOMUXC_GPIO_EMC_17_GPIO4_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_gpio9_io17: IOMUXC_GPIO_EMC_17_GPIO9_IO17 {
 		pinmux = <0x401f8058 5 0x0 0 0x401f8248>;
 		gpr = <0x400ac074 0x11 0x1>;
 	};
-	iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_lpuart4_cts_b: IOMUXC_GPIO_EMC_17_LPUART4_CTS_B {
 		pinmux = <0x401f8058 2 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_qtimer3_timer2: IOMUXC_GPIO_EMC_17_QTIMER3_TIMER2 {
 		pinmux = <0x401f8058 4 0x401f8584 0 0x401f8248>;
 		gpr = <0x400ac018 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_17_semc_addr08: IOMUXC_GPIO_EMC_17_SEMC_ADDR08 {
 		pinmux = <0x401f8058 0 0x0 0 0x401f8248>;
 	};
-	iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexcan1_rx: IOMUXC_GPIO_EMC_18_FLEXCAN1_RX {
 		pinmux = <0x401f805c 3 0x401f844c 1 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_flexpwm4_pwmb3: IOMUXC_GPIO_EMC_18_FLEXPWM4_PWMB3 {
 		pinmux = <0x401f805c 1 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio4_io18: IOMUXC_GPIO_EMC_18_GPIO4_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_gpio9_io18: IOMUXC_GPIO_EMC_18_GPIO9_IO18 {
 		pinmux = <0x401f805c 5 0x0 0 0x401f824c>;
 		gpr = <0x400ac074 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_lpuart4_rts_b: IOMUXC_GPIO_EMC_18_LPUART4_RTS_B {
 		pinmux = <0x401f805c 2 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_qtimer3_timer3: IOMUXC_GPIO_EMC_18_QTIMER3_TIMER3 {
 		pinmux = <0x401f805c 4 0x401f8588 0 0x401f824c>;
 		gpr = <0x400ac018 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_semc_addr09: IOMUXC_GPIO_EMC_18_SEMC_ADDR09 {
 		pinmux = <0x401f805c 0 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_18_snvs_vio_5_ctl: IOMUXC_GPIO_EMC_18_SNVS_VIO_5_CTL {
 		pinmux = <0x401f805c 6 0x0 0 0x401f824c>;
 	};
-	iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_enet_rx_data1: IOMUXC_GPIO_EMC_19_ENET_RX_DATA1 {
 		pinmux = <0x401f8060 3 0x401f8438 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_flexpwm2_pwma3: IOMUXC_GPIO_EMC_19_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f8060 1 0x401f8474 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio4_io19: IOMUXC_GPIO_EMC_19_GPIO4_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_gpio9_io19: IOMUXC_GPIO_EMC_19_GPIO9_IO19 {
 		pinmux = <0x401f8060 5 0x0 0 0x401f8250>;
 		gpr = <0x400ac074 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_lpuart4_tx: IOMUXC_GPIO_EMC_19_LPUART4_TX {
 		pinmux = <0x401f8060 2 0x401f8544 1 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_qtimer2_timer0: IOMUXC_GPIO_EMC_19_QTIMER2_TIMER0 {
 		pinmux = <0x401f8060 4 0x401f856c 0 0x401f8250>;
 		gpr = <0x400ac018 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_semc_addr11: IOMUXC_GPIO_EMC_19_SEMC_ADDR11 {
 		pinmux = <0x401f8060 0 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_19_snvs_vio_5_b: IOMUXC_GPIO_EMC_19_SNVS_VIO_5_B {
 		pinmux = <0x401f8060 6 0x0 0 0x401f8250>;
 	};
-	iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_enet_rx_data0: IOMUXC_GPIO_EMC_20_ENET_RX_DATA0 {
 		pinmux = <0x401f8064 3 0x401f8434 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_flexpwm2_pwmb3: IOMUXC_GPIO_EMC_20_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f8064 1 0x401f8484 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio4_io20: IOMUXC_GPIO_EMC_20_GPIO4_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_gpio9_io20: IOMUXC_GPIO_EMC_20_GPIO9_IO20 {
 		pinmux = <0x401f8064 5 0x0 0 0x401f8254>;
 		gpr = <0x400ac074 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_lpuart4_rx: IOMUXC_GPIO_EMC_20_LPUART4_RX {
 		pinmux = <0x401f8064 2 0x401f8540 1 0x401f8254>;
 	};
-	iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_qtimer2_timer1: IOMUXC_GPIO_EMC_20_QTIMER2_TIMER1 {
 		pinmux = <0x401f8064 4 0x401f8570 0 0x401f8254>;
 		gpr = <0x400ac018 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_20_semc_addr12: IOMUXC_GPIO_EMC_20_SEMC_ADDR12 {
 		pinmux = <0x401f8064 0 0x0 0 0x401f8254>;
 	};
-	iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_enet_tx_data1: IOMUXC_GPIO_EMC_21_ENET_TX_DATA1 {
 		pinmux = <0x401f8068 3 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_flexpwm3_pwma3: IOMUXC_GPIO_EMC_21_FLEXPWM3_PWMA3 {
 		pinmux = <0x401f8068 1 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio4_io21: IOMUXC_GPIO_EMC_21_GPIO4_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_gpio9_io21: IOMUXC_GPIO_EMC_21_GPIO9_IO21 {
 		pinmux = <0x401f8068 5 0x0 0 0x401f8258>;
 		gpr = <0x400ac074 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_lpi2c3_sda: IOMUXC_GPIO_EMC_21_LPI2C3_SDA {
 		pinmux = <0x401f8068 2 0x401f84e0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_qtimer2_timer2: IOMUXC_GPIO_EMC_21_QTIMER2_TIMER2 {
 		pinmux = <0x401f8068 4 0x401f8574 0 0x401f8258>;
 		gpr = <0x400ac018 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_21_semc_ba0: IOMUXC_GPIO_EMC_21_SEMC_BA0 {
 		pinmux = <0x401f8068 0 0x0 0 0x401f8258>;
 	};
-	iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_enet_tx_data0: IOMUXC_GPIO_EMC_22_ENET_TX_DATA0 {
 		pinmux = <0x401f806c 3 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_flexpwm3_pwmb3: IOMUXC_GPIO_EMC_22_FLEXPWM3_PWMB3 {
 		pinmux = <0x401f806c 1 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio4_io22: IOMUXC_GPIO_EMC_22_GPIO4_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_gpio9_io22: IOMUXC_GPIO_EMC_22_GPIO9_IO22 {
 		pinmux = <0x401f806c 5 0x0 0 0x401f825c>;
 		gpr = <0x400ac074 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_lpi2c3_scl: IOMUXC_GPIO_EMC_22_LPI2C3_SCL {
 		pinmux = <0x401f806c 2 0x401f84dc 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_qtimer2_timer3: IOMUXC_GPIO_EMC_22_QTIMER2_TIMER3 {
 		pinmux = <0x401f806c 4 0x401f8578 0 0x401f825c>;
 		gpr = <0x400ac018 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_22_semc_ba1: IOMUXC_GPIO_EMC_22_SEMC_BA1 {
 		pinmux = <0x401f806c 0 0x0 0 0x401f825c>;
 	};
-	iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_enet_rx_en: IOMUXC_GPIO_EMC_23_ENET_RX_EN {
 		pinmux = <0x401f8070 3 0x401f843c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_flexpwm1_pwma0: IOMUXC_GPIO_EMC_23_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f8070 1 0x401f8458 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio4_io23: IOMUXC_GPIO_EMC_23_GPIO4_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpio9_io23: IOMUXC_GPIO_EMC_23_GPIO9_IO23 {
 		pinmux = <0x401f8070 5 0x0 0 0x401f8260>;
 		gpr = <0x400ac074 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_gpt1_capture2: IOMUXC_GPIO_EMC_23_GPT1_CAPTURE2 {
 		pinmux = <0x401f8070 4 0x401f875c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_lpuart5_tx: IOMUXC_GPIO_EMC_23_LPUART5_TX {
 		pinmux = <0x401f8070 2 0x401f854c 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_23_semc_addr10: IOMUXC_GPIO_EMC_23_SEMC_ADDR10 {
 		pinmux = <0x401f8070 0 0x0 0 0x401f8260>;
 	};
-	iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_enet_tx_en: IOMUXC_GPIO_EMC_24_ENET_TX_EN {
 		pinmux = <0x401f8074 3 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_flexpwm1_pwmb0: IOMUXC_GPIO_EMC_24_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f8074 1 0x401f8468 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio4_io24: IOMUXC_GPIO_EMC_24_GPIO4_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpio9_io24: IOMUXC_GPIO_EMC_24_GPIO9_IO24 {
 		pinmux = <0x401f8074 5 0x0 0 0x401f8264>;
 		gpr = <0x400ac074 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_gpt1_capture1: IOMUXC_GPIO_EMC_24_GPT1_CAPTURE1 {
 		pinmux = <0x401f8074 4 0x401f8758 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_lpuart5_rx: IOMUXC_GPIO_EMC_24_LPUART5_RX {
 		pinmux = <0x401f8074 2 0x401f8548 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_24_semc_cas: IOMUXC_GPIO_EMC_24_SEMC_CAS {
 		pinmux = <0x401f8074 0 0x0 0 0x401f8264>;
 	};
-	iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_ref_clk: IOMUXC_GPIO_EMC_25_ENET_REF_CLK {
 		pinmux = <0x401f8078 4 0x401f842c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_enet_tx_clk: IOMUXC_GPIO_EMC_25_ENET_TX_CLK {
 		pinmux = <0x401f8078 3 0x401f8448 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_flexpwm1_pwma1: IOMUXC_GPIO_EMC_25_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f8078 1 0x401f845c 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio4_io25: IOMUXC_GPIO_EMC_25_GPIO4_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_gpio9_io25: IOMUXC_GPIO_EMC_25_GPIO9_IO25 {
 		pinmux = <0x401f8078 5 0x0 0 0x401f8268>;
 		gpr = <0x400ac074 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_lpuart6_tx: IOMUXC_GPIO_EMC_25_LPUART6_TX {
 		pinmux = <0x401f8078 2 0x401f8554 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_25_semc_ras: IOMUXC_GPIO_EMC_25_SEMC_RAS {
 		pinmux = <0x401f8078 0 0x0 0 0x401f8268>;
 	};
-	iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_enet_rx_er: IOMUXC_GPIO_EMC_26_ENET_RX_ER {
 		pinmux = <0x401f807c 3 0x401f8440 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexio1_flexio12: IOMUXC_GPIO_EMC_26_FLEXIO1_FLEXIO12 {
 		pinmux = <0x401f807c 4 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_flexpwm1_pwmb1: IOMUXC_GPIO_EMC_26_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f807c 1 0x401f846c 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio4_io26: IOMUXC_GPIO_EMC_26_GPIO4_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_gpio9_io26: IOMUXC_GPIO_EMC_26_GPIO9_IO26 {
 		pinmux = <0x401f807c 5 0x0 0 0x401f826c>;
 		gpr = <0x400ac074 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_lpuart6_rx: IOMUXC_GPIO_EMC_26_LPUART6_RX {
 		pinmux = <0x401f807c 2 0x401f8550 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_26_semc_clk: IOMUXC_GPIO_EMC_26_SEMC_CLK {
 		pinmux = <0x401f807c 0 0x0 0 0x401f826c>;
 	};
-	iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexio1_flexio13: IOMUXC_GPIO_EMC_27_FLEXIO1_FLEXIO13 {
 		pinmux = <0x401f8080 4 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_flexpwm1_pwma2: IOMUXC_GPIO_EMC_27_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f8080 1 0x401f8460 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio4_io27: IOMUXC_GPIO_EMC_27_GPIO4_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_gpio9_io27: IOMUXC_GPIO_EMC_27_GPIO9_IO27 {
 		pinmux = <0x401f8080 5 0x0 0 0x401f8270>;
 		gpr = <0x400ac074 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpspi1_sck: IOMUXC_GPIO_EMC_27_LPSPI1_SCK {
 		pinmux = <0x401f8080 3 0x401f84f0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_lpuart5_rts_b: IOMUXC_GPIO_EMC_27_LPUART5_RTS_B {
 		pinmux = <0x401f8080 2 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_27_semc_cke: IOMUXC_GPIO_EMC_27_SEMC_CKE {
 		pinmux = <0x401f8080 0 0x0 0 0x401f8270>;
 	};
-	iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexio1_flexio14: IOMUXC_GPIO_EMC_28_FLEXIO1_FLEXIO14 {
 		pinmux = <0x401f8084 4 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_flexpwm1_pwmb2: IOMUXC_GPIO_EMC_28_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f8084 1 0x401f8470 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio4_io28: IOMUXC_GPIO_EMC_28_GPIO4_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x0>;
 	};
-	iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_gpio9_io28: IOMUXC_GPIO_EMC_28_GPIO9_IO28 {
 		pinmux = <0x401f8084 5 0x0 0 0x401f8274>;
 		gpr = <0x400ac074 0x1c 0x1>;
 	};
-	iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpspi1_sdo: IOMUXC_GPIO_EMC_28_LPSPI1_SDO {
 		pinmux = <0x401f8084 3 0x401f84f8 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_lpuart5_cts_b: IOMUXC_GPIO_EMC_28_LPUART5_CTS_B {
 		pinmux = <0x401f8084 2 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_28_semc_we: IOMUXC_GPIO_EMC_28_SEMC_WE {
 		pinmux = <0x401f8084 0 0x0 0 0x401f8274>;
 	};
-	iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexio1_flexio15: IOMUXC_GPIO_EMC_29_FLEXIO1_FLEXIO15 {
 		pinmux = <0x401f8088 4 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_flexpwm3_pwma0: IOMUXC_GPIO_EMC_29_FLEXPWM3_PWMA0 {
 		pinmux = <0x401f8088 1 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio4_io29: IOMUXC_GPIO_EMC_29_GPIO4_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x0>;
 	};
-	iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_gpio9_io29: IOMUXC_GPIO_EMC_29_GPIO9_IO29 {
 		pinmux = <0x401f8088 5 0x0 0 0x401f8278>;
 		gpr = <0x400ac074 0x1d 0x1>;
 	};
-	iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpspi1_sdi: IOMUXC_GPIO_EMC_29_LPSPI1_SDI {
 		pinmux = <0x401f8088 3 0x401f84f4 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_lpuart6_rts_b: IOMUXC_GPIO_EMC_29_LPUART6_RTS_B {
 		pinmux = <0x401f8088 2 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_29_semc_cs0: IOMUXC_GPIO_EMC_29_SEMC_CS0 {
 		pinmux = <0x401f8088 0 0x0 0 0x401f8278>;
 	};
-	iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_csi_data23: IOMUXC_GPIO_EMC_30_CSI_DATA23 {
 		pinmux = <0x401f808c 4 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_enet2_tx_data0: IOMUXC_GPIO_EMC_30_ENET2_TX_DATA0 {
 		pinmux = <0x401f808c 8 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_flexpwm3_pwmb0: IOMUXC_GPIO_EMC_30_FLEXPWM3_PWMB0 {
 		pinmux = <0x401f808c 1 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio4_io30: IOMUXC_GPIO_EMC_30_GPIO4_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_gpio9_io30: IOMUXC_GPIO_EMC_30_GPIO9_IO30 {
 		pinmux = <0x401f808c 5 0x0 0 0x401f827c>;
 		gpr = <0x400ac074 0x1e 0x1>;
 	};
-	iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpspi1_pcs0: IOMUXC_GPIO_EMC_30_LPSPI1_PCS0 {
 		pinmux = <0x401f808c 3 0x401f84ec 1 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_lpuart6_cts_b: IOMUXC_GPIO_EMC_30_LPUART6_CTS_B {
 		pinmux = <0x401f808c 2 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_30_semc_data08: IOMUXC_GPIO_EMC_30_SEMC_DATA08 {
 		pinmux = <0x401f808c 0 0x0 0 0x401f827c>;
 	};
-	iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_csi_data22: IOMUXC_GPIO_EMC_31_CSI_DATA22 {
 		pinmux = <0x401f8090 4 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_enet2_tx_data1: IOMUXC_GPIO_EMC_31_ENET2_TX_DATA1 {
 		pinmux = <0x401f8090 8 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_flexpwm3_pwma1: IOMUXC_GPIO_EMC_31_FLEXPWM3_PWMA1 {
 		pinmux = <0x401f8090 1 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio4_io31: IOMUXC_GPIO_EMC_31_GPIO4_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x0>;
 	};
-	iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_gpio9_io31: IOMUXC_GPIO_EMC_31_GPIO9_IO31 {
 		pinmux = <0x401f8090 5 0x0 0 0x401f8280>;
 		gpr = <0x400ac074 0x1f 0x1>;
 	};
-	iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpspi1_pcs1: IOMUXC_GPIO_EMC_31_LPSPI1_PCS1 {
 		pinmux = <0x401f8090 3 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_lpuart7_tx: IOMUXC_GPIO_EMC_31_LPUART7_TX {
 		pinmux = <0x401f8090 2 0x401f855c 1 0x401f8280>;
 	};
-	iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_31_semc_data09: IOMUXC_GPIO_EMC_31_SEMC_DATA09 {
 		pinmux = <0x401f8090 0 0x0 0 0x401f8280>;
 	};
-	iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_ccm_pmic_rdy: IOMUXC_GPIO_EMC_32_CCM_PMIC_RDY {
 		pinmux = <0x401f8094 3 0x401f83fc 4 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_csi_data21: IOMUXC_GPIO_EMC_32_CSI_DATA21 {
 		pinmux = <0x401f8094 4 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_enet2_tx_en: IOMUXC_GPIO_EMC_32_ENET2_TX_EN {
 		pinmux = <0x401f8094 8 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_flexpwm3_pwmb1: IOMUXC_GPIO_EMC_32_FLEXPWM3_PWMB1 {
 		pinmux = <0x401f8094 1 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio3_io18: IOMUXC_GPIO_EMC_32_GPIO3_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_gpio8_io18: IOMUXC_GPIO_EMC_32_GPIO8_IO18 {
 		pinmux = <0x401f8094 5 0x0 0 0x401f8284>;
 		gpr = <0x400ac070 0x12 0x1>;
 	};
-	iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_lpuart7_rx: IOMUXC_GPIO_EMC_32_LPUART7_RX {
 		pinmux = <0x401f8094 2 0x401f8558 1 0x401f8284>;
 	};
-	iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_32_semc_data10: IOMUXC_GPIO_EMC_32_SEMC_DATA10 {
 		pinmux = <0x401f8094 0 0x0 0 0x401f8284>;
 	};
-	iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_csi_data20: IOMUXC_GPIO_EMC_33_CSI_DATA20 {
 		pinmux = <0x401f8098 4 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_ref_clk2: IOMUXC_GPIO_EMC_33_ENET2_REF_CLK2 {
 		pinmux = <0x401f8098 9 0x401f870c 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_enet2_tx_clk: IOMUXC_GPIO_EMC_33_ENET2_TX_CLK {
 		pinmux = <0x401f8098 8 0x401f8728 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_flexpwm3_pwma2: IOMUXC_GPIO_EMC_33_FLEXPWM3_PWMA2 {
 		pinmux = <0x401f8098 1 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio3_io19: IOMUXC_GPIO_EMC_33_GPIO3_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_gpio8_io19: IOMUXC_GPIO_EMC_33_GPIO8_IO19 {
 		pinmux = <0x401f8098 5 0x0 0 0x401f8288>;
 		gpr = <0x400ac070 0x13 0x1>;
 	};
-	iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_sai3_rx_data: IOMUXC_GPIO_EMC_33_SAI3_RX_DATA {
 		pinmux = <0x401f8098 3 0x401f8778 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_semc_data11: IOMUXC_GPIO_EMC_33_SEMC_DATA11 {
 		pinmux = <0x401f8098 0 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_33_usdhc1_reset_b: IOMUXC_GPIO_EMC_33_USDHC1_RESET_B {
 		pinmux = <0x401f8098 2 0x0 0 0x401f8288>;
 	};
-	iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_csi_data19: IOMUXC_GPIO_EMC_34_CSI_DATA19 {
 		pinmux = <0x401f809c 4 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_enet2_rx_er: IOMUXC_GPIO_EMC_34_ENET2_RX_ER {
 		pinmux = <0x401f809c 8 0x401f8720 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_flexpwm3_pwmb2: IOMUXC_GPIO_EMC_34_FLEXPWM3_PWMB2 {
 		pinmux = <0x401f809c 1 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio3_io20: IOMUXC_GPIO_EMC_34_GPIO3_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_gpio8_io20: IOMUXC_GPIO_EMC_34_GPIO8_IO20 {
 		pinmux = <0x401f809c 5 0x0 0 0x401f828c>;
 		gpr = <0x400ac070 0x14 0x1>;
 	};
-	iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_sai3_rx_sync: IOMUXC_GPIO_EMC_34_SAI3_RX_SYNC {
 		pinmux = <0x401f809c 3 0x401f877c 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_semc_data12: IOMUXC_GPIO_EMC_34_SEMC_DATA12 {
 		pinmux = <0x401f809c 0 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_34_usdhc1_vselect: IOMUXC_GPIO_EMC_34_USDHC1_VSELECT {
 		pinmux = <0x401f809c 2 0x0 0 0x401f828c>;
 	};
-	iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_csi_data18: IOMUXC_GPIO_EMC_35_CSI_DATA18 {
 		pinmux = <0x401f80a0 4 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_enet2_rx_data0: IOMUXC_GPIO_EMC_35_ENET2_RX_DATA0 {
 		pinmux = <0x401f80a0 8 0x401f8714 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio3_io21: IOMUXC_GPIO_EMC_35_GPIO3_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpio8_io21: IOMUXC_GPIO_EMC_35_GPIO8_IO21 {
 		pinmux = <0x401f80a0 5 0x0 0 0x401f8290>;
 		gpr = <0x400ac070 0x15 0x1>;
 	};
-	iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_gpt1_compare1: IOMUXC_GPIO_EMC_35_GPT1_COMPARE1 {
 		pinmux = <0x401f80a0 2 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_sai3_rx_bclk: IOMUXC_GPIO_EMC_35_SAI3_RX_BCLK {
 		pinmux = <0x401f80a0 3 0x401f8774 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_semc_data13: IOMUXC_GPIO_EMC_35_SEMC_DATA13 {
 		pinmux = <0x401f80a0 0 0x0 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_usdhc1_cd_b: IOMUXC_GPIO_EMC_35_USDHC1_CD_B {
 		pinmux = <0x401f80a0 6 0x401f85d4 0 0x401f8290>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_in18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_IN18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_35_xbar1_xbar_inout18: IOMUXC_GPIO_EMC_35_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x401f80a0 1 0x401f8630 0 0x401f8290>;
 		gpr = <0x400ac018 0x1e 0x0>;
 	};
-	iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_csi_data17: IOMUXC_GPIO_EMC_36_CSI_DATA17 {
 		pinmux = <0x401f80a4 4 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_enet2_rx_data1: IOMUXC_GPIO_EMC_36_ENET2_RX_DATA1 {
 		pinmux = <0x401f80a4 8 0x401f8718 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_flexcan3_tx: IOMUXC_GPIO_EMC_36_FLEXCAN3_TX {
 		pinmux = <0x401f80a4 9 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio3_io22: IOMUXC_GPIO_EMC_36_GPIO3_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpio8_io22: IOMUXC_GPIO_EMC_36_GPIO8_IO22 {
 		pinmux = <0x401f80a4 5 0x0 0 0x401f8294>;
 		gpr = <0x400ac070 0x16 0x1>;
 	};
-	iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_gpt1_compare2: IOMUXC_GPIO_EMC_36_GPT1_COMPARE2 {
 		pinmux = <0x401f80a4 2 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_sai3_tx_data: IOMUXC_GPIO_EMC_36_SAI3_TX_DATA {
 		pinmux = <0x401f80a4 3 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_semc_data14: IOMUXC_GPIO_EMC_36_SEMC_DATA14 {
 		pinmux = <0x401f80a4 0 0x0 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_usdhc1_wp: IOMUXC_GPIO_EMC_36_USDHC1_WP {
 		pinmux = <0x401f80a4 6 0x401f85d8 1 0x401f8294>;
 	};
-	iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_36_xbar1_xbar_in22: IOMUXC_GPIO_EMC_36_XBAR1_XBAR_IN22 {
 		pinmux = <0x401f80a4 1 0x401f8638 0 0x401f8294>;
 	};
-	iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_csi_data16: IOMUXC_GPIO_EMC_37_CSI_DATA16 {
 		pinmux = <0x401f80a8 4 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_enet2_rx_en: IOMUXC_GPIO_EMC_37_ENET2_RX_EN {
 		pinmux = <0x401f80a8 8 0x401f871c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_flexcan3_rx: IOMUXC_GPIO_EMC_37_FLEXCAN3_RX {
 		pinmux = <0x401f80a8 9 0x401f878c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio3_io23: IOMUXC_GPIO_EMC_37_GPIO3_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpio8_io23: IOMUXC_GPIO_EMC_37_GPIO8_IO23 {
 		pinmux = <0x401f80a8 5 0x0 0 0x401f8298>;
 		gpr = <0x400ac070 0x17 0x1>;
 	};
-	iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_gpt1_compare3: IOMUXC_GPIO_EMC_37_GPT1_COMPARE3 {
 		pinmux = <0x401f80a8 2 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_sai3_mclk: IOMUXC_GPIO_EMC_37_SAI3_MCLK {
 		pinmux = <0x401f80a8 3 0x401f8770 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_semc_data15: IOMUXC_GPIO_EMC_37_SEMC_DATA15 {
 		pinmux = <0x401f80a8 0 0x0 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_usdhc2_wp: IOMUXC_GPIO_EMC_37_USDHC2_WP {
 		pinmux = <0x401f80a8 6 0x401f8608 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_37_xbar1_xbar_in23: IOMUXC_GPIO_EMC_37_XBAR1_XBAR_IN23 {
 		pinmux = <0x401f80a8 1 0x401f863c 0 0x401f8298>;
 	};
-	iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_csi_field: IOMUXC_GPIO_EMC_38_CSI_FIELD {
 		pinmux = <0x401f80ac 4 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_enet2_mdc: IOMUXC_GPIO_EMC_38_ENET2_MDC {
 		pinmux = <0x401f80ac 8 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_flexpwm1_pwma3: IOMUXC_GPIO_EMC_38_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f80ac 1 0x401f8454 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio3_io24: IOMUXC_GPIO_EMC_38_GPIO3_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_gpio8_io24: IOMUXC_GPIO_EMC_38_GPIO8_IO24 {
 		pinmux = <0x401f80ac 5 0x0 0 0x401f829c>;
 		gpr = <0x400ac070 0x18 0x1>;
 	};
-	iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_lpuart8_tx: IOMUXC_GPIO_EMC_38_LPUART8_TX {
 		pinmux = <0x401f80ac 2 0x401f8564 2 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_sai3_tx_bclk: IOMUXC_GPIO_EMC_38_SAI3_TX_BCLK {
 		pinmux = <0x401f80ac 3 0x401f8780 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_semc_dm1: IOMUXC_GPIO_EMC_38_SEMC_DM1 {
 		pinmux = <0x401f80ac 0 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_38_usdhc2_vselect: IOMUXC_GPIO_EMC_38_USDHC2_VSELECT {
 		pinmux = <0x401f80ac 6 0x0 0 0x401f829c>;
 	};
-	iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_enet2_mdio: IOMUXC_GPIO_EMC_39_ENET2_MDIO {
 		pinmux = <0x401f80b0 8 0x401f8710 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_flexpwm1_pwmb3: IOMUXC_GPIO_EMC_39_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f80b0 1 0x401f8464 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio3_io25: IOMUXC_GPIO_EMC_39_GPIO3_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_gpio8_io25: IOMUXC_GPIO_EMC_39_GPIO8_IO25 {
 		pinmux = <0x401f80b0 5 0x0 0 0x401f82a0>;
 		gpr = <0x400ac070 0x19 0x1>;
 	};
-	iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_lpuart8_rx: IOMUXC_GPIO_EMC_39_LPUART8_RX {
 		pinmux = <0x401f80b0 2 0x401f8560 2 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_sai3_tx_sync: IOMUXC_GPIO_EMC_39_SAI3_TX_SYNC {
 		pinmux = <0x401f80b0 3 0x401f8784 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs: IOMUXC_GPIO_EMC_39_SEMC_DQS {
 		pinmux = <0x401f80b0 0 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_semc_dqs4: IOMUXC_GPIO_EMC_39_SEMC_DQS4 {
 		pinmux = <0x401f80b0 9 0x401f8788 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_usdhc2_cd_b: IOMUXC_GPIO_EMC_39_USDHC2_CD_B {
 		pinmux = <0x401f80b0 6 0x401f85e0 1 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_39_wdog1_b: IOMUXC_GPIO_EMC_39_WDOG1_B {
 		pinmux = <0x401f80b0 4 0x0 0 0x401f82a0>;
 	};
-	iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_enet_mdc: IOMUXC_GPIO_EMC_40_ENET_MDC {
 		pinmux = <0x401f80b4 4 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio3_io26: IOMUXC_GPIO_EMC_40_GPIO3_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpio8_io26: IOMUXC_GPIO_EMC_40_GPIO8_IO26 {
 		pinmux = <0x401f80b4 5 0x0 0 0x401f82a4>;
 		gpr = <0x400ac070 0x1a 0x1>;
 	};
-	iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_gpt2_capture2: IOMUXC_GPIO_EMC_40_GPT2_CAPTURE2 {
 		pinmux = <0x401f80b4 1 0x401f8768 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_lpspi1_pcs2: IOMUXC_GPIO_EMC_40_LPSPI1_PCS2 {
 		pinmux = <0x401f80b4 2 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_clk5: IOMUXC_GPIO_EMC_40_SEMC_CLK5 {
 		pinmux = <0x401f80b4 9 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_semc_rdy: IOMUXC_GPIO_EMC_40_SEMC_RDY {
 		pinmux = <0x401f80b4 0 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usb_otg2_oc: IOMUXC_GPIO_EMC_40_USB_OTG2_OC {
 		pinmux = <0x401f80b4 3 0x401f85cc 1 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_40_usdhc2_reset_b: IOMUXC_GPIO_EMC_40_USDHC2_RESET_B {
 		pinmux = <0x401f80b4 6 0x0 0 0x401f82a4>;
 	};
-	iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_enet_mdio: IOMUXC_GPIO_EMC_41_ENET_MDIO {
 		pinmux = <0x401f80b8 4 0x401f8430 1 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio3_io27: IOMUXC_GPIO_EMC_41_GPIO3_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpio8_io27: IOMUXC_GPIO_EMC_41_GPIO8_IO27 {
 		pinmux = <0x401f80b8 5 0x0 0 0x401f82a8>;
 		gpr = <0x400ac070 0x1b 0x1>;
 	};
-	iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_gpt2_capture1: IOMUXC_GPIO_EMC_41_GPT2_CAPTURE1 {
 		pinmux = <0x401f80b8 1 0x401f8764 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_lpspi1_pcs3: IOMUXC_GPIO_EMC_41_LPSPI1_PCS3 {
 		pinmux = <0x401f80b8 2 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_semc_csx0: IOMUXC_GPIO_EMC_41_SEMC_CSX0 {
 		pinmux = <0x401f80b8 0 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usb_otg2_pwr: IOMUXC_GPIO_EMC_41_USB_OTG2_PWR {
 		pinmux = <0x401f80b8 3 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_41_usdhc1_vselect: IOMUXC_GPIO_EMC_41_USDHC1_VSELECT {
 		pinmux = <0x401f80b8 6 0x0 0 0x401f82a8>;
 	};
-	iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_enet2_tx_en: IOMUXC_GPIO_SD_B0_00_ENET2_TX_EN {
 		pinmux = <0x401f81bc 8 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexpwm1_pwma0: IOMUXC_GPIO_SD_B0_00_FLEXPWM1_PWMA0 {
 		pinmux = <0x401f81bc 1 0x401f8458 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B0_00_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81bc 6 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio3_io12: IOMUXC_GPIO_SD_B0_00_GPIO3_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_gpio8_io12: IOMUXC_GPIO_SD_B0_00_GPIO8_IO12 {
 		pinmux = <0x401f81bc 5 0x0 0 0x401f83ac>;
 		gpr = <0x400ac070 0xc 0x1>;
 	};
-	iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpi2c3_scl: IOMUXC_GPIO_SD_B0_00_LPI2C3_SCL {
 		pinmux = <0x401f81bc 2 0x401f84dc 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_lpspi1_sck: IOMUXC_GPIO_SD_B0_00_LPSPI1_SCK {
 		pinmux = <0x401f81bc 4 0x401f84f0 1 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_semc_dqs4: IOMUXC_GPIO_SD_B0_00_SEMC_DQS4 {
 		pinmux = <0x401f81bc 9 0x401f8788 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_usdhc1_cmd: IOMUXC_GPIO_SD_B0_00_USDHC1_CMD {
 		pinmux = <0x401f81bc 0 0x0 0 0x401f83ac>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_in04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_IN04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_00_xbar1_xbar_inout04: IOMUXC_GPIO_SD_B0_00_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x401f81bc 3 0x401f8614 1 0x401f83ac>;
 		gpr = <0x400ac018 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_ref_clk2: IOMUXC_GPIO_SD_B0_01_ENET2_REF_CLK2 {
 		pinmux = <0x401f81c0 9 0x401f870c 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_enet2_tx_clk: IOMUXC_GPIO_SD_B0_01_ENET2_TX_CLK {
 		pinmux = <0x401f81c0 8 0x401f8728 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0: IOMUXC_GPIO_SD_B0_01_FLEXPWM1_PWMB0 {
 		pinmux = <0x401f81c0 1 0x401f8468 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_flexspi_b_ss1_b: IOMUXC_GPIO_SD_B0_01_FLEXSPI_B_SS1_B {
 		pinmux = <0x401f81c0 6 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio3_io13: IOMUXC_GPIO_SD_B0_01_GPIO3_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_gpio8_io13: IOMUXC_GPIO_SD_B0_01_GPIO8_IO13 {
 		pinmux = <0x401f81c0 5 0x0 0 0x401f83b0>;
 		gpr = <0x400ac070 0xd 0x1>;
 	};
-	iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpi2c3_sda: IOMUXC_GPIO_SD_B0_01_LPI2C3_SDA {
 		pinmux = <0x401f81c0 2 0x401f84e0 1 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_lpspi1_pcs0: IOMUXC_GPIO_SD_B0_01_LPSPI1_PCS0 {
 		pinmux = <0x401f81c0 4 0x401f84ec 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_usdhc1_clk: IOMUXC_GPIO_SD_B0_01_USDHC1_CLK {
 		pinmux = <0x401f81c0 0 0x0 0 0x401f83b0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_in05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_IN05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_01_xbar1_xbar_inout05: IOMUXC_GPIO_SD_B0_01_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x401f81c0 3 0x401f8618 1 0x401f83b0>;
 		gpr = <0x400ac018 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_enet2_rx_er: IOMUXC_GPIO_SD_B0_02_ENET2_RX_ER {
 		pinmux = <0x401f81c4 8 0x401f8720 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_flexpwm1_pwma1: IOMUXC_GPIO_SD_B0_02_FLEXPWM1_PWMA1 {
 		pinmux = <0x401f81c4 1 0x401f845c 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio3_io14: IOMUXC_GPIO_SD_B0_02_GPIO3_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_gpio8_io14: IOMUXC_GPIO_SD_B0_02_GPIO8_IO14 {
 		pinmux = <0x401f81c4 5 0x0 0 0x401f83b4>;
 		gpr = <0x400ac070 0xe 0x1>;
 	};
-	iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpspi1_sdo: IOMUXC_GPIO_SD_B0_02_LPSPI1_SDO {
 		pinmux = <0x401f81c4 4 0x401f84f8 1 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_lpuart8_cts_b: IOMUXC_GPIO_SD_B0_02_LPUART8_CTS_B {
 		pinmux = <0x401f81c4 2 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_semc_clk5: IOMUXC_GPIO_SD_B0_02_SEMC_CLK5 {
 		pinmux = <0x401f81c4 9 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_usdhc1_data0: IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0 {
 		pinmux = <0x401f81c4 0 0x0 0 0x401f83b4>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_in06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_IN06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_02_xbar1_xbar_inout06: IOMUXC_GPIO_SD_B0_02_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x401f81c4 3 0x401f861c 1 0x401f83b4>;
 		gpr = <0x400ac018 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_enet2_rx_data0: IOMUXC_GPIO_SD_B0_03_ENET2_RX_DATA0 {
 		pinmux = <0x401f81c8 8 0x401f8714 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_flexpwm1_pwmb1: IOMUXC_GPIO_SD_B0_03_FLEXPWM1_PWMB1 {
 		pinmux = <0x401f81c8 1 0x401f846c 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio3_io15: IOMUXC_GPIO_SD_B0_03_GPIO3_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_gpio8_io15: IOMUXC_GPIO_SD_B0_03_GPIO8_IO15 {
 		pinmux = <0x401f81c8 5 0x0 0 0x401f83b8>;
 		gpr = <0x400ac070 0xf 0x1>;
 	};
-	iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpspi1_sdi: IOMUXC_GPIO_SD_B0_03_LPSPI1_SDI {
 		pinmux = <0x401f81c8 4 0x401f84f4 1 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_lpuart8_rts_b: IOMUXC_GPIO_SD_B0_03_LPUART8_RTS_B {
 		pinmux = <0x401f81c8 2 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_semc_clk6: IOMUXC_GPIO_SD_B0_03_SEMC_CLK6 {
 		pinmux = <0x401f81c8 9 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_usdhc1_data1: IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1 {
 		pinmux = <0x401f81c8 0 0x0 0 0x401f83b8>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_in07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_IN07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_03_xbar1_xbar_inout07: IOMUXC_GPIO_SD_B0_03_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x401f81c8 3 0x401f8620 1 0x401f83b8>;
 		gpr = <0x400ac018 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_ccm_clko1: IOMUXC_GPIO_SD_B0_04_CCM_CLKO1 {
 		pinmux = <0x401f81cc 6 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_enet2_rx_data1: IOMUXC_GPIO_SD_B0_04_ENET2_RX_DATA1 {
 		pinmux = <0x401f81cc 8 0x401f8718 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexpwm1_pwma2: IOMUXC_GPIO_SD_B0_04_FLEXPWM1_PWMA2 {
 		pinmux = <0x401f81cc 1 0x401f8460 1 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B0_04_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81cc 4 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio3_io16: IOMUXC_GPIO_SD_B0_04_GPIO3_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_gpio8_io16: IOMUXC_GPIO_SD_B0_04_GPIO8_IO16 {
 		pinmux = <0x401f81cc 5 0x0 0 0x401f83bc>;
 		gpr = <0x400ac070 0x10 0x1>;
 	};
-	iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_lpuart8_tx: IOMUXC_GPIO_SD_B0_04_LPUART8_TX {
 		pinmux = <0x401f81cc 2 0x401f8564 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_usdhc1_data2: IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2 {
 		pinmux = <0x401f81cc 0 0x0 0 0x401f83bc>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_in08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_IN08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_04_xbar1_xbar_inout08: IOMUXC_GPIO_SD_B0_04_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x401f81cc 3 0x401f8624 1 0x401f83bc>;
 		gpr = <0x400ac018 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_ccm_clko2: IOMUXC_GPIO_SD_B0_05_CCM_CLKO2 {
 		pinmux = <0x401f81d0 6 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_enet2_rx_en: IOMUXC_GPIO_SD_B0_05_ENET2_RX_EN {
 		pinmux = <0x401f81d0 8 0x401f871c 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexpwm1_pwmb2: IOMUXC_GPIO_SD_B0_05_FLEXPWM1_PWMB2 {
 		pinmux = <0x401f81d0 1 0x401f8470 1 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_flexspi_b_dqs: IOMUXC_GPIO_SD_B0_05_FLEXSPI_B_DQS {
 		pinmux = <0x401f81d0 4 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio3_io17: IOMUXC_GPIO_SD_B0_05_GPIO3_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_gpio8_io17: IOMUXC_GPIO_SD_B0_05_GPIO8_IO17 {
 		pinmux = <0x401f81d0 5 0x0 0 0x401f83c0>;
 		gpr = <0x400ac070 0x11 0x1>;
 	};
-	iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_lpuart8_rx: IOMUXC_GPIO_SD_B0_05_LPUART8_RX {
 		pinmux = <0x401f81d0 2 0x401f8560 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_usdhc1_data3: IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3 {
 		pinmux = <0x401f81d0 0 0x0 0 0x401f83c0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_in09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_IN09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b0_05_xbar1_xbar_inout09: IOMUXC_GPIO_SD_B0_05_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x401f81d0 3 0x401f8628 1 0x401f83c0>;
 		gpr = <0x400ac018 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexpwm1_pwma3: IOMUXC_GPIO_SD_B1_00_FLEXPWM1_PWMA3 {
 		pinmux = <0x401f81d4 2 0x401f8454 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi_b_data3: IOMUXC_GPIO_SD_B1_00_FLEXSPI_B_DATA3 {
 		pinmux = <0x401f81d4 1 0x401f84c4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio3_io00: IOMUXC_GPIO_SD_B1_00_GPIO3_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio8_io00: IOMUXC_GPIO_SD_B1_00_GPIO8_IO00 {
 		pinmux = <0x401f81d4 5 0x0 0 0x401f83c4>;
 		gpr = <0x400ac070 0x0 0x1>;
 	};
-	iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_lpuart4_tx: IOMUXC_GPIO_SD_B1_00_LPUART4_TX {
 		pinmux = <0x401f81d4 4 0x401f8544 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai1_tx_data3: IOMUXC_GPIO_SD_B1_00_SAI1_TX_DATA3 {
 		pinmux = <0x401f81d4 3 0x401f8598 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_sai3_rx_data: IOMUXC_GPIO_SD_B1_00_SAI3_RX_DATA {
 		pinmux = <0x401f81d4 8 0x401f8778 1 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc2_data3: IOMUXC_GPIO_SD_B1_00_USDHC2_DATA3 {
 		pinmux = <0x401f81d4 0 0x401f85f4 0 0x401f83c4>;
 	};
-	iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexpwm1_pwmb3: IOMUXC_GPIO_SD_B1_01_FLEXPWM1_PWMB3 {
 		pinmux = <0x401f81d8 2 0x401f8464 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi_b_data2: IOMUXC_GPIO_SD_B1_01_FLEXSPI_B_DATA2 {
 		pinmux = <0x401f81d8 1 0x401f84c0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio3_io01: IOMUXC_GPIO_SD_B1_01_GPIO3_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio8_io01: IOMUXC_GPIO_SD_B1_01_GPIO8_IO01 {
 		pinmux = <0x401f81d8 5 0x0 0 0x401f83c8>;
 		gpr = <0x400ac070 0x1 0x1>;
 	};
-	iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_lpuart4_rx: IOMUXC_GPIO_SD_B1_01_LPUART4_RX {
 		pinmux = <0x401f81d8 4 0x401f8540 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai1_tx_data2: IOMUXC_GPIO_SD_B1_01_SAI1_TX_DATA2 {
 		pinmux = <0x401f81d8 3 0x401f859c 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_sai3_tx_data: IOMUXC_GPIO_SD_B1_01_SAI3_TX_DATA {
 		pinmux = <0x401f81d8 8 0x0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc2_data2: IOMUXC_GPIO_SD_B1_01_USDHC2_DATA2 {
 		pinmux = <0x401f81d8 0 0x401f85f0 0 0x401f83c8>;
 	};
-	iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_ccm_wait: IOMUXC_GPIO_SD_B1_02_CCM_WAIT {
 		pinmux = <0x401f81dc 6 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexcan1_tx: IOMUXC_GPIO_SD_B1_02_FLEXCAN1_TX {
 		pinmux = <0x401f81dc 4 0x0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexpwm2_pwma3: IOMUXC_GPIO_SD_B1_02_FLEXPWM2_PWMA3 {
 		pinmux = <0x401f81dc 2 0x401f8474 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi_b_data1: IOMUXC_GPIO_SD_B1_02_FLEXSPI_B_DATA1 {
 		pinmux = <0x401f81dc 1 0x401f84bc 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio3_io02: IOMUXC_GPIO_SD_B1_02_GPIO3_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio8_io02: IOMUXC_GPIO_SD_B1_02_GPIO8_IO02 {
 		pinmux = <0x401f81dc 5 0x0 0 0x401f83cc>;
 		gpr = <0x400ac070 0x2 0x1>;
 	};
-	iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai1_tx_data1: IOMUXC_GPIO_SD_B1_02_SAI1_TX_DATA1 {
 		pinmux = <0x401f81dc 3 0x401f85a0 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_sai3_tx_sync: IOMUXC_GPIO_SD_B1_02_SAI3_TX_SYNC {
 		pinmux = <0x401f81dc 8 0x401f8784 1 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc2_data1: IOMUXC_GPIO_SD_B1_02_USDHC2_DATA1 {
 		pinmux = <0x401f81dc 0 0x401f85ec 0 0x401f83cc>;
 	};
-	iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_ccm_pmic_rdy: IOMUXC_GPIO_SD_B1_03_CCM_PMIC_RDY {
 		pinmux = <0x401f81e0 6 0x401f83fc 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexcan1_rx: IOMUXC_GPIO_SD_B1_03_FLEXCAN1_RX {
 		pinmux = <0x401f81e0 4 0x401f844c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexpwm2_pwmb3: IOMUXC_GPIO_SD_B1_03_FLEXPWM2_PWMB3 {
 		pinmux = <0x401f81e0 2 0x401f8484 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi_b_data0: IOMUXC_GPIO_SD_B1_03_FLEXSPI_B_DATA0 {
 		pinmux = <0x401f81e0 1 0x401f84b8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio3_io03: IOMUXC_GPIO_SD_B1_03_GPIO3_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio8_io03: IOMUXC_GPIO_SD_B1_03_GPIO8_IO03 {
 		pinmux = <0x401f81e0 5 0x0 0 0x401f83d0>;
 		gpr = <0x400ac070 0x3 0x1>;
 	};
-	iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai1_mclk: IOMUXC_GPIO_SD_B1_03_SAI1_MCLK {
 		pinmux = <0x401f81e0 3 0x401f858c 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_sai3_tx_bclk: IOMUXC_GPIO_SD_B1_03_SAI3_TX_BCLK {
 		pinmux = <0x401f81e0 8 0x401f8780 1 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc2_data0: IOMUXC_GPIO_SD_B1_03_USDHC2_DATA0 {
 		pinmux = <0x401f81e0 0 0x401f85e8 0 0x401f83d0>;
 	};
-	iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_ccm_stop: IOMUXC_GPIO_SD_B1_04_CCM_STOP {
 		pinmux = <0x401f81e4 6 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_a_ss1_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI_A_SS1_B {
 		pinmux = <0x401f81e4 4 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi_b_sclk: IOMUXC_GPIO_SD_B1_04_FLEXSPI_B_SCLK {
 		pinmux = <0x401f81e4 1 0x0 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio3_io04: IOMUXC_GPIO_SD_B1_04_GPIO3_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio8_io04: IOMUXC_GPIO_SD_B1_04_GPIO8_IO04 {
 		pinmux = <0x401f81e4 5 0x0 0 0x401f83d4>;
 		gpr = <0x400ac070 0x4 0x1>;
 	};
-	iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_lpi2c1_scl: IOMUXC_GPIO_SD_B1_04_LPI2C1_SCL {
 		pinmux = <0x401f81e4 2 0x401f84cc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai1_rx_sync: IOMUXC_GPIO_SD_B1_04_SAI1_RX_SYNC {
 		pinmux = <0x401f81e4 3 0x401f85a4 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_sai3_mclk: IOMUXC_GPIO_SD_B1_04_SAI3_MCLK {
 		pinmux = <0x401f81e4 8 0x401f8770 1 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc2_clk: IOMUXC_GPIO_SD_B1_04_USDHC2_CLK {
 		pinmux = <0x401f81e4 0 0x401f85dc 0 0x401f83d4>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_a_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI_A_DQS {
 		pinmux = <0x401f81e8 1 0x401f84a4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi_b_ss0_b: IOMUXC_GPIO_SD_B1_05_FLEXSPI_B_SS0_B {
 		pinmux = <0x401f81e8 4 0x0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio3_io05: IOMUXC_GPIO_SD_B1_05_GPIO3_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio8_io05: IOMUXC_GPIO_SD_B1_05_GPIO8_IO05 {
 		pinmux = <0x401f81e8 5 0x0 0 0x401f83d8>;
 		gpr = <0x400ac070 0x5 0x1>;
 	};
-	iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_lpi2c1_sda: IOMUXC_GPIO_SD_B1_05_LPI2C1_SDA {
 		pinmux = <0x401f81e8 2 0x401f84d0 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai1_rx_bclk: IOMUXC_GPIO_SD_B1_05_SAI1_RX_BCLK {
 		pinmux = <0x401f81e8 3 0x401f8590 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_sai3_rx_sync: IOMUXC_GPIO_SD_B1_05_SAI3_RX_SYNC {
 		pinmux = <0x401f81e8 8 0x401f877c 1 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc2_cmd: IOMUXC_GPIO_SD_B1_05_USDHC2_CMD {
 		pinmux = <0x401f81e8 0 0x401f85e4 0 0x401f83d8>;
 	};
-	iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_flexspi_a_ss0_b: IOMUXC_GPIO_SD_B1_06_FLEXSPI_A_SS0_B {
 		pinmux = <0x401f81ec 1 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio3_io06: IOMUXC_GPIO_SD_B1_06_GPIO3_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x0>;
 	};
-	iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_gpio8_io06: IOMUXC_GPIO_SD_B1_06_GPIO8_IO06 {
 		pinmux = <0x401f81ec 5 0x0 0 0x401f83dc>;
 		gpr = <0x400ac070 0x6 0x1>;
 	};
-	iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpspi2_pcs0: IOMUXC_GPIO_SD_B1_06_LPSPI2_PCS0 {
 		pinmux = <0x401f81ec 4 0x401f84fc 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_lpuart7_cts_b: IOMUXC_GPIO_SD_B1_06_LPUART7_CTS_B {
 		pinmux = <0x401f81ec 2 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai1_rx_data0: IOMUXC_GPIO_SD_B1_06_SAI1_RX_DATA0 {
 		pinmux = <0x401f81ec 3 0x401f8594 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_sai3_rx_bclk: IOMUXC_GPIO_SD_B1_06_SAI3_RX_BCLK {
 		pinmux = <0x401f81ec 8 0x401f8774 1 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B1_06_USDHC2_RESET_B {
 		pinmux = <0x401f81ec 0 0x0 0 0x401f83dc>;
 	};
-	iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_flexspi_a_sclk: IOMUXC_GPIO_SD_B1_07_FLEXSPI_A_SCLK {
 		pinmux = <0x401f81f0 1 0x401f84c8 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio3_io07: IOMUXC_GPIO_SD_B1_07_GPIO3_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x0>;
 	};
-	iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_gpio8_io07: IOMUXC_GPIO_SD_B1_07_GPIO8_IO07 {
 		pinmux = <0x401f81f0 5 0x0 0 0x401f83e0>;
 		gpr = <0x400ac070 0x7 0x1>;
 	};
-	iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpspi2_sck: IOMUXC_GPIO_SD_B1_07_LPSPI2_SCK {
 		pinmux = <0x401f81f0 4 0x401f8500 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_lpuart7_rts_b: IOMUXC_GPIO_SD_B1_07_LPUART7_RTS_B {
 		pinmux = <0x401f81f0 2 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_sai1_tx_data0: IOMUXC_GPIO_SD_B1_07_SAI1_TX_DATA0 {
 		pinmux = <0x401f81f0 3 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_07_semc_csx1: IOMUXC_GPIO_SD_B1_07_SEMC_CSX1 {
 		pinmux = <0x401f81f0 0 0x0 0 0x401f83e0>;
 	};
-	iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_flexspi_a_data0: IOMUXC_GPIO_SD_B1_08_FLEXSPI_A_DATA0 {
 		pinmux = <0x401f81f4 1 0x401f84a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio3_io08: IOMUXC_GPIO_SD_B1_08_GPIO3_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x0>;
 	};
-	iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_gpio8_io08: IOMUXC_GPIO_SD_B1_08_GPIO8_IO08 {
 		pinmux = <0x401f81f4 5 0x0 0 0x401f83e4>;
 		gpr = <0x400ac070 0x8 0x1>;
 	};
-	iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpspi2_sdo: IOMUXC_GPIO_SD_B1_08_LPSPI2_SDO {
 		pinmux = <0x401f81f4 4 0x401f8508 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_lpuart7_tx: IOMUXC_GPIO_SD_B1_08_LPUART7_TX {
 		pinmux = <0x401f81f4 2 0x401f855c 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_sai1_tx_bclk: IOMUXC_GPIO_SD_B1_08_SAI1_TX_BCLK {
 		pinmux = <0x401f81f4 3 0x401f85a8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_semc_csx2: IOMUXC_GPIO_SD_B1_08_SEMC_CSX2 {
 		pinmux = <0x401f81f4 6 0x0 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_08_usdhc2_data4: IOMUXC_GPIO_SD_B1_08_USDHC2_DATA4 {
 		pinmux = <0x401f81f4 0 0x401f85f8 0 0x401f83e4>;
 	};
-	iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_flexspi_a_data1: IOMUXC_GPIO_SD_B1_09_FLEXSPI_A_DATA1 {
 		pinmux = <0x401f81f8 1 0x401f84ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio3_io09: IOMUXC_GPIO_SD_B1_09_GPIO3_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x0>;
 	};
-	iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_gpio8_io09: IOMUXC_GPIO_SD_B1_09_GPIO8_IO09 {
 		pinmux = <0x401f81f8 5 0x0 0 0x401f83e8>;
 		gpr = <0x400ac070 0x9 0x1>;
 	};
-	iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpspi2_sdi: IOMUXC_GPIO_SD_B1_09_LPSPI2_SDI {
 		pinmux = <0x401f81f8 4 0x401f8504 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_lpuart7_rx: IOMUXC_GPIO_SD_B1_09_LPUART7_RX {
 		pinmux = <0x401f81f8 2 0x401f8558 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_sai1_tx_sync: IOMUXC_GPIO_SD_B1_09_SAI1_TX_SYNC {
 		pinmux = <0x401f81f8 3 0x401f85ac 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_09_usdhc2_data5: IOMUXC_GPIO_SD_B1_09_USDHC2_DATA5 {
 		pinmux = <0x401f81f8 0 0x401f85fc 0 0x401f83e8>;
 	};
-	iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_flexspi_a_data2: IOMUXC_GPIO_SD_B1_10_FLEXSPI_A_DATA2 {
 		pinmux = <0x401f81fc 1 0x401f84b0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio3_io10: IOMUXC_GPIO_SD_B1_10_GPIO3_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x0>;
 	};
-	iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_gpio8_io10: IOMUXC_GPIO_SD_B1_10_GPIO8_IO10 {
 		pinmux = <0x401f81fc 5 0x0 0 0x401f83ec>;
 		gpr = <0x400ac070 0xa 0x1>;
 	};
-	iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpi2c2_sda: IOMUXC_GPIO_SD_B1_10_LPI2C2_SDA {
 		pinmux = <0x401f81fc 3 0x401f84d8 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpspi2_pcs2: IOMUXC_GPIO_SD_B1_10_LPSPI2_PCS2 {
 		pinmux = <0x401f81fc 4 0x0 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_lpuart2_rx: IOMUXC_GPIO_SD_B1_10_LPUART2_RX {
 		pinmux = <0x401f81fc 2 0x401f852c 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_10_usdhc2_data6: IOMUXC_GPIO_SD_B1_10_USDHC2_DATA6 {
 		pinmux = <0x401f81fc 0 0x401f8600 0 0x401f83ec>;
 	};
-	iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_flexspi_a_data3: IOMUXC_GPIO_SD_B1_11_FLEXSPI_A_DATA3 {
 		pinmux = <0x401f8200 1 0x401f84b4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio3_io11: IOMUXC_GPIO_SD_B1_11_GPIO3_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x0>;
 	};
-	iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_gpio8_io11: IOMUXC_GPIO_SD_B1_11_GPIO8_IO11 {
 		pinmux = <0x401f8200 5 0x0 0 0x401f83f0>;
 		gpr = <0x400ac070 0xb 0x1>;
 	};
-	iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpi2c2_scl: IOMUXC_GPIO_SD_B1_11_LPI2C2_SCL {
 		pinmux = <0x401f8200 3 0x401f84d4 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpspi2_pcs3: IOMUXC_GPIO_SD_B1_11_LPSPI2_PCS3 {
 		pinmux = <0x401f8200 4 0x0 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_lpuart2_tx: IOMUXC_GPIO_SD_B1_11_LPUART2_TX {
 		pinmux = <0x401f8200 2 0x401f8530 0 0x401f83f0>;
 	};
-	iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_11_usdhc2_data7: IOMUXC_GPIO_SD_B1_11_USDHC2_DATA7 {
 		pinmux = <0x401f8200 0 0x401f8604 0 0x401f83f0>;
 	};
-	iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
+	/omit-if-no-ref/ iomuxc_snvs_onoff_src_reset_b: IOMUXC_SNVS_ONOFF_SRC_RESET_B {
 		pinmux = <0x0 0 0x0 0 0x400a8014>;
 	};
-	iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio5_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO5_IO01 {
 		pinmux = <0x400a8004 5 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_PMIC_ON_REQ {
 		pinmux = <0x400a8004 0 0x0 0 0x400a801c>;
 	};
-	iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_ccm_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_CCM_PMIC_VSTBY_REQ {
 		pinmux = <0x400a8008 0 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio5_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO5_IO02 {
 		pinmux = <0x400a8008 5 0x0 0 0x400a8020>;
 	};
-	iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
+	/omit-if-no-ref/ iomuxc_snvs_por_b_src_por_b: IOMUXC_SNVS_POR_B_SRC_POR_B {
 		pinmux = <0x0 0 0x0 0 0x400a8010>;
 	};
-	iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
+	/omit-if-no-ref/ iomuxc_snvs_test_mode_test_mode: IOMUXC_SNVS_TEST_MODE_TEST_MODE {
 		pinmux = <0x0 0 0x0 0 0x400a800c>;
 	};
-	iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_arm_nmi: IOMUXC_SNVS_WAKEUP_ARM_NMI {
 		pinmux = <0x400a8000 7 0x0 0 0x400a8018>;
 	};
-	iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio5_io00: IOMUXC_SNVS_WAKEUP_GPIO5_IO00 {
 		pinmux = <0x400a8000 5 0x0 0 0x400a8018>;
 	};
 };

--- a/dts/nxp/nxp_imx/rt/mimxrt1166cvm5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1166cvm5a-pinctrl.dtsi
@@ -18,6191 +18,6196 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
+ * to correct missing daisy register values
+ */
+
+/*
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};

--- a/dts/nxp/nxp_imx/rt/mimxrt1166dvm6a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1166dvm6a-pinctrl.dtsi
@@ -18,6186 +18,6191 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
+ * to correct missing daisy register values
+ */
+
+/*
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};

--- a/dts/nxp/nxp_imx/rt/mimxrt1166xvm5a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1166xvm5a-pinctrl.dtsi
@@ -18,6191 +18,6191 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};

--- a/dts/nxp/nxp_imx/rt/mimxrt1176avm8a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1176avm8a-pinctrl.dtsi
@@ -18,6362 +18,6362 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
 		pinmux = <0x400e815c 9 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
 		pinmux = <0x400e8160 9 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
 		pinmux = <0x400e8164 9 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
 		pinmux = <0x400e8168 9 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
 		pinmux = <0x400e8174 9 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
 		pinmux = <0x400e8178 9 0x400e84ec 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
 		pinmux = <0x400e81e4 8 0x400e84f8 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
 		pinmux = <0x400e81e8 8 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
 		pinmux = <0x400e81e8 9 0x400e84fc 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
 		pinmux = <0x400e81ec 8 0x400e84f0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
 		pinmux = <0x400e81f0 8 0x400e84f4 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
 		pinmux = <0x400e81f4 8 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
 		pinmux = <0x400e81f8 8 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
 		pinmux = <0x400e81fc 8 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
 		pinmux = <0x400e8200 8 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8204 8 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
 		pinmux = <0x400e8208 8 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
 		pinmux = <0x400e820c 8 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8210 9 0x400e84a0 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8210 8 0x400e84a4 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
 		pinmux = <0x400e8214 8 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
 		pinmux = <0x400e821c 8 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8220 8 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
 		pinmux = <0x400e8224 8 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8228 8 0x400e84a4 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
 		pinmux = <0x400e822c 8 0x400e84f0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
 		pinmux = <0x400e8230 8 0x400e84f4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
 		pinmux = <0x400e8234 8 0x400e84f8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
 		pinmux = <0x400e8238 8 0x400e84fc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
 		pinmux = <0x400e823c 8 0x400e84fc 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
 		pinmux = <0x400e8240 8 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
 		pinmux = <0x400e8244 8 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
 		pinmux = <0x400e8248 8 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
 		pinmux = <0x400e824c 8 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
 		pinmux = <0x400e8250 8 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
 		pinmux = <0x400e80b8 7 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
 		pinmux = <0x400e80bc 7 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
 		pinmux = <0x400e80c0 7 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
 		pinmux = <0x400e8104 8 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
 		pinmux = <0x400e8108 8 0x400e84ec 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8108 3 0x400e84a0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
 		pinmux = <0x400e81ac 9 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
 		pinmux = <0x400e81b0 9 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e81d0 9 0x400e84a0 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};

--- a/dts/nxp/nxp_imx/rt/mimxrt1176cvm8a-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1176cvm8a-pinctrl.dtsi
@@ -18,6362 +18,6367 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
+ * to correct missing daisy register values
+ */
+
+/*
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
 		pinmux = <0x400e815c 9 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
 		pinmux = <0x400e8160 9 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
 		pinmux = <0x400e8164 9 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
 		pinmux = <0x400e8168 9 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
 		pinmux = <0x400e8174 9 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
 		pinmux = <0x400e8178 9 0x400e84ec 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
 		pinmux = <0x400e81e4 8 0x400e84f8 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
 		pinmux = <0x400e81e8 8 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
 		pinmux = <0x400e81e8 9 0x400e84fc 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
 		pinmux = <0x400e81ec 8 0x400e84f0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
 		pinmux = <0x400e81f0 8 0x400e84f4 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
 		pinmux = <0x400e81f4 8 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
 		pinmux = <0x400e81f8 8 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
 		pinmux = <0x400e81fc 8 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
 		pinmux = <0x400e8200 8 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8204 8 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
 		pinmux = <0x400e8208 8 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
 		pinmux = <0x400e820c 8 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8210 9 0x400e84a0 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8210 8 0x400e84a4 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
 		pinmux = <0x400e8214 8 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
 		pinmux = <0x400e821c 8 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8220 8 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
 		pinmux = <0x400e8224 8 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8228 8 0x400e84a4 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
 		pinmux = <0x400e822c 8 0x400e84f0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
 		pinmux = <0x400e8230 8 0x400e84f4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
 		pinmux = <0x400e8234 8 0x400e84f8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
 		pinmux = <0x400e8238 8 0x400e84fc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
 		pinmux = <0x400e823c 8 0x400e84fc 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
 		pinmux = <0x400e8240 8 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
 		pinmux = <0x400e8244 8 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
 		pinmux = <0x400e8248 8 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
 		pinmux = <0x400e824c 8 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
 		pinmux = <0x400e8250 8 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
 		pinmux = <0x400e80b8 7 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
 		pinmux = <0x400e80bc 7 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
 		pinmux = <0x400e80c0 7 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
 		pinmux = <0x400e8104 8 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
 		pinmux = <0x400e8108 8 0x400e84ec 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8108 3 0x400e84a0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
 		pinmux = <0x400e81ac 9 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
 		pinmux = <0x400e81b0 9 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e81d0 9 0x400e84a0 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};

--- a/dts/nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi
+++ b/dts/nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi
@@ -18,6362 +18,6362 @@
  */
 
 /*
- * NOTE: file fixup performed by fixup-pinmux.py
+ * NOTE: file fixup performed by rt_fixup_pinmux.py
  * to correct missing daisy register values
  */
 
 &iomuxc {
-	iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_acmp1_in1: IOMUXC_GPIO_AD_00_ACMP1_IN1 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_can2_tx: IOMUXC_GPIO_AD_00_CAN2_TX {
 		pinmux = <0x400e810c 1 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_enet_1g_1588_event1_in: IOMUXC_GPIO_AD_00_ENET_1G_1588_EVENT1_IN {
 		pinmux = <0x400e810c 2 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexio2_flexio00: IOMUXC_GPIO_AD_00_FLEXIO2_FLEXIO00 {
 		pinmux = <0x400e810c 8 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexpwm1_pwm0_a: IOMUXC_GPIO_AD_00_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e810c 4 0x400e8500 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_flexspi2_b_ss1_b: IOMUXC_GPIO_AD_00_FLEXSPI2_B_SS1_B {
 		pinmux = <0x400e810c 9 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio8_io31: IOMUXC_GPIO_AD_00_GPIO8_IO31 {
 		pinmux = <0x400e810c 10 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpio_mux2_io31_cm7: IOMUXC_GPIO_AD_00_GPIO_MUX2_IO31_CM7 {
 		pinmux = <0x400e810c 5 0x0 0 0x400e8350>;
 		pin-pue;
 		gpr = <0x400e40a4 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_gpt2_capture1: IOMUXC_GPIO_AD_00_GPT2_CAPTURE1 {
 		pinmux = <0x400e810c 3 0x0 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_lpuart7_tx: IOMUXC_GPIO_AD_00_LPUART7_TX {
 		pinmux = <0x400e810c 6 0x400e8630 0 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_00_sim1_trxd: IOMUXC_GPIO_AD_00_SIM1_TRXD {
 		pinmux = <0x400e810c 0 0x400e869c 1 0x400e8350>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_acmp1_in2: IOMUXC_GPIO_AD_01_ACMP1_IN2 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_can2_rx: IOMUXC_GPIO_AD_01_CAN2_RX {
 		pinmux = <0x400e8110 1 0x400e849c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_enet_1g_1588_event1_out: IOMUXC_GPIO_AD_01_ENET_1G_1588_EVENT1_OUT {
 		pinmux = <0x400e8110 2 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexio2_flexio01: IOMUXC_GPIO_AD_01_FLEXIO2_FLEXIO01 {
 		pinmux = <0x400e8110 8 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexpwm1_pwm0_b: IOMUXC_GPIO_AD_01_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8110 4 0x400e850c 1 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_flexspi2_a_ss1_b: IOMUXC_GPIO_AD_01_FLEXSPI2_A_SS1_B {
 		pinmux = <0x400e8110 9 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio9_io00: IOMUXC_GPIO_AD_01_GPIO9_IO00 {
 		pinmux = <0x400e8110 10 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpio_mux3_io00_cm7: IOMUXC_GPIO_AD_01_GPIO_MUX3_IO00_CM7 {
 		pinmux = <0x400e8110 5 0x0 0 0x400e8354>;
 		pin-pue;
 		gpr = <0x400e40a8 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_gpt2_capture2: IOMUXC_GPIO_AD_01_GPT2_CAPTURE2 {
 		pinmux = <0x400e8110 3 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_lpuart7_rx: IOMUXC_GPIO_AD_01_LPUART7_RX {
 		pinmux = <0x400e8110 6 0x400e862c 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_01_sim1_clk: IOMUXC_GPIO_AD_01_SIM1_CLK {
 		pinmux = <0x400e8110 0 0x0 0 0x400e8354>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_acmp1_in3: IOMUXC_GPIO_AD_02_ACMP1_IN3 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_enet_1g_1588_event2_in: IOMUXC_GPIO_AD_02_ENET_1G_1588_EVENT2_IN {
 		pinmux = <0x400e8114 2 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexio2_flexio02: IOMUXC_GPIO_AD_02_FLEXIO2_FLEXIO02 {
 		pinmux = <0x400e8114 8 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_flexpwm1_pwm1_a: IOMUXC_GPIO_AD_02_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8114 4 0x400e8504 1 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio9_io01: IOMUXC_GPIO_AD_02_GPIO9_IO01 {
 		pinmux = <0x400e8114 10 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpio_mux3_io01_cm7: IOMUXC_GPIO_AD_02_GPIO_MUX3_IO01_CM7 {
 		pinmux = <0x400e8114 5 0x0 0 0x400e8358>;
 		pin-pue;
 		gpr = <0x400e40a8 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_gpt2_compare1: IOMUXC_GPIO_AD_02_GPT2_COMPARE1 {
 		pinmux = <0x400e8114 3 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart7_cts_b: IOMUXC_GPIO_AD_02_LPUART7_CTS_B {
 		pinmux = <0x400e8114 1 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_lpuart8_tx: IOMUXC_GPIO_AD_02_LPUART8_TX {
 		pinmux = <0x400e8114 6 0x400e8638 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_sim1_rst_b: IOMUXC_GPIO_AD_02_SIM1_RST_B {
 		pinmux = <0x400e8114 0 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_02_video_mux_ext_dcic1: IOMUXC_GPIO_AD_02_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e8114 9 0x0 0 0x400e8358>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_acmp1_in4: IOMUXC_GPIO_AD_03_ACMP1_IN4 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_enet_1g_1588_event2_out: IOMUXC_GPIO_AD_03_ENET_1G_1588_EVENT2_OUT {
 		pinmux = <0x400e8118 2 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexio2_flexio03: IOMUXC_GPIO_AD_03_FLEXIO2_FLEXIO03 {
 		pinmux = <0x400e8118 8 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_flexpwm1_pwm1_b: IOMUXC_GPIO_AD_03_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8118 4 0x400e8510 1 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio9_io02: IOMUXC_GPIO_AD_03_GPIO9_IO02 {
 		pinmux = <0x400e8118 10 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpio_mux3_io02_cm7: IOMUXC_GPIO_AD_03_GPIO_MUX3_IO02_CM7 {
 		pinmux = <0x400e8118 5 0x0 0 0x400e835c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_gpt2_compare2: IOMUXC_GPIO_AD_03_GPT2_COMPARE2 {
 		pinmux = <0x400e8118 3 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart7_rts_b: IOMUXC_GPIO_AD_03_LPUART7_RTS_B {
 		pinmux = <0x400e8118 1 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_lpuart8_rx: IOMUXC_GPIO_AD_03_LPUART8_RX {
 		pinmux = <0x400e8118 6 0x400e8634 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_sim1_sven: IOMUXC_GPIO_AD_03_SIM1_SVEN {
 		pinmux = <0x400e8118 0 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_03_video_mux_ext_dcic2: IOMUXC_GPIO_AD_03_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8118 9 0x0 0 0x400e835c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_acmp2_in1: IOMUXC_GPIO_AD_04_ACMP2_IN1 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_enet_1g_1588_event3_in: IOMUXC_GPIO_AD_04_ENET_1G_1588_EVENT3_IN {
 		pinmux = <0x400e811c 2 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexio2_flexio04: IOMUXC_GPIO_AD_04_FLEXIO2_FLEXIO04 {
 		pinmux = <0x400e811c 8 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_flexpwm1_pwm2_a: IOMUXC_GPIO_AD_04_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e811c 4 0x400e8508 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio9_io03: IOMUXC_GPIO_AD_04_GPIO9_IO03 {
 		pinmux = <0x400e811c 10 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpio_mux3_io03_cm7: IOMUXC_GPIO_AD_04_GPIO_MUX3_IO03_CM7 {
 		pinmux = <0x400e811c 5 0x0 0 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e40a8 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_gpt2_compare3: IOMUXC_GPIO_AD_04_GPT2_COMPARE3 {
 		pinmux = <0x400e811c 3 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_lpuart8_cts_b: IOMUXC_GPIO_AD_04_LPUART8_CTS_B {
 		pinmux = <0x400e811c 1 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_qtimer4_timer0: IOMUXC_GPIO_AD_04_QTIMER4_TIMER0 {
 		pinmux = <0x400e811c 9 0x400e8660 1 0x400e8360>;
 		pin-pue;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_sim1_pd: IOMUXC_GPIO_AD_04_SIM1_PD {
 		pinmux = <0x400e811c 0 0x400e86a0 1 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_04_wdog1_wdog_b: IOMUXC_GPIO_AD_04_WDOG1_WDOG_B {
 		pinmux = <0x400e811c 6 0x0 0 0x400e8360>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_acmp2_in2: IOMUXC_GPIO_AD_05_ACMP2_IN2 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_enet_1g_1588_event3_out: IOMUXC_GPIO_AD_05_ENET_1G_1588_EVENT3_OUT {
 		pinmux = <0x400e8120 2 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexio2_flexio05: IOMUXC_GPIO_AD_05_FLEXIO2_FLEXIO05 {
 		pinmux = <0x400e8120 8 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_flexpwm1_pwm2_b: IOMUXC_GPIO_AD_05_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8120 4 0x400e8514 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio9_io04: IOMUXC_GPIO_AD_05_GPIO9_IO04 {
 		pinmux = <0x400e8120 10 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpio_mux3_io04_cm7: IOMUXC_GPIO_AD_05_GPIO_MUX3_IO04_CM7 {
 		pinmux = <0x400e8120 5 0x0 0 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e40a8 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_gpt2_clk: IOMUXC_GPIO_AD_05_GPT2_CLK {
 		pinmux = <0x400e8120 3 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_lpuart8_rts_b: IOMUXC_GPIO_AD_05_LPUART8_RTS_B {
 		pinmux = <0x400e8120 1 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_qtimer4_timer1: IOMUXC_GPIO_AD_05_QTIMER4_TIMER1 {
 		pinmux = <0x400e8120 9 0x400e8664 1 0x400e8364>;
 		pin-pue;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_sim1_power_fail: IOMUXC_GPIO_AD_05_SIM1_POWER_FAIL {
 		pinmux = <0x400e8120 0 0x400e86a4 1 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_05_wdog2_wdog_b: IOMUXC_GPIO_AD_05_WDOG2_WDOG_B {
 		pinmux = <0x400e8120 6 0x0 0 0x400e8364>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_adc1_ch0a: IOMUXC_GPIO_AD_06_ADC1_CH0A {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_can1_tx: IOMUXC_GPIO_AD_06_CAN1_TX {
 		pinmux = <0x400e8124 1 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_enet_1588_event1_in: IOMUXC_GPIO_AD_06_ENET_1588_EVENT1_IN {
 		pinmux = <0x400e8124 6 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexio2_flexio06: IOMUXC_GPIO_AD_06_FLEXIO2_FLEXIO06 {
 		pinmux = <0x400e8124 8 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_flexpwm1_pwm0_x: IOMUXC_GPIO_AD_06_FLEXPWM1_PWM0_X {
 		pinmux = <0x400e8124 11 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio9_io05: IOMUXC_GPIO_AD_06_GPIO9_IO05 {
 		pinmux = <0x400e8124 10 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpio_mux3_io05_cm7: IOMUXC_GPIO_AD_06_GPIO_MUX3_IO05_CM7 {
 		pinmux = <0x400e8124 5 0x0 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e40a8 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_gpt3_capture1: IOMUXC_GPIO_AD_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e8124 3 0x400e8590 1 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_qtimer4_timer2: IOMUXC_GPIO_AD_06_QTIMER4_TIMER2 {
 		pinmux = <0x400e8124 9 0x400e8668 0 0x400e8368>;
 		pin-pue;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_sim2_trxd: IOMUXC_GPIO_AD_06_SIM2_TRXD {
 		pinmux = <0x400e8124 2 0x400e86a8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_usb_otg2_oc: IOMUXC_GPIO_AD_06_USB_OTG2_OC {
 		pinmux = <0x400e8124 0 0x400e86b8 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_06_video_mux_csi_data15: IOMUXC_GPIO_AD_06_VIDEO_MUX_CSI_DATA15 {
 		pinmux = <0x400e8124 4 0x0 0 0x400e8368>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_adc1_ch0b: IOMUXC_GPIO_AD_07_ADC1_CH0B {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_can1_rx: IOMUXC_GPIO_AD_07_CAN1_RX {
 		pinmux = <0x400e8128 1 0x400e8498 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_enet_1588_event1_out: IOMUXC_GPIO_AD_07_ENET_1588_EVENT1_OUT {
 		pinmux = <0x400e8128 6 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexio2_flexio07: IOMUXC_GPIO_AD_07_FLEXIO2_FLEXIO07 {
 		pinmux = <0x400e8128 8 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_flexpwm1_pwm1_x: IOMUXC_GPIO_AD_07_FLEXPWM1_PWM1_X {
 		pinmux = <0x400e8128 11 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio9_io06: IOMUXC_GPIO_AD_07_GPIO9_IO06 {
 		pinmux = <0x400e8128 10 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpio_mux3_io06_cm7: IOMUXC_GPIO_AD_07_GPIO_MUX3_IO06_CM7 {
 		pinmux = <0x400e8128 5 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e40a8 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_gpt3_capture2: IOMUXC_GPIO_AD_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e8128 3 0x400e8594 1 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_qtimer4_timer3: IOMUXC_GPIO_AD_07_QTIMER4_TIMER3 {
 		pinmux = <0x400e8128 9 0x0 0 0x400e836c>;
 		pin-pue;
 		gpr = <0x400e403c 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_sim2_clk: IOMUXC_GPIO_AD_07_SIM2_CLK {
 		pinmux = <0x400e8128 2 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_usb_otg2_pwr: IOMUXC_GPIO_AD_07_USB_OTG2_PWR {
 		pinmux = <0x400e8128 0 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_07_video_mux_csi_data14: IOMUXC_GPIO_AD_07_VIDEO_MUX_CSI_DATA14 {
 		pinmux = <0x400e8128 4 0x0 0 0x400e836c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_adc1_ch1a: IOMUXC_GPIO_AD_08_ADC1_CH1A {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_enet_1588_event2_in: IOMUXC_GPIO_AD_08_ENET_1588_EVENT2_IN {
 		pinmux = <0x400e812c 6 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexio2_flexio08: IOMUXC_GPIO_AD_08_FLEXIO2_FLEXIO08 {
 		pinmux = <0x400e812c 8 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_flexpwm1_pwm2_x: IOMUXC_GPIO_AD_08_FLEXPWM1_PWM2_X {
 		pinmux = <0x400e812c 11 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio9_io07: IOMUXC_GPIO_AD_08_GPIO9_IO07 {
 		pinmux = <0x400e812c 10 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpio_mux3_io07_cm7: IOMUXC_GPIO_AD_08_GPIO_MUX3_IO07_CM7 {
 		pinmux = <0x400e812c 5 0x0 0 0x400e8370>;
 		pin-pue;
 		gpr = <0x400e40a8 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_gpt3_compare1: IOMUXC_GPIO_AD_08_GPT3_COMPARE1 {
 		pinmux = <0x400e812c 3 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_lpi2c1_scl: IOMUXC_GPIO_AD_08_LPI2C1_SCL {
 		pinmux = <0x400e812c 1 0x400e85ac 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_sim2_rst_b: IOMUXC_GPIO_AD_08_SIM2_RST_B {
 		pinmux = <0x400e812c 2 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_usbphy2_otg_id: IOMUXC_GPIO_AD_08_USBPHY2_OTG_ID {
 		pinmux = <0x400e812c 0 0x400e86c4 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_08_video_mux_csi_data13: IOMUXC_GPIO_AD_08_VIDEO_MUX_CSI_DATA13 {
 		pinmux = <0x400e812c 4 0x0 0 0x400e8370>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_adc1_ch1b: IOMUXC_GPIO_AD_09_ADC1_CH1B {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_enet_1588_event2_out: IOMUXC_GPIO_AD_09_ENET_1588_EVENT2_OUT {
 		pinmux = <0x400e8130 6 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexio2_flexio09: IOMUXC_GPIO_AD_09_FLEXIO2_FLEXIO09 {
 		pinmux = <0x400e8130 8 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_flexpwm1_pwm3_x: IOMUXC_GPIO_AD_09_FLEXPWM1_PWM3_X {
 		pinmux = <0x400e8130 11 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio9_io08: IOMUXC_GPIO_AD_09_GPIO9_IO08 {
 		pinmux = <0x400e8130 10 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpio_mux3_io08_cm7: IOMUXC_GPIO_AD_09_GPIO_MUX3_IO08_CM7 {
 		pinmux = <0x400e8130 5 0x0 0 0x400e8374>;
 		pin-pue;
 		gpr = <0x400e40a8 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_gpt3_compare2: IOMUXC_GPIO_AD_09_GPT3_COMPARE2 {
 		pinmux = <0x400e8130 3 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_lpi2c1_sda: IOMUXC_GPIO_AD_09_LPI2C1_SDA {
 		pinmux = <0x400e8130 1 0x400e85b0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_sim2_sven: IOMUXC_GPIO_AD_09_SIM2_SVEN {
 		pinmux = <0x400e8130 2 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_usbphy1_otg_id: IOMUXC_GPIO_AD_09_USBPHY1_OTG_ID {
 		pinmux = <0x400e8130 0 0x400e86c0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_09_video_mux_csi_data12: IOMUXC_GPIO_AD_09_VIDEO_MUX_CSI_DATA12 {
 		pinmux = <0x400e8130 4 0x0 0 0x400e8374>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_adc1_ch2a: IOMUXC_GPIO_AD_10_ADC1_CH2A {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_enet_1588_event3_in: IOMUXC_GPIO_AD_10_ENET_1588_EVENT3_IN {
 		pinmux = <0x400e8134 6 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexio2_flexio10: IOMUXC_GPIO_AD_10_FLEXIO2_FLEXIO10 {
 		pinmux = <0x400e8134 8 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_flexpwm2_pwm0_x: IOMUXC_GPIO_AD_10_FLEXPWM2_PWM0_X {
 		pinmux = <0x400e8134 11 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio9_io09: IOMUXC_GPIO_AD_10_GPIO9_IO09 {
 		pinmux = <0x400e8134 10 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpio_mux3_io09_cm7: IOMUXC_GPIO_AD_10_GPIO_MUX3_IO09_CM7 {
 		pinmux = <0x400e8134 5 0x0 0 0x400e8378>;
 		pin-pue;
 		gpr = <0x400e40a8 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_gpt3_compare3: IOMUXC_GPIO_AD_10_GPT3_COMPARE3 {
 		pinmux = <0x400e8134 3 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_lpi2c1_scls: IOMUXC_GPIO_AD_10_LPI2C1_SCLS {
 		pinmux = <0x400e8134 1 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_sim2_pd: IOMUXC_GPIO_AD_10_SIM2_PD {
 		pinmux = <0x400e8134 2 0x400e86ac 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_usb_otg1_pwr: IOMUXC_GPIO_AD_10_USB_OTG1_PWR {
 		pinmux = <0x400e8134 0 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_10_video_mux_csi_data11: IOMUXC_GPIO_AD_10_VIDEO_MUX_CSI_DATA11 {
 		pinmux = <0x400e8134 4 0x0 0 0x400e8378>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_adc1_ch2b: IOMUXC_GPIO_AD_11_ADC1_CH2B {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_enet_1588_event3_out: IOMUXC_GPIO_AD_11_ENET_1588_EVENT3_OUT {
 		pinmux = <0x400e8138 6 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexio2_flexio11: IOMUXC_GPIO_AD_11_FLEXIO2_FLEXIO11 {
 		pinmux = <0x400e8138 8 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_flexpwm2_pwm1_x: IOMUXC_GPIO_AD_11_FLEXPWM2_PWM1_X {
 		pinmux = <0x400e8138 11 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio9_io10: IOMUXC_GPIO_AD_11_GPIO9_IO10 {
 		pinmux = <0x400e8138 10 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpio_mux3_io10_cm7: IOMUXC_GPIO_AD_11_GPIO_MUX3_IO10_CM7 {
 		pinmux = <0x400e8138 5 0x0 0 0x400e837c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_gpt3_clk: IOMUXC_GPIO_AD_11_GPT3_CLK {
 		pinmux = <0x400e8138 3 0x400e8598 1 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_lpi2c1_sdas: IOMUXC_GPIO_AD_11_LPI2C1_SDAS {
 		pinmux = <0x400e8138 1 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_sim2_power_fail: IOMUXC_GPIO_AD_11_SIM2_POWER_FAIL {
 		pinmux = <0x400e8138 2 0x400e86b0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_usb_otg1_oc: IOMUXC_GPIO_AD_11_USB_OTG1_OC {
 		pinmux = <0x400e8138 0 0x400e86bc 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_11_video_mux_csi_data10: IOMUXC_GPIO_AD_11_VIDEO_MUX_CSI_DATA10 {
 		pinmux = <0x400e8138 4 0x0 0 0x400e837c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc1_ch3a: IOMUXC_GPIO_AD_12_ADC1_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_adc2_ch3a: IOMUXC_GPIO_AD_12_ADC2_CH3A {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_enet_tdata03: IOMUXC_GPIO_AD_12_ENET_TDATA03 {
 		pinmux = <0x400e813c 6 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_ewm_ewm_out_b: IOMUXC_GPIO_AD_12_EWM_EWM_OUT_B {
 		pinmux = <0x400e813c 9 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexio2_flexio12: IOMUXC_GPIO_AD_12_FLEXIO2_FLEXIO12 {
 		pinmux = <0x400e813c 8 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexpwm2_pwm2_x: IOMUXC_GPIO_AD_12_FLEXPWM2_PWM2_X {
 		pinmux = <0x400e813c 11 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_flexspi1_b_data03: IOMUXC_GPIO_AD_12_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e813c 3 0x400e8570 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio9_io11: IOMUXC_GPIO_AD_12_GPIO9_IO11 {
 		pinmux = <0x400e813c 10 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpio_mux3_io11_cm7: IOMUXC_GPIO_AD_12_GPIO_MUX3_IO11_CM7 {
 		pinmux = <0x400e813c 5 0x0 0 0x400e8380>;
 		pin-pue;
 		gpr = <0x400e40a8 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_gpt1_capture1: IOMUXC_GPIO_AD_12_GPT1_CAPTURE1 {
 		pinmux = <0x400e813c 2 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_lpi2c1_hreq: IOMUXC_GPIO_AD_12_LPI2C1_HREQ {
 		pinmux = <0x400e813c 1 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_spdif_lock: IOMUXC_GPIO_AD_12_SPDIF_LOCK {
 		pinmux = <0x400e813c 0 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_12_video_mux_csi_pixclk: IOMUXC_GPIO_AD_12_VIDEO_MUX_CSI_PIXCLK {
 		pinmux = <0x400e813c 4 0x0 0 0x400e8380>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc1_ch3b: IOMUXC_GPIO_AD_13_ADC1_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_adc2_ch3b: IOMUXC_GPIO_AD_13_ADC2_CH3B {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_enet_tdata02: IOMUXC_GPIO_AD_13_ENET_TDATA02 {
 		pinmux = <0x400e8140 6 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexio2_flexio13: IOMUXC_GPIO_AD_13_FLEXIO2_FLEXIO13 {
 		pinmux = <0x400e8140 8 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexpwm2_pwm3_x: IOMUXC_GPIO_AD_13_FLEXPWM2_PWM3_X {
 		pinmux = <0x400e8140 11 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_flexspi1_b_data02: IOMUXC_GPIO_AD_13_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e8140 3 0x400e856c 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio9_io12: IOMUXC_GPIO_AD_13_GPIO9_IO12 {
 		pinmux = <0x400e8140 10 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpio_mux3_io12_cm7: IOMUXC_GPIO_AD_13_GPIO_MUX3_IO12_CM7 {
 		pinmux = <0x400e8140 5 0x0 0 0x400e8384>;
 		pin-pue;
 		gpr = <0x400e40a8 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_gpt1_capture2: IOMUXC_GPIO_AD_13_GPT1_CAPTURE2 {
 		pinmux = <0x400e8140 2 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_pit1_trigger00: IOMUXC_GPIO_AD_13_PIT1_TRIGGER00 {
 		pinmux = <0x400e8140 1 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_spdif_sr_clk: IOMUXC_GPIO_AD_13_SPDIF_SR_CLK {
 		pinmux = <0x400e8140 0 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_13_video_mux_csi_mclk: IOMUXC_GPIO_AD_13_VIDEO_MUX_CSI_MCLK {
 		pinmux = <0x400e8140 4 0x0 0 0x400e8384>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc1_ch4a: IOMUXC_GPIO_AD_14_ADC1_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_adc2_ch4a: IOMUXC_GPIO_AD_14_ADC2_CH4A {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_ccm_enet_ref_clk_25m: IOMUXC_GPIO_AD_14_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8144 9 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_enet_rx_clk: IOMUXC_GPIO_AD_14_ENET_RX_CLK {
 		pinmux = <0x400e8144 6 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexio2_flexio14: IOMUXC_GPIO_AD_14_FLEXIO2_FLEXIO14 {
 		pinmux = <0x400e8144 8 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexpwm3_pwm0_x: IOMUXC_GPIO_AD_14_FLEXPWM3_PWM0_X {
 		pinmux = <0x400e8144 11 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_flexspi1_b_data01: IOMUXC_GPIO_AD_14_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e8144 3 0x400e8568 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio9_io13: IOMUXC_GPIO_AD_14_GPIO9_IO13 {
 		pinmux = <0x400e8144 10 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpio_mux3_io13_cm7: IOMUXC_GPIO_AD_14_GPIO_MUX3_IO13_CM7 {
 		pinmux = <0x400e8144 5 0x0 0 0x400e8388>;
 		pin-pue;
 		gpr = <0x400e40a8 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_gpt1_compare1: IOMUXC_GPIO_AD_14_GPT1_COMPARE1 {
 		pinmux = <0x400e8144 2 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_spdif_ext_clk: IOMUXC_GPIO_AD_14_SPDIF_EXT_CLK {
 		pinmux = <0x400e8144 0 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_14_video_mux_csi_vsync: IOMUXC_GPIO_AD_14_VIDEO_MUX_CSI_VSYNC {
 		pinmux = <0x400e8144 4 0x0 0 0x400e8388>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc1_ch4b: IOMUXC_GPIO_AD_15_ADC1_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_adc2_ch4b: IOMUXC_GPIO_AD_15_ADC2_CH4B {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_enet_tx_er: IOMUXC_GPIO_AD_15_ENET_TX_ER {
 		pinmux = <0x400e8148 6 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexio2_flexio15: IOMUXC_GPIO_AD_15_FLEXIO2_FLEXIO15 {
 		pinmux = <0x400e8148 8 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexpwm3_pwm1_x: IOMUXC_GPIO_AD_15_FLEXPWM3_PWM1_X {
 		pinmux = <0x400e8148 11 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_flexspi1_b_data00: IOMUXC_GPIO_AD_15_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e8148 3 0x400e8564 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio9_io14: IOMUXC_GPIO_AD_15_GPIO9_IO14 {
 		pinmux = <0x400e8148 10 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpio_mux3_io14_cm7: IOMUXC_GPIO_AD_15_GPIO_MUX3_IO14_CM7 {
 		pinmux = <0x400e8148 5 0x0 0 0x400e838c>;
 		pin-pue;
 		gpr = <0x400e40a8 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_gpt1_compare2: IOMUXC_GPIO_AD_15_GPT1_COMPARE2 {
 		pinmux = <0x400e8148 2 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_lpuart10_tx: IOMUXC_GPIO_AD_15_LPUART10_TX {
 		pinmux = <0x400e8148 1 0x400e8628 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_spdif_in: IOMUXC_GPIO_AD_15_SPDIF_IN {
 		pinmux = <0x400e8148 0 0x400e86b4 1 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_15_video_mux_csi_hsync: IOMUXC_GPIO_AD_15_VIDEO_MUX_CSI_HSYNC {
 		pinmux = <0x400e8148 4 0x0 0 0x400e838c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc1_ch5a: IOMUXC_GPIO_AD_16_ADC1_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_adc2_ch5a: IOMUXC_GPIO_AD_16_ADC2_CH5A {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_1g_mdc: IOMUXC_GPIO_AD_16_ENET_1G_MDC {
 		pinmux = <0x400e814c 9 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_enet_rdata03: IOMUXC_GPIO_AD_16_ENET_RDATA03 {
 		pinmux = <0x400e814c 6 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexio2_flexio16: IOMUXC_GPIO_AD_16_FLEXIO2_FLEXIO16 {
 		pinmux = <0x400e814c 8 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexpwm3_pwm2_x: IOMUXC_GPIO_AD_16_FLEXPWM3_PWM2_X {
 		pinmux = <0x400e814c 11 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_flexspi1_b_sclk: IOMUXC_GPIO_AD_16_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e814c 3 0x400e8578 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio9_io15: IOMUXC_GPIO_AD_16_GPIO9_IO15 {
 		pinmux = <0x400e814c 10 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpio_mux3_io15_cm7: IOMUXC_GPIO_AD_16_GPIO_MUX3_IO15_CM7 {
 		pinmux = <0x400e814c 5 0x0 0 0x400e8390>;
 		pin-pue;
 		gpr = <0x400e40a8 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_gpt1_compare3: IOMUXC_GPIO_AD_16_GPT1_COMPARE3 {
 		pinmux = <0x400e814c 2 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_lpuart10_rx: IOMUXC_GPIO_AD_16_LPUART10_RX {
 		pinmux = <0x400e814c 1 0x400e8624 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_spdif_out: IOMUXC_GPIO_AD_16_SPDIF_OUT {
 		pinmux = <0x400e814c 0 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_16_video_mux_csi_data09: IOMUXC_GPIO_AD_16_VIDEO_MUX_CSI_DATA09 {
 		pinmux = <0x400e814c 4 0x0 0 0x400e8390>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_acmp1_cmpo: IOMUXC_GPIO_AD_17_ACMP1_CMPO {
 		pinmux = <0x400e8150 1 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc1_ch5b: IOMUXC_GPIO_AD_17_ADC1_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_adc2_ch5b: IOMUXC_GPIO_AD_17_ADC2_CH5B {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_1g_mdio: IOMUXC_GPIO_AD_17_ENET_1G_MDIO {
 		pinmux = <0x400e8150 9 0x400e84c8 2 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_enet_rdata02: IOMUXC_GPIO_AD_17_ENET_RDATA02 {
 		pinmux = <0x400e8150 6 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexio2_flexio17: IOMUXC_GPIO_AD_17_FLEXIO2_FLEXIO17 {
 		pinmux = <0x400e8150 8 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexpwm3_pwm3_x: IOMUXC_GPIO_AD_17_FLEXPWM3_PWM3_X {
 		pinmux = <0x400e8150 11 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_flexspi1_a_dqs: IOMUXC_GPIO_AD_17_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8150 3 0x400e8550 1 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio9_io16: IOMUXC_GPIO_AD_17_GPIO9_IO16 {
 		pinmux = <0x400e8150 10 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x0>;
 	};
-	iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpio_mux3_io16_cm7: IOMUXC_GPIO_AD_17_GPIO_MUX3_IO16_CM7 {
 		pinmux = <0x400e8150 5 0x0 0 0x400e8394>;
 		pin-pue;
 		gpr = <0x400e40ac 0x0 0x1>;
 	};
-	iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_gpt1_clk: IOMUXC_GPIO_AD_17_GPT1_CLK {
 		pinmux = <0x400e8150 2 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_sai1_mclk: IOMUXC_GPIO_AD_17_SAI1_MCLK {
 		pinmux = <0x400e8150 0 0x400e866c 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_17_video_mux_csi_data08: IOMUXC_GPIO_AD_17_VIDEO_MUX_CSI_DATA08 {
 		pinmux = <0x400e8150 4 0x0 0 0x400e8394>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_acmp2_cmpo: IOMUXC_GPIO_AD_18_ACMP2_CMPO {
 		pinmux = <0x400e8154 1 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_adc2_ch0a: IOMUXC_GPIO_AD_18_ADC2_CH0A {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_enet_crs: IOMUXC_GPIO_AD_18_ENET_CRS {
 		pinmux = <0x400e8154 6 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexio2_flexio18: IOMUXC_GPIO_AD_18_FLEXIO2_FLEXIO18 {
 		pinmux = <0x400e8154 8 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexpwm4_pwm0_x: IOMUXC_GPIO_AD_18_FLEXPWM4_PWM0_X {
 		pinmux = <0x400e8154 11 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_flexspi1_a_ss0_b: IOMUXC_GPIO_AD_18_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e8154 3 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio9_io17: IOMUXC_GPIO_AD_18_GPIO9_IO17 {
 		pinmux = <0x400e8154 10 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x0>;
 	};
-	iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_gpio_mux3_io17_cm7: IOMUXC_GPIO_AD_18_GPIO_MUX3_IO17_CM7 {
 		pinmux = <0x400e8154 5 0x0 0 0x400e8398>;
 		pin-pue;
 		gpr = <0x400e40ac 0x1 0x1>;
 	};
-	iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpi2c2_scl: IOMUXC_GPIO_AD_18_LPI2C2_SCL {
 		pinmux = <0x400e8154 9 0x400e85b4 1 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_lpspi1_pcs1: IOMUXC_GPIO_AD_18_LPSPI1_PCS1 {
 		pinmux = <0x400e8154 2 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_sai1_rx_sync: IOMUXC_GPIO_AD_18_SAI1_RX_SYNC {
 		pinmux = <0x400e8154 0 0x400e8678 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_18_video_mux_csi_data07: IOMUXC_GPIO_AD_18_VIDEO_MUX_CSI_DATA07 {
 		pinmux = <0x400e8154 4 0x0 0 0x400e8398>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_acmp3_cmpo: IOMUXC_GPIO_AD_19_ACMP3_CMPO {
 		pinmux = <0x400e8158 1 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_adc2_ch0b: IOMUXC_GPIO_AD_19_ADC2_CH0B {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_enet_col: IOMUXC_GPIO_AD_19_ENET_COL {
 		pinmux = <0x400e8158 6 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexio2_flexio19: IOMUXC_GPIO_AD_19_FLEXIO2_FLEXIO19 {
 		pinmux = <0x400e8158 8 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexpwm4_pwm1_x: IOMUXC_GPIO_AD_19_FLEXPWM4_PWM1_X {
 		pinmux = <0x400e8158 11 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_flexspi1_a_sclk: IOMUXC_GPIO_AD_19_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e8158 3 0x400e8574 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio9_io18: IOMUXC_GPIO_AD_19_GPIO9_IO18 {
 		pinmux = <0x400e8158 10 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x0>;
 	};
-	iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_gpio_mux3_io18_cm7: IOMUXC_GPIO_AD_19_GPIO_MUX3_IO18_CM7 {
 		pinmux = <0x400e8158 5 0x0 0 0x400e839c>;
 		pin-pue;
 		gpr = <0x400e40ac 0x2 0x1>;
 	};
-	iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpi2c2_sda: IOMUXC_GPIO_AD_19_LPI2C2_SDA {
 		pinmux = <0x400e8158 9 0x400e85b8 1 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_lpspi1_pcs2: IOMUXC_GPIO_AD_19_LPSPI1_PCS2 {
 		pinmux = <0x400e8158 2 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_sai1_rx_bclk: IOMUXC_GPIO_AD_19_SAI1_RX_BCLK {
 		pinmux = <0x400e8158 0 0x400e8670 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_19_video_mux_csi_data06: IOMUXC_GPIO_AD_19_VIDEO_MUX_CSI_DATA06 {
 		pinmux = <0x400e8158 4 0x0 0 0x400e839c>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_acmp4_cmpo: IOMUXC_GPIO_AD_20_ACMP4_CMPO {
 		pinmux = <0x400e815c 1 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_adc2_ch1a: IOMUXC_GPIO_AD_20_ADC2_CH1A {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_enet_qos_1588_event2_out: IOMUXC_GPIO_AD_20_ENET_QOS_1588_EVENT2_OUT {
 		pinmux = <0x400e815c 9 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexio2_flexio20: IOMUXC_GPIO_AD_20_FLEXIO2_FLEXIO20 {
 		pinmux = <0x400e815c 8 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexpwm4_pwm2_x: IOMUXC_GPIO_AD_20_FLEXPWM4_PWM2_X {
 		pinmux = <0x400e815c 11 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_flexspi1_a_data00: IOMUXC_GPIO_AD_20_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e815c 3 0x400e8554 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio9_io19: IOMUXC_GPIO_AD_20_GPIO9_IO19 {
 		pinmux = <0x400e815c 10 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x0>;
 	};
-	iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_gpio_mux3_io19_cm7: IOMUXC_GPIO_AD_20_GPIO_MUX3_IO19_CM7 {
 		pinmux = <0x400e815c 5 0x0 0 0x400e83a0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x3 0x1>;
 	};
-	iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_kpp_row07: IOMUXC_GPIO_AD_20_KPP_ROW07 {
 		pinmux = <0x400e815c 6 0x400e85a8 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_lpspi1_pcs3: IOMUXC_GPIO_AD_20_LPSPI1_PCS3 {
 		pinmux = <0x400e815c 2 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_sai1_rx_data00: IOMUXC_GPIO_AD_20_SAI1_RX_DATA00 {
 		pinmux = <0x400e815c 0 0x400e8674 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_20_video_mux_csi_data05: IOMUXC_GPIO_AD_20_VIDEO_MUX_CSI_DATA05 {
 		pinmux = <0x400e815c 4 0x0 0 0x400e83a0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_adc2_ch1b: IOMUXC_GPIO_AD_21_ADC2_CH1B {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_enet_qos_1588_event2_in: IOMUXC_GPIO_AD_21_ENET_QOS_1588_EVENT2_IN {
 		pinmux = <0x400e8160 9 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexio2_flexio21: IOMUXC_GPIO_AD_21_FLEXIO2_FLEXIO21 {
 		pinmux = <0x400e8160 8 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexpwm4_pwm3_x: IOMUXC_GPIO_AD_21_FLEXPWM4_PWM3_X {
 		pinmux = <0x400e8160 11 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_flexspi1_a_data01: IOMUXC_GPIO_AD_21_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e8160 3 0x400e8558 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio9_io20: IOMUXC_GPIO_AD_21_GPIO9_IO20 {
 		pinmux = <0x400e8160 10 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x0>;
 	};
-	iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_gpio_mux3_io20_cm7: IOMUXC_GPIO_AD_21_GPIO_MUX3_IO20_CM7 {
 		pinmux = <0x400e8160 5 0x0 0 0x400e83a4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x4 0x1>;
 	};
-	iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_kpp_col07: IOMUXC_GPIO_AD_21_KPP_COL07 {
 		pinmux = <0x400e8160 6 0x400e85a0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_lpspi2_pcs1: IOMUXC_GPIO_AD_21_LPSPI2_PCS1 {
 		pinmux = <0x400e8160 2 0x400e85e0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_sai1_tx_data00: IOMUXC_GPIO_AD_21_SAI1_TX_DATA00 {
 		pinmux = <0x400e8160 0 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_21_video_mux_csi_data04: IOMUXC_GPIO_AD_21_VIDEO_MUX_CSI_DATA04 {
 		pinmux = <0x400e8160 4 0x0 0 0x400e83a4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_adc2_ch2a: IOMUXC_GPIO_AD_22_ADC2_CH2A {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_enet_qos_1588_event3_out: IOMUXC_GPIO_AD_22_ENET_QOS_1588_EVENT3_OUT {
 		pinmux = <0x400e8164 9 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexio2_flexio22: IOMUXC_GPIO_AD_22_FLEXIO2_FLEXIO22 {
 		pinmux = <0x400e8164 8 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_flexspi1_a_data02: IOMUXC_GPIO_AD_22_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e8164 3 0x400e855c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio9_io21: IOMUXC_GPIO_AD_22_GPIO9_IO21 {
 		pinmux = <0x400e8164 10 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x0>;
 	};
-	iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_gpio_mux3_io21_cm7: IOMUXC_GPIO_AD_22_GPIO_MUX3_IO21_CM7 {
 		pinmux = <0x400e8164 5 0x0 0 0x400e83a8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x5 0x1>;
 	};
-	iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_kpp_row06: IOMUXC_GPIO_AD_22_KPP_ROW06 {
 		pinmux = <0x400e8164 6 0x400e85a4 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_lpspi2_pcs2: IOMUXC_GPIO_AD_22_LPSPI2_PCS2 {
 		pinmux = <0x400e8164 2 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_sai1_tx_bclk: IOMUXC_GPIO_AD_22_SAI1_TX_BCLK {
 		pinmux = <0x400e8164 0 0x400e867c 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_22_video_mux_csi_data03: IOMUXC_GPIO_AD_22_VIDEO_MUX_CSI_DATA03 {
 		pinmux = <0x400e8164 4 0x0 0 0x400e83a8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_adc2_ch2b: IOMUXC_GPIO_AD_23_ADC2_CH2B {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_enet_qos_1588_event3_in: IOMUXC_GPIO_AD_23_ENET_QOS_1588_EVENT3_IN {
 		pinmux = <0x400e8168 9 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexio2_flexio23: IOMUXC_GPIO_AD_23_FLEXIO2_FLEXIO23 {
 		pinmux = <0x400e8168 8 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_flexspi1_a_data03: IOMUXC_GPIO_AD_23_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e8168 3 0x400e8560 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio9_io22: IOMUXC_GPIO_AD_23_GPIO9_IO22 {
 		pinmux = <0x400e8168 10 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x0>;
 	};
-	iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_gpio_mux3_io22_cm7: IOMUXC_GPIO_AD_23_GPIO_MUX3_IO22_CM7 {
 		pinmux = <0x400e8168 5 0x0 0 0x400e83ac>;
 		pin-pue;
 		gpr = <0x400e40ac 0x6 0x1>;
 	};
-	iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_kpp_col06: IOMUXC_GPIO_AD_23_KPP_COL06 {
 		pinmux = <0x400e8168 6 0x400e859c 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_lpspi2_pcs3: IOMUXC_GPIO_AD_23_LPSPI2_PCS3 {
 		pinmux = <0x400e8168 2 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_sai1_tx_sync: IOMUXC_GPIO_AD_23_SAI1_TX_SYNC {
 		pinmux = <0x400e8168 0 0x400e8680 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_23_video_mux_csi_data02: IOMUXC_GPIO_AD_23_VIDEO_MUX_CSI_DATA02 {
 		pinmux = <0x400e8168 4 0x0 0 0x400e83ac>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_adc2_ch6a: IOMUXC_GPIO_AD_24_ADC2_CH6A {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_enet_rx_en: IOMUXC_GPIO_AD_24_ENET_RX_EN {
 		pinmux = <0x400e816c 3 0x400e84b8 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexio2_flexio24: IOMUXC_GPIO_AD_24_FLEXIO2_FLEXIO24 {
 		pinmux = <0x400e816c 8 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_flexpwm2_pwm0_a: IOMUXC_GPIO_AD_24_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e816c 4 0x400e8518 1 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio9_io23: IOMUXC_GPIO_AD_24_GPIO9_IO23 {
 		pinmux = <0x400e816c 10 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x0>;
 	};
-	iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_gpio_mux3_io23_cm7: IOMUXC_GPIO_AD_24_GPIO_MUX3_IO23_CM7 {
 		pinmux = <0x400e816c 5 0x0 0 0x400e83b0>;
 		pin-pue;
 		gpr = <0x400e40ac 0x7 0x1>;
 	};
-	iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_kpp_row05: IOMUXC_GPIO_AD_24_KPP_ROW05 {
 		pinmux = <0x400e816c 6 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpi2c4_scl: IOMUXC_GPIO_AD_24_LPI2C4_SCL {
 		pinmux = <0x400e816c 9 0x400e85c4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpspi2_sck: IOMUXC_GPIO_AD_24_LPSPI2_SCK {
 		pinmux = <0x400e816c 1 0x400e85e4 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_lpuart1_tx: IOMUXC_GPIO_AD_24_LPUART1_TX {
 		pinmux = <0x400e816c 0 0x400e8620 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_24_video_mux_csi_data00: IOMUXC_GPIO_AD_24_VIDEO_MUX_CSI_DATA00 {
 		pinmux = <0x400e816c 2 0x0 0 0x400e83b0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_adc2_ch6b: IOMUXC_GPIO_AD_25_ADC2_CH6B {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_enet_rx_er: IOMUXC_GPIO_AD_25_ENET_RX_ER {
 		pinmux = <0x400e8170 3 0x400e84bc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexio2_flexio25: IOMUXC_GPIO_AD_25_FLEXIO2_FLEXIO25 {
 		pinmux = <0x400e8170 8 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_flexpwm2_pwm0_b: IOMUXC_GPIO_AD_25_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e8170 4 0x400e8524 1 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio9_io24: IOMUXC_GPIO_AD_25_GPIO9_IO24 {
 		pinmux = <0x400e8170 10 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x0>;
 	};
-	iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_gpio_mux3_io24_cm7: IOMUXC_GPIO_AD_25_GPIO_MUX3_IO24_CM7 {
 		pinmux = <0x400e8170 5 0x0 0 0x400e83b4>;
 		pin-pue;
 		gpr = <0x400e40ac 0x8 0x1>;
 	};
-	iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_kpp_col05: IOMUXC_GPIO_AD_25_KPP_COL05 {
 		pinmux = <0x400e8170 6 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpi2c4_sda: IOMUXC_GPIO_AD_25_LPI2C4_SDA {
 		pinmux = <0x400e8170 9 0x400e85c8 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpspi2_pcs0: IOMUXC_GPIO_AD_25_LPSPI2_PCS0 {
 		pinmux = <0x400e8170 1 0x400e85dc 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_lpuart1_rx: IOMUXC_GPIO_AD_25_LPUART1_RX {
 		pinmux = <0x400e8170 0 0x400e861c 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_25_video_mux_csi_data01: IOMUXC_GPIO_AD_25_VIDEO_MUX_CSI_DATA01 {
 		pinmux = <0x400e8170 2 0x0 0 0x400e83b4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_acmp2_in3: IOMUXC_GPIO_AD_26_ACMP2_IN3 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_qos_mdc: IOMUXC_GPIO_AD_26_ENET_QOS_MDC {
 		pinmux = <0x400e8174 9 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_enet_rdata00: IOMUXC_GPIO_AD_26_ENET_RDATA00 {
 		pinmux = <0x400e8174 3 0x400e84b0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexio2_flexio26: IOMUXC_GPIO_AD_26_FLEXIO2_FLEXIO26 {
 		pinmux = <0x400e8174 8 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_flexpwm2_pwm1_a: IOMUXC_GPIO_AD_26_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8174 4 0x400e851c 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio9_io25: IOMUXC_GPIO_AD_26_GPIO9_IO25 {
 		pinmux = <0x400e8174 10 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x0>;
 	};
-	iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_gpio_mux3_io25_cm7: IOMUXC_GPIO_AD_26_GPIO_MUX3_IO25_CM7 {
 		pinmux = <0x400e8174 5 0x0 0 0x400e83b8>;
 		pin-pue;
 		gpr = <0x400e40ac 0x9 0x1>;
 	};
-	iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_kpp_row04: IOMUXC_GPIO_AD_26_KPP_ROW04 {
 		pinmux = <0x400e8174 6 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpspi2_sdo: IOMUXC_GPIO_AD_26_LPSPI2_SDO {
 		pinmux = <0x400e8174 1 0x400e85ec 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_lpuart1_cts_b: IOMUXC_GPIO_AD_26_LPUART1_CTS_B {
 		pinmux = <0x400e8174 0 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_semc_csx01: IOMUXC_GPIO_AD_26_SEMC_CSX01 {
 		pinmux = <0x400e8174 2 0x0 0 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_26_usdhc2_cd_b: IOMUXC_GPIO_AD_26_USDHC2_CD_B {
 		pinmux = <0x400e8174 11 0x400e86d0 1 0x400e83b8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_acmp2_in4: IOMUXC_GPIO_AD_27_ACMP2_IN4 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_qos_mdio: IOMUXC_GPIO_AD_27_ENET_QOS_MDIO {
 		pinmux = <0x400e8178 9 0x400e84ec 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_enet_rdata01: IOMUXC_GPIO_AD_27_ENET_RDATA01 {
 		pinmux = <0x400e8178 3 0x400e84b4 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexio2_flexio27: IOMUXC_GPIO_AD_27_FLEXIO2_FLEXIO27 {
 		pinmux = <0x400e8178 8 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_flexpwm2_pwm1_b: IOMUXC_GPIO_AD_27_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8178 4 0x400e8528 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio9_io26: IOMUXC_GPIO_AD_27_GPIO9_IO26 {
 		pinmux = <0x400e8178 10 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x0>;
 	};
-	iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_gpio_mux3_io26_cm7: IOMUXC_GPIO_AD_27_GPIO_MUX3_IO26_CM7 {
 		pinmux = <0x400e8178 5 0x0 0 0x400e83bc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xa 0x1>;
 	};
-	iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_kpp_col04: IOMUXC_GPIO_AD_27_KPP_COL04 {
 		pinmux = <0x400e8178 6 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpspi2_sdi: IOMUXC_GPIO_AD_27_LPSPI2_SDI {
 		pinmux = <0x400e8178 1 0x400e85e8 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_lpuart1_rts_b: IOMUXC_GPIO_AD_27_LPUART1_RTS_B {
 		pinmux = <0x400e8178 0 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_semc_csx02: IOMUXC_GPIO_AD_27_SEMC_CSX02 {
 		pinmux = <0x400e8178 2 0x0 0 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_27_usdhc2_wp: IOMUXC_GPIO_AD_27_USDHC2_WP {
 		pinmux = <0x400e8178 11 0x400e86d4 1 0x400e83bc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_acmp3_in1: IOMUXC_GPIO_AD_28_ACMP3_IN1 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_enet_tx_en: IOMUXC_GPIO_AD_28_ENET_TX_EN {
 		pinmux = <0x400e817c 3 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexio2_flexio28: IOMUXC_GPIO_AD_28_FLEXIO2_FLEXIO28 {
 		pinmux = <0x400e817c 8 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_flexpwm2_pwm2_a: IOMUXC_GPIO_AD_28_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e817c 4 0x400e8520 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio9_io27: IOMUXC_GPIO_AD_28_GPIO9_IO27 {
 		pinmux = <0x400e817c 10 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x0>;
 	};
-	iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_gpio_mux3_io27_cm7: IOMUXC_GPIO_AD_28_GPIO_MUX3_IO27_CM7 {
 		pinmux = <0x400e817c 5 0x0 0 0x400e83c0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xb 0x1>;
 	};
-	iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_kpp_row03: IOMUXC_GPIO_AD_28_KPP_ROW03 {
 		pinmux = <0x400e817c 6 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpspi1_sck: IOMUXC_GPIO_AD_28_LPSPI1_SCK {
 		pinmux = <0x400e817c 0 0x400e85d0 1 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_lpuart5_tx: IOMUXC_GPIO_AD_28_LPUART5_TX {
 		pinmux = <0x400e817c 1 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_semc_csx03: IOMUXC_GPIO_AD_28_SEMC_CSX03 {
 		pinmux = <0x400e817c 2 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_usdhc2_vselect: IOMUXC_GPIO_AD_28_USDHC2_VSELECT {
 		pinmux = <0x400e817c 11 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_28_video_mux_ext_dcic1: IOMUXC_GPIO_AD_28_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e817c 9 0x0 0 0x400e83c0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_acmp3_in2: IOMUXC_GPIO_AD_29_ACMP3_IN2 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_ref_clk: IOMUXC_GPIO_AD_29_ENET_REF_CLK {
 		pinmux = <0x400e8180 2 0x400e84a8 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_enet_tx_clk: IOMUXC_GPIO_AD_29_ENET_TX_CLK {
 		pinmux = <0x400e8180 3 0x400e84c0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexio2_flexio29: IOMUXC_GPIO_AD_29_FLEXIO2_FLEXIO29 {
 		pinmux = <0x400e8180 8 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_flexpwm2_pwm2_b: IOMUXC_GPIO_AD_29_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e8180 4 0x400e852c 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio9_io28: IOMUXC_GPIO_AD_29_GPIO9_IO28 {
 		pinmux = <0x400e8180 10 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x0>;
 	};
-	iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_gpio_mux3_io28_cm7: IOMUXC_GPIO_AD_29_GPIO_MUX3_IO28_CM7 {
 		pinmux = <0x400e8180 5 0x0 0 0x400e83c4>;
 		pin-pue;
 		gpr = <0x400e40ac 0xc 0x1>;
 	};
-	iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_kpp_col03: IOMUXC_GPIO_AD_29_KPP_COL03 {
 		pinmux = <0x400e8180 6 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpspi1_pcs0: IOMUXC_GPIO_AD_29_LPSPI1_PCS0 {
 		pinmux = <0x400e8180 0 0x400e85cc 1 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_lpuart5_rx: IOMUXC_GPIO_AD_29_LPUART5_RX {
 		pinmux = <0x400e8180 1 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_usdhc2_reset_b: IOMUXC_GPIO_AD_29_USDHC2_RESET_B {
 		pinmux = <0x400e8180 11 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_29_video_mux_ext_dcic2: IOMUXC_GPIO_AD_29_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8180 9 0x0 0 0x400e83c4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_acmp3_in3: IOMUXC_GPIO_AD_30_ACMP3_IN3 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_can2_tx: IOMUXC_GPIO_AD_30_CAN2_TX {
 		pinmux = <0x400e8184 2 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_enet_tdata00: IOMUXC_GPIO_AD_30_ENET_TDATA00 {
 		pinmux = <0x400e8184 3 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_flexio2_flexio30: IOMUXC_GPIO_AD_30_FLEXIO2_FLEXIO30 {
 		pinmux = <0x400e8184 8 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio9_io29: IOMUXC_GPIO_AD_30_GPIO9_IO29 {
 		pinmux = <0x400e8184 10 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_gpio_mux3_io29_cm7: IOMUXC_GPIO_AD_30_GPIO_MUX3_IO29_CM7 {
 		pinmux = <0x400e8184 5 0x0 0 0x400e83c8>;
 		pin-pue;
 		gpr = <0x400e40ac 0xd 0x1>;
 	};
-	iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_kpp_row02: IOMUXC_GPIO_AD_30_KPP_ROW02 {
 		pinmux = <0x400e8184 6 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpspi1_sdo: IOMUXC_GPIO_AD_30_LPSPI1_SDO {
 		pinmux = <0x400e8184 0 0x400e85d8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_lpuart3_tx: IOMUXC_GPIO_AD_30_LPUART3_TX {
 		pinmux = <0x400e8184 4 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_usb_otg2_oc: IOMUXC_GPIO_AD_30_USB_OTG2_OC {
 		pinmux = <0x400e8184 1 0x400e86b8 1 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_30_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_AD_30_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e8184 9 0x0 0 0x400e83c8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_acmp3_in4: IOMUXC_GPIO_AD_31_ACMP3_IN4 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_can2_rx: IOMUXC_GPIO_AD_31_CAN2_RX {
 		pinmux = <0x400e8188 2 0x400e849c 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_enet_tdata01: IOMUXC_GPIO_AD_31_ENET_TDATA01 {
 		pinmux = <0x400e8188 3 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_flexio2_flexio31: IOMUXC_GPIO_AD_31_FLEXIO2_FLEXIO31 {
 		pinmux = <0x400e8188 8 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio9_io30: IOMUXC_GPIO_AD_31_GPIO9_IO30 {
 		pinmux = <0x400e8188 10 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_gpio_mux3_io30_cm7: IOMUXC_GPIO_AD_31_GPIO_MUX3_IO30_CM7 {
 		pinmux = <0x400e8188 5 0x0 0 0x400e83cc>;
 		pin-pue;
 		gpr = <0x400e40ac 0xe 0x1>;
 	};
-	iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_kpp_col02: IOMUXC_GPIO_AD_31_KPP_COL02 {
 		pinmux = <0x400e8188 6 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpspi1_sdi: IOMUXC_GPIO_AD_31_LPSPI1_SDI {
 		pinmux = <0x400e8188 0 0x400e85d4 1 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_lpuart3_rx: IOMUXC_GPIO_AD_31_LPUART3_RX {
 		pinmux = <0x400e8188 4 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_usb_otg2_pwr: IOMUXC_GPIO_AD_31_USB_OTG2_PWR {
 		pinmux = <0x400e8188 1 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_ad_31_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_AD_31_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8188 9 0x0 0 0x400e83cc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_acmp4_in1: IOMUXC_GPIO_AD_32_ACMP4_IN1 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_1g_mdc: IOMUXC_GPIO_AD_32_ENET_1G_MDC {
 		pinmux = <0x400e818c 9 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_enet_mdc: IOMUXC_GPIO_AD_32_ENET_MDC {
 		pinmux = <0x400e818c 3 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio9_io31: IOMUXC_GPIO_AD_32_GPIO9_IO31 {
 		pinmux = <0x400e818c 10 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_gpio_mux3_io31_cm7: IOMUXC_GPIO_AD_32_GPIO_MUX3_IO31_CM7 {
 		pinmux = <0x400e818c 5 0x0 0 0x400e83d0>;
 		pin-pue;
 		gpr = <0x400e40ac 0xf 0x1>;
 	};
-	iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_kpp_row01: IOMUXC_GPIO_AD_32_KPP_ROW01 {
 		pinmux = <0x400e818c 6 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpi2c1_scl: IOMUXC_GPIO_AD_32_LPI2C1_SCL {
 		pinmux = <0x400e818c 0 0x400e85ac 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_lpuart10_tx: IOMUXC_GPIO_AD_32_LPUART10_TX {
 		pinmux = <0x400e818c 8 0x400e8628 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_pgmc_pmic_ready: IOMUXC_GPIO_AD_32_PGMC_PMIC_READY {
 		pinmux = <0x400e818c 2 0x0 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usbphy2_otg_id: IOMUXC_GPIO_AD_32_USBPHY2_OTG_ID {
 		pinmux = <0x400e818c 1 0x400e86c4 1 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_32_usdhc1_cd_b: IOMUXC_GPIO_AD_32_USDHC1_CD_B {
 		pinmux = <0x400e818c 4 0x400e86c8 0 0x400e83d0>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_acmp4_in2: IOMUXC_GPIO_AD_33_ACMP4_IN2 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_1g_mdio: IOMUXC_GPIO_AD_33_ENET_1G_MDIO {
 		pinmux = <0x400e8190 9 0x400e84c8 3 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_enet_mdio: IOMUXC_GPIO_AD_33_ENET_MDIO {
 		pinmux = <0x400e8190 3 0x400e84ac 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio10_io00: IOMUXC_GPIO_AD_33_GPIO10_IO00 {
 		pinmux = <0x400e8190 10 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_gpio_mux4_io00: IOMUXC_GPIO_AD_33_GPIO_MUX4_IO00 {
 		pinmux = <0x400e8190 5 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_kpp_col01: IOMUXC_GPIO_AD_33_KPP_COL01 {
 		pinmux = <0x400e8190 6 0x0 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpi2c1_sda: IOMUXC_GPIO_AD_33_LPI2C1_SDA {
 		pinmux = <0x400e8190 0 0x400e85b0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_lpuart10_rx: IOMUXC_GPIO_AD_33_LPUART10_RX {
 		pinmux = <0x400e8190 8 0x400e8624 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usbphy1_otg_id: IOMUXC_GPIO_AD_33_USBPHY1_OTG_ID {
 		pinmux = <0x400e8190 1 0x400e86c0 1 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_usdhc1_wp: IOMUXC_GPIO_AD_33_USDHC1_WP {
 		pinmux = <0x400e8190 4 0x400e86cc 0 0x400e83d4>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_in17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_IN17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_33_xbar1_xbar_inout17: IOMUXC_GPIO_AD_33_XBAR1_XBAR_INOUT17 {
 		pinmux = <0x400e8190 2 0x0 0 0x400e83d4>;
 		pin-pue;
 		gpr = <0x400e4050 0xd 0x0>;
 	};
-	iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_acmp4_in3: IOMUXC_GPIO_AD_34_ACMP4_IN3 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1588_EVENT0_IN {
 		pinmux = <0x400e8194 3 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_enet_1g_1588_event0_in: IOMUXC_GPIO_AD_34_ENET_1G_1588_EVENT0_IN {
 		pinmux = <0x400e8194 0 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio10_io01: IOMUXC_GPIO_AD_34_GPIO10_IO01 {
 		pinmux = <0x400e8194 10 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_gpio_mux4_io01: IOMUXC_GPIO_AD_34_GPIO_MUX4_IO01 {
 		pinmux = <0x400e8194 5 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_kpp_row00: IOMUXC_GPIO_AD_34_KPP_ROW00 {
 		pinmux = <0x400e8194 6 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_lpuart10_cts_b: IOMUXC_GPIO_AD_34_LPUART10_CTS_B {
 		pinmux = <0x400e8194 8 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usb_otg1_pwr: IOMUXC_GPIO_AD_34_USB_OTG1_PWR {
 		pinmux = <0x400e8194 1 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_usdhc1_vselect: IOMUXC_GPIO_AD_34_USDHC1_VSELECT {
 		pinmux = <0x400e8194 4 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_wdog1_wdog_any: IOMUXC_GPIO_AD_34_WDOG1_WDOG_ANY {
 		pinmux = <0x400e8194 9 0x0 0 0x400e83d8>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_in18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_IN18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_34_xbar1_xbar_inout18: IOMUXC_GPIO_AD_34_XBAR1_XBAR_INOUT18 {
 		pinmux = <0x400e8194 2 0x0 0 0x400e83d8>;
 		pin-pue;
 		gpr = <0x400e4050 0xe 0x0>;
 	};
-	iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_acmp4_in4: IOMUXC_GPIO_AD_35_ACMP4_IN4 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 3 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_enet_1g_1588_event0_out: IOMUXC_GPIO_AD_35_ENET_1G_1588_EVENT0_OUT {
 		pinmux = <0x400e8198 0 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_flexspi1_b_ss1_b: IOMUXC_GPIO_AD_35_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e8198 9 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio10_io02: IOMUXC_GPIO_AD_35_GPIO10_IO02 {
 		pinmux = <0x400e8198 10 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_gpio_mux4_io02: IOMUXC_GPIO_AD_35_GPIO_MUX4_IO02 {
 		pinmux = <0x400e8198 5 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_kpp_col00: IOMUXC_GPIO_AD_35_KPP_COL00 {
 		pinmux = <0x400e8198 6 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_lpuart10_rts_b: IOMUXC_GPIO_AD_35_LPUART10_RTS_B {
 		pinmux = <0x400e8198 8 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usb_otg1_oc: IOMUXC_GPIO_AD_35_USB_OTG1_OC {
 		pinmux = <0x400e8198 1 0x400e86bc 1 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_usdhc1_reset_b: IOMUXC_GPIO_AD_35_USDHC1_RESET_B {
 		pinmux = <0x400e8198 4 0x0 0 0x400e83dc>;
 		pin-pue;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_in19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_IN19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
+	/omit-if-no-ref/ iomuxc_gpio_ad_35_xbar1_xbar_inout19: IOMUXC_GPIO_AD_35_XBAR1_XBAR_INOUT19 {
 		pinmux = <0x400e8198 2 0x0 0 0x400e83dc>;
 		pin-pue;
 		gpr = <0x400e4050 0xf 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_1g_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81e4 1 0x400e84e0 2 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_enet_qos_rx_en: IOMUXC_GPIO_DISP_B1_00_ENET_QOS_RX_EN {
 		pinmux = <0x400e81e4 8 0x400e84f8 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio10_io21: IOMUXC_GPIO_DISP_B1_00_GPIO10_IO21 {
 		pinmux = <0x400e81e4 10 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_gpio_mux4_io21: IOMUXC_GPIO_DISP_B1_00_GPIO_MUX4_IO21 {
 		pinmux = <0x400e81e4 5 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_qtimer1_timer0: IOMUXC_GPIO_DISP_B1_00_QTIMER1_TIMER0 {
 		pinmux = <0x400e81e4 3 0x400e863c 2 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_video_mux_lcdif_clk: IOMUXC_GPIO_DISP_B1_00_VIDEO_MUX_LCDIF_CLK {
 		pinmux = <0x400e81e4 0 0x0 0 0x400e8428>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_in26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_00_xbar1_xbar_inout26: IOMUXC_GPIO_DISP_B1_00_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e81e4 4 0x400e86f0 1 0x400e8428>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81e8 1 0x400e84cc 2 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_1g_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_ER {
 		pinmux = <0x400e81e8 2 0x400e84e4 1 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_clk: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_CLK {
 		pinmux = <0x400e81e8 8 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_enet_qos_rx_er: IOMUXC_GPIO_DISP_B1_01_ENET_QOS_RX_ER {
 		pinmux = <0x400e81e8 9 0x400e84fc 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio10_io22: IOMUXC_GPIO_DISP_B1_01_GPIO10_IO22 {
 		pinmux = <0x400e81e8 10 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_gpio_mux4_io22: IOMUXC_GPIO_DISP_B1_01_GPIO_MUX4_IO22 {
 		pinmux = <0x400e81e8 5 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_qtimer1_timer1: IOMUXC_GPIO_DISP_B1_01_QTIMER1_TIMER1 {
 		pinmux = <0x400e81e8 3 0x400e8640 2 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_video_mux_lcdif_enable: IOMUXC_GPIO_DISP_B1_01_VIDEO_MUX_LCDIF_ENABLE {
 		pinmux = <0x400e81e8 0 0x0 0 0x400e842c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_in27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_01_xbar1_xbar_inout27: IOMUXC_GPIO_DISP_B1_01_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e81e8 4 0x400e86f4 1 0x400e842c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_1g_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81ec 1 0x400e84d0 2 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_enet_qos_rdata00: IOMUXC_GPIO_DISP_B1_02_ENET_QOS_RDATA00 {
 		pinmux = <0x400e81ec 8 0x400e84f0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio10_io23: IOMUXC_GPIO_DISP_B1_02_GPIO10_IO23 {
 		pinmux = <0x400e81ec 10 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_gpio_mux4_io23: IOMUXC_GPIO_DISP_B1_02_GPIO_MUX4_IO23 {
 		pinmux = <0x400e81ec 5 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpi2c3_scl: IOMUXC_GPIO_DISP_B1_02_LPI2C3_SCL {
 		pinmux = <0x400e81ec 2 0x400e85bc 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_lpuart1_tx: IOMUXC_GPIO_DISP_B1_02_LPUART1_TX {
 		pinmux = <0x400e81ec 9 0x400e8620 1 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_qtimer1_timer2: IOMUXC_GPIO_DISP_B1_02_QTIMER1_TIMER2 {
 		pinmux = <0x400e81ec 3 0x400e8644 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_video_mux_lcdif_hsync: IOMUXC_GPIO_DISP_B1_02_VIDEO_MUX_LCDIF_HSYNC {
 		pinmux = <0x400e81ec 0 0x0 0 0x400e8430>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_in28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_02_xbar1_xbar_inout28: IOMUXC_GPIO_DISP_B1_02_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e81ec 4 0x400e86f8 1 0x400e8430>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_1g_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81f0 1 0x400e84d4 2 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_enet_qos_rdata01: IOMUXC_GPIO_DISP_B1_03_ENET_QOS_RDATA01 {
 		pinmux = <0x400e81f0 8 0x400e84f4 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio10_io24: IOMUXC_GPIO_DISP_B1_03_GPIO10_IO24 {
 		pinmux = <0x400e81f0 10 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_gpio_mux4_io24: IOMUXC_GPIO_DISP_B1_03_GPIO_MUX4_IO24 {
 		pinmux = <0x400e81f0 5 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpi2c3_sda: IOMUXC_GPIO_DISP_B1_03_LPI2C3_SDA {
 		pinmux = <0x400e81f0 2 0x400e85c0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_lpuart1_rx: IOMUXC_GPIO_DISP_B1_03_LPUART1_RX {
 		pinmux = <0x400e81f0 9 0x400e861c 1 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_qtimer2_timer0: IOMUXC_GPIO_DISP_B1_03_QTIMER2_TIMER0 {
 		pinmux = <0x400e81f0 3 0x400e8648 2 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_video_mux_lcdif_vsync: IOMUXC_GPIO_DISP_B1_03_VIDEO_MUX_LCDIF_VSYNC {
 		pinmux = <0x400e81f0 0 0x0 0 0x400e8434>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_in29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_03_xbar1_xbar_inout29: IOMUXC_GPIO_DISP_B1_03_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e81f0 4 0x400e86fc 1 0x400e8434>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_1g_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81f4 1 0x400e84d8 2 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_enet_qos_rdata02: IOMUXC_GPIO_DISP_B1_04_ENET_QOS_RDATA02 {
 		pinmux = <0x400e81f4 8 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio10_io25: IOMUXC_GPIO_DISP_B1_04_GPIO10_IO25 {
 		pinmux = <0x400e81f4 10 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_gpio_mux4_io25: IOMUXC_GPIO_DISP_B1_04_GPIO_MUX4_IO25 {
 		pinmux = <0x400e81f4 5 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpspi3_sck: IOMUXC_GPIO_DISP_B1_04_LPSPI3_SCK {
 		pinmux = <0x400e81f4 9 0x400e8600 1 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_lpuart4_rx: IOMUXC_GPIO_DISP_B1_04_LPUART4_RX {
 		pinmux = <0x400e81f4 2 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_qtimer2_timer1: IOMUXC_GPIO_DISP_B1_04_QTIMER2_TIMER1 {
 		pinmux = <0x400e81f4 3 0x400e864c 2 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_video_mux_lcdif_data00: IOMUXC_GPIO_DISP_B1_04_VIDEO_MUX_LCDIF_DATA00 {
 		pinmux = <0x400e81f4 0 0x0 0 0x400e8438>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_in30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_04_xbar1_xbar_inout30: IOMUXC_GPIO_DISP_B1_04_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e81f4 4 0x400e8700 1 0x400e8438>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_1g_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81f8 1 0x400e84dc 2 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_enet_qos_rdata03: IOMUXC_GPIO_DISP_B1_05_ENET_QOS_RDATA03 {
 		pinmux = <0x400e81f8 8 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio10_io26: IOMUXC_GPIO_DISP_B1_05_GPIO10_IO26 {
 		pinmux = <0x400e81f8 10 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_gpio_mux4_io26: IOMUXC_GPIO_DISP_B1_05_GPIO_MUX4_IO26 {
 		pinmux = <0x400e81f8 5 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpspi3_sdi: IOMUXC_GPIO_DISP_B1_05_LPSPI3_SDI {
 		pinmux = <0x400e81f8 9 0x400e8604 1 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_lpuart4_cts_b: IOMUXC_GPIO_DISP_B1_05_LPUART4_CTS_B {
 		pinmux = <0x400e81f8 2 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_qtimer2_timer2: IOMUXC_GPIO_DISP_B1_05_QTIMER2_TIMER2 {
 		pinmux = <0x400e81f8 3 0x400e8650 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_video_mux_lcdif_data01: IOMUXC_GPIO_DISP_B1_05_VIDEO_MUX_LCDIF_DATA01 {
 		pinmux = <0x400e81f8 0 0x0 0 0x400e843c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_in31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_05_xbar1_xbar_inout31: IOMUXC_GPIO_DISP_B1_05_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e81f8 4 0x400e8704 1 0x400e843c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_1g_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81fc 1 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_enet_qos_tdata03: IOMUXC_GPIO_DISP_B1_06_ENET_QOS_TDATA03 {
 		pinmux = <0x400e81fc 8 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio10_io27: IOMUXC_GPIO_DISP_B1_06_GPIO10_IO27 {
 		pinmux = <0x400e81fc 10 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_gpio_mux4_io27: IOMUXC_GPIO_DISP_B1_06_GPIO_MUX4_IO27 {
 		pinmux = <0x400e81fc 5 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpspi3_sdo: IOMUXC_GPIO_DISP_B1_06_LPSPI3_SDO {
 		pinmux = <0x400e81fc 9 0x400e8608 1 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_lpuart4_tx: IOMUXC_GPIO_DISP_B1_06_LPUART4_TX {
 		pinmux = <0x400e81fc 2 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_qtimer3_timer0: IOMUXC_GPIO_DISP_B1_06_QTIMER3_TIMER0 {
 		pinmux = <0x400e81fc 3 0x400e8654 2 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_src_bt_cfg00: IOMUXC_GPIO_DISP_B1_06_SRC_BT_CFG00 {
 		pinmux = <0x400e81fc 6 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_video_mux_lcdif_data02: IOMUXC_GPIO_DISP_B1_06_VIDEO_MUX_LCDIF_DATA02 {
 		pinmux = <0x400e81fc 0 0x0 0 0x400e8440>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_in32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_06_xbar1_xbar_inout32: IOMUXC_GPIO_DISP_B1_06_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e81fc 4 0x400e8708 1 0x400e8440>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_1g_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e8200 1 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_enet_qos_tdata02: IOMUXC_GPIO_DISP_B1_07_ENET_QOS_TDATA02 {
 		pinmux = <0x400e8200 8 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio10_io28: IOMUXC_GPIO_DISP_B1_07_GPIO10_IO28 {
 		pinmux = <0x400e8200 10 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_gpio_mux4_io28: IOMUXC_GPIO_DISP_B1_07_GPIO_MUX4_IO28 {
 		pinmux = <0x400e8200 5 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpspi3_pcs0: IOMUXC_GPIO_DISP_B1_07_LPSPI3_PCS0 {
 		pinmux = <0x400e8200 9 0x400e85f0 1 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_lpuart4_rts_b: IOMUXC_GPIO_DISP_B1_07_LPUART4_RTS_B {
 		pinmux = <0x400e8200 2 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_qtimer3_timer1: IOMUXC_GPIO_DISP_B1_07_QTIMER3_TIMER1 {
 		pinmux = <0x400e8200 3 0x400e8658 2 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_src_bt_cfg01: IOMUXC_GPIO_DISP_B1_07_SRC_BT_CFG01 {
 		pinmux = <0x400e8200 6 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_video_mux_lcdif_data03: IOMUXC_GPIO_DISP_B1_07_VIDEO_MUX_LCDIF_DATA03 {
 		pinmux = <0x400e8200 0 0x0 0 0x400e8444>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_in33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_07_xbar1_xbar_inout33: IOMUXC_GPIO_DISP_B1_07_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e8200 4 0x400e870c 1 0x400e8444>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_1g_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e8204 1 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_enet_qos_tdata01: IOMUXC_GPIO_DISP_B1_08_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8204 8 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio10_io29: IOMUXC_GPIO_DISP_B1_08_GPIO10_IO29 {
 		pinmux = <0x400e8204 10 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_gpio_mux4_io29: IOMUXC_GPIO_DISP_B1_08_GPIO_MUX4_IO29 {
 		pinmux = <0x400e8204 5 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_lpspi3_pcs1: IOMUXC_GPIO_DISP_B1_08_LPSPI3_PCS1 {
 		pinmux = <0x400e8204 9 0x400e85f4 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_qtimer3_timer2: IOMUXC_GPIO_DISP_B1_08_QTIMER3_TIMER2 {
 		pinmux = <0x400e8204 3 0x400e865c 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_src_bt_cfg02: IOMUXC_GPIO_DISP_B1_08_SRC_BT_CFG02 {
 		pinmux = <0x400e8204 6 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_usdhc1_cd_b: IOMUXC_GPIO_DISP_B1_08_USDHC1_CD_B {
 		pinmux = <0x400e8204 2 0x400e86c8 1 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_video_mux_lcdif_data04: IOMUXC_GPIO_DISP_B1_08_VIDEO_MUX_LCDIF_DATA04 {
 		pinmux = <0x400e8204 0 0x0 0 0x400e8448>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_in34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_08_xbar1_xbar_inout34: IOMUXC_GPIO_DISP_B1_08_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e8204 4 0x400e8710 1 0x400e8448>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_1g_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e8208 1 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_enet_qos_tdata00: IOMUXC_GPIO_DISP_B1_09_ENET_QOS_TDATA00 {
 		pinmux = <0x400e8208 8 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio10_io30: IOMUXC_GPIO_DISP_B1_09_GPIO10_IO30 {
 		pinmux = <0x400e8208 10 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_gpio_mux4_io30: IOMUXC_GPIO_DISP_B1_09_GPIO_MUX4_IO30 {
 		pinmux = <0x400e8208 5 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_lpspi3_pcs2: IOMUXC_GPIO_DISP_B1_09_LPSPI3_PCS2 {
 		pinmux = <0x400e8208 9 0x400e85f8 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_qtimer4_timer0: IOMUXC_GPIO_DISP_B1_09_QTIMER4_TIMER0 {
 		pinmux = <0x400e8208 3 0x400e8660 2 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_src_bt_cfg03: IOMUXC_GPIO_DISP_B1_09_SRC_BT_CFG03 {
 		pinmux = <0x400e8208 6 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_usdhc1_wp: IOMUXC_GPIO_DISP_B1_09_USDHC1_WP {
 		pinmux = <0x400e8208 2 0x400e86cc 1 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_video_mux_lcdif_data05: IOMUXC_GPIO_DISP_B1_09_VIDEO_MUX_LCDIF_DATA05 {
 		pinmux = <0x400e8208 0 0x0 0 0x400e844c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_in35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_09_xbar1_xbar_inout35: IOMUXC_GPIO_DISP_B1_09_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e8208 4 0x400e8714 1 0x400e844c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_1g_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_1G_TX_EN {
 		pinmux = <0x400e820c 1 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_enet_qos_tx_en: IOMUXC_GPIO_DISP_B1_10_ENET_QOS_TX_EN {
 		pinmux = <0x400e820c 8 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio10_io31: IOMUXC_GPIO_DISP_B1_10_GPIO10_IO31 {
 		pinmux = <0x400e820c 10 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_gpio_mux4_io31: IOMUXC_GPIO_DISP_B1_10_GPIO_MUX4_IO31 {
 		pinmux = <0x400e820c 5 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_lpspi3_pcs3: IOMUXC_GPIO_DISP_B1_10_LPSPI3_PCS3 {
 		pinmux = <0x400e820c 9 0x400e85fc 1 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_qtimer4_timer1: IOMUXC_GPIO_DISP_B1_10_QTIMER4_TIMER1 {
 		pinmux = <0x400e820c 3 0x400e8664 2 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_src_bt_cfg04: IOMUXC_GPIO_DISP_B1_10_SRC_BT_CFG04 {
 		pinmux = <0x400e820c 6 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_usdhc1_reset_b: IOMUXC_GPIO_DISP_B1_10_USDHC1_RESET_B {
 		pinmux = <0x400e820c 2 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_video_mux_lcdif_data06: IOMUXC_GPIO_DISP_B1_10_VIDEO_MUX_LCDIF_DATA06 {
 		pinmux = <0x400e820c 0 0x0 0 0x400e8450>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_in36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_IN36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_10_xbar1_xbar_inout36: IOMUXC_GPIO_DISP_B1_10_XBAR1_XBAR_INOUT36 {
 		pinmux = <0x400e820c 4 0x0 0 0x400e8450>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x4 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8210 2 0x400e84c4 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_1g_tx_clk_io: IOMUXC_GPIO_DISP_B1_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e8210 1 0x400e84e8 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_ref_clk1: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8210 9 0x400e84a0 2 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B1_11_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8210 8 0x400e84a4 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio11_io00: IOMUXC_GPIO_DISP_B1_11_GPIO11_IO00 {
 		pinmux = <0x400e8210 10 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_gpio_mux5_io00: IOMUXC_GPIO_DISP_B1_11_GPIO_MUX5_IO00 {
 		pinmux = <0x400e8210 5 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_qtimer4_timer2: IOMUXC_GPIO_DISP_B1_11_QTIMER4_TIMER2 {
 		pinmux = <0x400e8210 3 0x400e8668 1 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e403c 0xa 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_src_bt_cfg05: IOMUXC_GPIO_DISP_B1_11_SRC_BT_CFG05 {
 		pinmux = <0x400e8210 6 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_video_mux_lcdif_data07: IOMUXC_GPIO_DISP_B1_11_VIDEO_MUX_LCDIF_DATA07 {
 		pinmux = <0x400e8210 0 0x0 0 0x400e8454>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_in37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_IN37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b1_11_xbar1_xbar_inout37: IOMUXC_GPIO_DISP_B1_11_XBAR1_XBAR_INOUT37 {
 		pinmux = <0x400e8210 4 0x0 0 0x400e8454>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x5 0x0>;
 	};
-	iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_1g_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_1G_TX_ER {
 		pinmux = <0x400e8214 3 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_enet_qos_tx_er: IOMUXC_GPIO_DISP_B2_00_ENET_QOS_TX_ER {
 		pinmux = <0x400e8214 8 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio11_io01: IOMUXC_GPIO_DISP_B2_00_GPIO11_IO01 {
 		pinmux = <0x400e8214 10 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_gpio_mux5_io01: IOMUXC_GPIO_DISP_B2_00_GPIO_MUX5_IO01 {
 		pinmux = <0x400e8214 5 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_mqs_right: IOMUXC_GPIO_DISP_B2_00_MQS_RIGHT {
 		pinmux = <0x400e8214 2 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_rx_data01: IOMUXC_GPIO_DISP_B2_00_SAI1_RX_DATA01 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_sai1_tx_data03: IOMUXC_GPIO_DISP_B2_00_SAI1_TX_DATA03 {
 		pinmux = <0x400e8214 4 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_src_bt_cfg06: IOMUXC_GPIO_DISP_B2_00_SRC_BT_CFG06 {
 		pinmux = <0x400e8214 6 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_video_mux_lcdif_data08: IOMUXC_GPIO_DISP_B2_00_VIDEO_MUX_LCDIF_DATA08 {
 		pinmux = <0x400e8214 0 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_00_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_00_WDOG1_WDOG_B {
 		pinmux = <0x400e8214 1 0x0 0 0x400e8458>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ccm_enet_ref_clk_25m: IOMUXC_GPIO_DISP_B2_01_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e8218 9 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_ewm_ewm_out_b: IOMUXC_GPIO_DISP_B2_01_EWM_EWM_OUT_B {
 		pinmux = <0x400e8218 8 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio11_io02: IOMUXC_GPIO_DISP_B2_01_GPIO11_IO02 {
 		pinmux = <0x400e8218 10 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_gpio_mux5_io02: IOMUXC_GPIO_DISP_B2_01_GPIO_MUX5_IO02 {
 		pinmux = <0x400e8218 5 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_mqs_left: IOMUXC_GPIO_DISP_B2_01_MQS_LEFT {
 		pinmux = <0x400e8218 2 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_rx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_RX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_sai1_tx_data02: IOMUXC_GPIO_DISP_B2_01_SAI1_TX_DATA02 {
 		pinmux = <0x400e8218 4 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_src_bt_cfg07: IOMUXC_GPIO_DISP_B2_01_SRC_BT_CFG07 {
 		pinmux = <0x400e8218 6 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_usdhc1_vselect: IOMUXC_GPIO_DISP_B2_01_USDHC1_VSELECT {
 		pinmux = <0x400e8218 1 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_video_mux_lcdif_data09: IOMUXC_GPIO_DISP_B2_01_VIDEO_MUX_LCDIF_DATA09 {
 		pinmux = <0x400e8218 0 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_01_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_01_WDOG2_WDOG_B {
 		pinmux = <0x400e8218 3 0x0 0 0x400e845c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_arm_trace00: IOMUXC_GPIO_DISP_B2_02_ARM_TRACE00 {
 		pinmux = <0x400e821c 3 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_qos_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_QOS_TDATA00 {
 		pinmux = <0x400e821c 8 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_enet_tdata00: IOMUXC_GPIO_DISP_B2_02_ENET_TDATA00 {
 		pinmux = <0x400e821c 1 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio11_io03: IOMUXC_GPIO_DISP_B2_02_GPIO11_IO03 {
 		pinmux = <0x400e821c 10 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_gpio_mux5_io03: IOMUXC_GPIO_DISP_B2_02_GPIO_MUX5_IO03 {
 		pinmux = <0x400e821c 5 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_pit1_trigger03: IOMUXC_GPIO_DISP_B2_02_PIT1_TRIGGER03 {
 		pinmux = <0x400e821c 2 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_rx_data03: IOMUXC_GPIO_DISP_B2_02_SAI1_RX_DATA03 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_sai1_tx_data01: IOMUXC_GPIO_DISP_B2_02_SAI1_TX_DATA01 {
 		pinmux = <0x400e821c 4 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_src_bt_cfg08: IOMUXC_GPIO_DISP_B2_02_SRC_BT_CFG08 {
 		pinmux = <0x400e821c 6 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_02_video_mux_lcdif_data10: IOMUXC_GPIO_DISP_B2_02_VIDEO_MUX_LCDIF_DATA10 {
 		pinmux = <0x400e821c 0 0x0 0 0x400e8460>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_arm_trace01: IOMUXC_GPIO_DISP_B2_03_ARM_TRACE01 {
 		pinmux = <0x400e8220 3 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_qos_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_QOS_TDATA01 {
 		pinmux = <0x400e8220 8 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_enet_tdata01: IOMUXC_GPIO_DISP_B2_03_ENET_TDATA01 {
 		pinmux = <0x400e8220 1 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio11_io04: IOMUXC_GPIO_DISP_B2_03_GPIO11_IO04 {
 		pinmux = <0x400e8220 10 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_gpio_mux5_io04: IOMUXC_GPIO_DISP_B2_03_GPIO_MUX5_IO04 {
 		pinmux = <0x400e8220 5 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_pit1_trigger02: IOMUXC_GPIO_DISP_B2_03_PIT1_TRIGGER02 {
 		pinmux = <0x400e8220 2 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_sai1_mclk: IOMUXC_GPIO_DISP_B2_03_SAI1_MCLK {
 		pinmux = <0x400e8220 4 0x400e866c 1 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_src_bt_cfg09: IOMUXC_GPIO_DISP_B2_03_SRC_BT_CFG09 {
 		pinmux = <0x400e8220 6 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_03_video_mux_lcdif_data11: IOMUXC_GPIO_DISP_B2_03_VIDEO_MUX_LCDIF_DATA11 {
 		pinmux = <0x400e8220 0 0x0 0 0x400e8464>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_arm_trace02: IOMUXC_GPIO_DISP_B2_04_ARM_TRACE02 {
 		pinmux = <0x400e8224 3 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_qos_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_QOS_TX_EN {
 		pinmux = <0x400e8224 8 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_enet_tx_en: IOMUXC_GPIO_DISP_B2_04_ENET_TX_EN {
 		pinmux = <0x400e8224 1 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio11_io05: IOMUXC_GPIO_DISP_B2_04_GPIO11_IO05 {
 		pinmux = <0x400e8224 10 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_gpio_mux5_io05: IOMUXC_GPIO_DISP_B2_04_GPIO_MUX5_IO05 {
 		pinmux = <0x400e8224 5 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_pit1_trigger01: IOMUXC_GPIO_DISP_B2_04_PIT1_TRIGGER01 {
 		pinmux = <0x400e8224 2 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_sai1_rx_sync: IOMUXC_GPIO_DISP_B2_04_SAI1_RX_SYNC {
 		pinmux = <0x400e8224 4 0x400e8678 1 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_src_bt_cfg10: IOMUXC_GPIO_DISP_B2_04_SRC_BT_CFG10 {
 		pinmux = <0x400e8224 6 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_04_video_mux_lcdif_data12: IOMUXC_GPIO_DISP_B2_04_VIDEO_MUX_LCDIF_DATA12 {
 		pinmux = <0x400e8224 0 0x0 0 0x400e8468>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_arm_trace03: IOMUXC_GPIO_DISP_B2_05_ARM_TRACE03 {
 		pinmux = <0x400e8228 3 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_qos_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_QOS_TX_CLK {
 		pinmux = <0x400e8228 8 0x400e84a4 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_ref_clk: IOMUXC_GPIO_DISP_B2_05_ENET_REF_CLK {
 		pinmux = <0x400e8228 2 0x400e84a8 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_enet_tx_clk: IOMUXC_GPIO_DISP_B2_05_ENET_TX_CLK {
 		pinmux = <0x400e8228 1 0x400e84c0 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio11_io06: IOMUXC_GPIO_DISP_B2_05_GPIO11_IO06 {
 		pinmux = <0x400e8228 10 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_gpio_mux5_io06: IOMUXC_GPIO_DISP_B2_05_GPIO_MUX5_IO06 {
 		pinmux = <0x400e8228 5 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_sai1_rx_bclk: IOMUXC_GPIO_DISP_B2_05_SAI1_RX_BCLK {
 		pinmux = <0x400e8228 4 0x400e8670 1 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_src_bt_cfg11: IOMUXC_GPIO_DISP_B2_05_SRC_BT_CFG11 {
 		pinmux = <0x400e8228 6 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_05_video_mux_lcdif_data13: IOMUXC_GPIO_DISP_B2_05_VIDEO_MUX_LCDIF_DATA13 {
 		pinmux = <0x400e8228 0 0x0 0 0x400e846c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_arm_trace_clk: IOMUXC_GPIO_DISP_B2_06_ARM_TRACE_CLK {
 		pinmux = <0x400e822c 3 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_qos_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_QOS_RDATA00 {
 		pinmux = <0x400e822c 8 0x400e84f0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_enet_rdata00: IOMUXC_GPIO_DISP_B2_06_ENET_RDATA00 {
 		pinmux = <0x400e822c 1 0x400e84b0 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio11_io07: IOMUXC_GPIO_DISP_B2_06_GPIO11_IO07 {
 		pinmux = <0x400e822c 10 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_gpio_mux5_io07: IOMUXC_GPIO_DISP_B2_06_GPIO_MUX5_IO07 {
 		pinmux = <0x400e822c 5 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_lpuart7_tx: IOMUXC_GPIO_DISP_B2_06_LPUART7_TX {
 		pinmux = <0x400e822c 2 0x400e8630 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_sai1_rx_data00: IOMUXC_GPIO_DISP_B2_06_SAI1_RX_DATA00 {
 		pinmux = <0x400e822c 4 0x400e8674 1 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_06_video_mux_lcdif_data14: IOMUXC_GPIO_DISP_B2_06_VIDEO_MUX_LCDIF_DATA14 {
 		pinmux = <0x400e822c 0 0x0 0 0x400e8470>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_arm_trace_swo: IOMUXC_GPIO_DISP_B2_07_ARM_TRACE_SWO {
 		pinmux = <0x400e8230 3 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_qos_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_QOS_RDATA01 {
 		pinmux = <0x400e8230 8 0x400e84f4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_enet_rdata01: IOMUXC_GPIO_DISP_B2_07_ENET_RDATA01 {
 		pinmux = <0x400e8230 1 0x400e84b4 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio11_io08: IOMUXC_GPIO_DISP_B2_07_GPIO11_IO08 {
 		pinmux = <0x400e8230 10 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_gpio_mux5_io08: IOMUXC_GPIO_DISP_B2_07_GPIO_MUX5_IO08 {
 		pinmux = <0x400e8230 5 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_lpuart7_rx: IOMUXC_GPIO_DISP_B2_07_LPUART7_RX {
 		pinmux = <0x400e8230 2 0x400e862c 1 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_sai1_tx_data00: IOMUXC_GPIO_DISP_B2_07_SAI1_TX_DATA00 {
 		pinmux = <0x400e8230 4 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_07_video_mux_lcdif_data15: IOMUXC_GPIO_DISP_B2_07_VIDEO_MUX_LCDIF_DATA15 {
 		pinmux = <0x400e8230 0 0x0 0 0x400e8474>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_cm7_imxrt_txev: IOMUXC_GPIO_DISP_B2_08_CM7_IMXRT_TXEV {
 		pinmux = <0x400e8234 3 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_qos_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_QOS_RX_EN {
 		pinmux = <0x400e8234 8 0x400e84f8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_enet_rx_en: IOMUXC_GPIO_DISP_B2_08_ENET_RX_EN {
 		pinmux = <0x400e8234 1 0x400e84b8 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio11_io09: IOMUXC_GPIO_DISP_B2_08_GPIO11_IO09 {
 		pinmux = <0x400e8234 10 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_gpio_mux5_io09: IOMUXC_GPIO_DISP_B2_08_GPIO_MUX5_IO09 {
 		pinmux = <0x400e8234 5 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart1_tx: IOMUXC_GPIO_DISP_B2_08_LPUART1_TX {
 		pinmux = <0x400e8234 9 0x400e8620 2 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_lpuart8_tx: IOMUXC_GPIO_DISP_B2_08_LPUART8_TX {
 		pinmux = <0x400e8234 2 0x400e8638 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_sai1_tx_bclk: IOMUXC_GPIO_DISP_B2_08_SAI1_TX_BCLK {
 		pinmux = <0x400e8234 4 0x400e867c 1 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_08_video_mux_lcdif_data16: IOMUXC_GPIO_DISP_B2_08_VIDEO_MUX_LCDIF_DATA16 {
 		pinmux = <0x400e8234 0 0x0 0 0x400e8478>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_cm7_imxrt_rxev: IOMUXC_GPIO_DISP_B2_09_CM7_IMXRT_RXEV {
 		pinmux = <0x400e8238 3 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_QOS_RX_ER {
 		pinmux = <0x400e8238 8 0x400e84fc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_enet_rx_er: IOMUXC_GPIO_DISP_B2_09_ENET_RX_ER {
 		pinmux = <0x400e8238 1 0x400e84bc 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio11_io10: IOMUXC_GPIO_DISP_B2_09_GPIO11_IO10 {
 		pinmux = <0x400e8238 10 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_gpio_mux5_io10: IOMUXC_GPIO_DISP_B2_09_GPIO_MUX5_IO10 {
 		pinmux = <0x400e8238 5 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart1_rx: IOMUXC_GPIO_DISP_B2_09_LPUART1_RX {
 		pinmux = <0x400e8238 9 0x400e861c 2 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_lpuart8_rx: IOMUXC_GPIO_DISP_B2_09_LPUART8_RX {
 		pinmux = <0x400e8238 2 0x400e8634 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_sai1_tx_sync: IOMUXC_GPIO_DISP_B2_09_SAI1_TX_SYNC {
 		pinmux = <0x400e8238 4 0x400e8680 1 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_09_video_mux_lcdif_data17: IOMUXC_GPIO_DISP_B2_09_VIDEO_MUX_LCDIF_DATA17 {
 		pinmux = <0x400e8238 0 0x0 0 0x400e847c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_enet_qos_rx_er: IOMUXC_GPIO_DISP_B2_10_ENET_QOS_RX_ER {
 		pinmux = <0x400e823c 8 0x400e84fc 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio11_io11: IOMUXC_GPIO_DISP_B2_10_GPIO11_IO11 {
 		pinmux = <0x400e823c 10 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_gpio_mux5_io11: IOMUXC_GPIO_DISP_B2_10_GPIO_MUX5_IO11 {
 		pinmux = <0x400e823c 5 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpi2c3_scl: IOMUXC_GPIO_DISP_B2_10_LPI2C3_SCL {
 		pinmux = <0x400e823c 6 0x400e85bc 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_lpuart2_tx: IOMUXC_GPIO_DISP_B2_10_LPUART2_TX {
 		pinmux = <0x400e823c 2 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_sim2_trxd: IOMUXC_GPIO_DISP_B2_10_SIM2_TRXD {
 		pinmux = <0x400e823c 1 0x400e86a8 1 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_spdif_in: IOMUXC_GPIO_DISP_B2_10_SPDIF_IN {
 		pinmux = <0x400e823c 9 0x400e86b4 2 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_video_mux_lcdif_data18: IOMUXC_GPIO_DISP_B2_10_VIDEO_MUX_LCDIF_DATA18 {
 		pinmux = <0x400e823c 0 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_wdog2_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_10_WDOG2_WDOG_RST_B_DEB {
 		pinmux = <0x400e823c 3 0x0 0 0x400e8480>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_in38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_IN38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_10_xbar1_xbar_inout38: IOMUXC_GPIO_DISP_B2_10_XBAR1_XBAR_INOUT38 {
 		pinmux = <0x400e823c 4 0x0 0 0x400e8480>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x6 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_enet_qos_crs: IOMUXC_GPIO_DISP_B2_11_ENET_QOS_CRS {
 		pinmux = <0x400e8240 8 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio11_io12: IOMUXC_GPIO_DISP_B2_11_GPIO11_IO12 {
 		pinmux = <0x400e8240 10 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_gpio_mux5_io12: IOMUXC_GPIO_DISP_B2_11_GPIO_MUX5_IO12 {
 		pinmux = <0x400e8240 5 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpi2c3_sda: IOMUXC_GPIO_DISP_B2_11_LPI2C3_SDA {
 		pinmux = <0x400e8240 6 0x400e85c0 1 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_lpuart2_rx: IOMUXC_GPIO_DISP_B2_11_LPUART2_RX {
 		pinmux = <0x400e8240 2 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_sim2_clk: IOMUXC_GPIO_DISP_B2_11_SIM2_CLK {
 		pinmux = <0x400e8240 1 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_spdif_out: IOMUXC_GPIO_DISP_B2_11_SPDIF_OUT {
 		pinmux = <0x400e8240 9 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_video_mux_lcdif_data19: IOMUXC_GPIO_DISP_B2_11_VIDEO_MUX_LCDIF_DATA19 {
 		pinmux = <0x400e8240 0 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_wdog1_wdog_rst_b_deb: IOMUXC_GPIO_DISP_B2_11_WDOG1_WDOG_RST_B_DEB {
 		pinmux = <0x400e8240 3 0x0 0 0x400e8484>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_in39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_IN39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_11_xbar1_xbar_inout39: IOMUXC_GPIO_DISP_B2_11_XBAR1_XBAR_INOUT39 {
 		pinmux = <0x400e8240 4 0x0 0 0x400e8484>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x7 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_can1_tx: IOMUXC_GPIO_DISP_B2_12_CAN1_TX {
 		pinmux = <0x400e8244 2 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_enet_qos_col: IOMUXC_GPIO_DISP_B2_12_ENET_QOS_COL {
 		pinmux = <0x400e8244 8 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio11_io13: IOMUXC_GPIO_DISP_B2_12_GPIO11_IO13 {
 		pinmux = <0x400e8244 10 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_gpio_mux5_io13: IOMUXC_GPIO_DISP_B2_12_GPIO_MUX5_IO13 {
 		pinmux = <0x400e8244 5 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpi2c4_scl: IOMUXC_GPIO_DISP_B2_12_LPI2C4_SCL {
 		pinmux = <0x400e8244 6 0x400e85c4 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpspi4_sck: IOMUXC_GPIO_DISP_B2_12_LPSPI4_SCK {
 		pinmux = <0x400e8244 9 0x400e8610 1 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_lpuart2_cts_b: IOMUXC_GPIO_DISP_B2_12_LPUART2_CTS_B {
 		pinmux = <0x400e8244 3 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_sim2_rst_b: IOMUXC_GPIO_DISP_B2_12_SIM2_RST_B {
 		pinmux = <0x400e8244 1 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_video_mux_lcdif_data20: IOMUXC_GPIO_DISP_B2_12_VIDEO_MUX_LCDIF_DATA20 {
 		pinmux = <0x400e8244 0 0x0 0 0x400e8488>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_in40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_IN40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_12_xbar1_xbar_inout40: IOMUXC_GPIO_DISP_B2_12_XBAR1_XBAR_INOUT40 {
 		pinmux = <0x400e8244 4 0x0 0 0x400e8488>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x8 0x0>;
 	};
-	iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_can1_rx: IOMUXC_GPIO_DISP_B2_13_CAN1_RX {
 		pinmux = <0x400e8248 2 0x400e8498 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_qos_1588_event0_out: IOMUXC_GPIO_DISP_B2_13_ENET_QOS_1588_EVENT0_OUT {
 		pinmux = <0x400e8248 8 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_enet_ref_clk: IOMUXC_GPIO_DISP_B2_13_ENET_REF_CLK {
 		pinmux = <0x400e8248 4 0x400e84a8 2 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio11_io14: IOMUXC_GPIO_DISP_B2_13_GPIO11_IO14 {
 		pinmux = <0x400e8248 10 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_gpio_mux5_io14: IOMUXC_GPIO_DISP_B2_13_GPIO_MUX5_IO14 {
 		pinmux = <0x400e8248 5 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpi2c4_sda: IOMUXC_GPIO_DISP_B2_13_LPI2C4_SDA {
 		pinmux = <0x400e8248 6 0x400e85c8 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpspi4_sdi: IOMUXC_GPIO_DISP_B2_13_LPSPI4_SDI {
 		pinmux = <0x400e8248 9 0x400e8614 1 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_lpuart2_rts_b: IOMUXC_GPIO_DISP_B2_13_LPUART2_RTS_B {
 		pinmux = <0x400e8248 3 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_sim2_sven: IOMUXC_GPIO_DISP_B2_13_SIM2_SVEN {
 		pinmux = <0x400e8248 1 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_13_video_mux_lcdif_data21: IOMUXC_GPIO_DISP_B2_13_VIDEO_MUX_LCDIF_DATA21 {
 		pinmux = <0x400e8248 0 0x0 0 0x400e848c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_can1_tx: IOMUXC_GPIO_DISP_B2_14_CAN1_TX {
 		pinmux = <0x400e824c 6 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_1g_ref_clk1: IOMUXC_GPIO_DISP_B2_14_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e824c 4 0x400e84c4 3 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_enet_qos_1588_event0_in: IOMUXC_GPIO_DISP_B2_14_ENET_QOS_1588_EVENT0_IN {
 		pinmux = <0x400e824c 8 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio11_io15: IOMUXC_GPIO_DISP_B2_14_GPIO11_IO15 {
 		pinmux = <0x400e824c 10 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_gpio_mux5_io15: IOMUXC_GPIO_DISP_B2_14_GPIO_MUX5_IO15 {
 		pinmux = <0x400e824c 5 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_lpspi4_sdo: IOMUXC_GPIO_DISP_B2_14_LPSPI4_SDO {
 		pinmux = <0x400e824c 9 0x400e8618 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_sim2_pd: IOMUXC_GPIO_DISP_B2_14_SIM2_PD {
 		pinmux = <0x400e824c 1 0x400e86ac 1 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_ext_dcic1: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_EXT_DCIC1 {
 		pinmux = <0x400e824c 3 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_video_mux_lcdif_data22: IOMUXC_GPIO_DISP_B2_14_VIDEO_MUX_LCDIF_DATA22 {
 		pinmux = <0x400e824c 0 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_14_wdog2_wdog_b: IOMUXC_GPIO_DISP_B2_14_WDOG2_WDOG_B {
 		pinmux = <0x400e824c 2 0x0 0 0x400e8490>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_can1_rx: IOMUXC_GPIO_DISP_B2_15_CAN1_RX {
 		pinmux = <0x400e8250 6 0x400e8498 2 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_enet_qos_1588_event0_aux_in: IOMUXC_GPIO_DISP_B2_15_ENET_QOS_1588_EVENT0_AUX_IN {
 		pinmux = <0x400e8250 8 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio11_io16: IOMUXC_GPIO_DISP_B2_15_GPIO11_IO16 {
 		pinmux = <0x400e8250 10 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_gpio_mux5_io16: IOMUXC_GPIO_DISP_B2_15_GPIO_MUX5_IO16 {
 		pinmux = <0x400e8250 5 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_lpspi4_pcs0: IOMUXC_GPIO_DISP_B2_15_LPSPI4_PCS0 {
 		pinmux = <0x400e8250 9 0x400e860c 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_pit1_trigger00: IOMUXC_GPIO_DISP_B2_15_PIT1_TRIGGER00 {
 		pinmux = <0x400e8250 4 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_sim2_power_fail: IOMUXC_GPIO_DISP_B2_15_SIM2_POWER_FAIL {
 		pinmux = <0x400e8250 1 0x400e86b0 1 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_ext_dcic2: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_EXT_DCIC2 {
 		pinmux = <0x400e8250 3 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_video_mux_lcdif_data23: IOMUXC_GPIO_DISP_B2_15_VIDEO_MUX_LCDIF_DATA23 {
 		pinmux = <0x400e8250 0 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_disp_b2_15_wdog1_wdog_b: IOMUXC_GPIO_DISP_B2_15_WDOG1_WDOG_B {
 		pinmux = <0x400e8250 2 0x0 0 0x400e8494>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexio1_flexio00: IOMUXC_GPIO_EMC_B1_00_FLEXIO1_FLEXIO00 {
 		pinmux = <0x400e8010 8 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_flexpwm4_pwm0_a: IOMUXC_GPIO_EMC_B1_00_FLEXPWM4_PWM0_A {
 		pinmux = <0x400e8010 1 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio7_io00: IOMUXC_GPIO_EMC_B1_00_GPIO7_IO00 {
 		pinmux = <0x400e8010 10 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_gpio_mux1_io00: IOMUXC_GPIO_EMC_B1_00_GPIO_MUX1_IO00 {
 		pinmux = <0x400e8010 5 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_00_semc_data00: IOMUXC_GPIO_EMC_B1_00_SEMC_DATA00 {
 		pinmux = <0x400e8010 0 0x0 0 0x400e8254>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexio1_flexio01: IOMUXC_GPIO_EMC_B1_01_FLEXIO1_FLEXIO01 {
 		pinmux = <0x400e8014 8 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_flexpwm4_pwm0_b: IOMUXC_GPIO_EMC_B1_01_FLEXPWM4_PWM0_B {
 		pinmux = <0x400e8014 1 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio7_io01: IOMUXC_GPIO_EMC_B1_01_GPIO7_IO01 {
 		pinmux = <0x400e8014 10 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_gpio_mux1_io01: IOMUXC_GPIO_EMC_B1_01_GPIO_MUX1_IO01 {
 		pinmux = <0x400e8014 5 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_01_semc_data01: IOMUXC_GPIO_EMC_B1_01_SEMC_DATA01 {
 		pinmux = <0x400e8014 0 0x0 0 0x400e8258>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexio1_flexio02: IOMUXC_GPIO_EMC_B1_02_FLEXIO1_FLEXIO02 {
 		pinmux = <0x400e8018 8 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_flexpwm4_pwm1_a: IOMUXC_GPIO_EMC_B1_02_FLEXPWM4_PWM1_A {
 		pinmux = <0x400e8018 1 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio7_io02: IOMUXC_GPIO_EMC_B1_02_GPIO7_IO02 {
 		pinmux = <0x400e8018 10 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_gpio_mux1_io02: IOMUXC_GPIO_EMC_B1_02_GPIO_MUX1_IO02 {
 		pinmux = <0x400e8018 5 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_02_semc_data02: IOMUXC_GPIO_EMC_B1_02_SEMC_DATA02 {
 		pinmux = <0x400e8018 0 0x0 0 0x400e825c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexio1_flexio03: IOMUXC_GPIO_EMC_B1_03_FLEXIO1_FLEXIO03 {
 		pinmux = <0x400e801c 8 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_flexpwm4_pwm1_b: IOMUXC_GPIO_EMC_B1_03_FLEXPWM4_PWM1_B {
 		pinmux = <0x400e801c 1 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio7_io03: IOMUXC_GPIO_EMC_B1_03_GPIO7_IO03 {
 		pinmux = <0x400e801c 10 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_gpio_mux1_io03: IOMUXC_GPIO_EMC_B1_03_GPIO_MUX1_IO03 {
 		pinmux = <0x400e801c 5 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_03_semc_data03: IOMUXC_GPIO_EMC_B1_03_SEMC_DATA03 {
 		pinmux = <0x400e801c 0 0x0 0 0x400e8260>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexio1_flexio04: IOMUXC_GPIO_EMC_B1_04_FLEXIO1_FLEXIO04 {
 		pinmux = <0x400e8020 8 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_flexpwm4_pwm2_a: IOMUXC_GPIO_EMC_B1_04_FLEXPWM4_PWM2_A {
 		pinmux = <0x400e8020 1 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio7_io04: IOMUXC_GPIO_EMC_B1_04_GPIO7_IO04 {
 		pinmux = <0x400e8020 10 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_gpio_mux1_io04: IOMUXC_GPIO_EMC_B1_04_GPIO_MUX1_IO04 {
 		pinmux = <0x400e8020 5 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_04_semc_data04: IOMUXC_GPIO_EMC_B1_04_SEMC_DATA04 {
 		pinmux = <0x400e8020 0 0x0 0 0x400e8264>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexio1_flexio05: IOMUXC_GPIO_EMC_B1_05_FLEXIO1_FLEXIO05 {
 		pinmux = <0x400e8024 8 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_flexpwm4_pwm2_b: IOMUXC_GPIO_EMC_B1_05_FLEXPWM4_PWM2_B {
 		pinmux = <0x400e8024 1 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio7_io05: IOMUXC_GPIO_EMC_B1_05_GPIO7_IO05 {
 		pinmux = <0x400e8024 10 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_gpio_mux1_io05: IOMUXC_GPIO_EMC_B1_05_GPIO_MUX1_IO05 {
 		pinmux = <0x400e8024 5 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_05_semc_data05: IOMUXC_GPIO_EMC_B1_05_SEMC_DATA05 {
 		pinmux = <0x400e8024 0 0x0 0 0x400e8268>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexio1_flexio06: IOMUXC_GPIO_EMC_B1_06_FLEXIO1_FLEXIO06 {
 		pinmux = <0x400e8028 8 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_flexpwm2_pwm0_a: IOMUXC_GPIO_EMC_B1_06_FLEXPWM2_PWM0_A {
 		pinmux = <0x400e8028 1 0x400e8518 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio7_io06: IOMUXC_GPIO_EMC_B1_06_GPIO7_IO06 {
 		pinmux = <0x400e8028 10 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_gpio_mux1_io06: IOMUXC_GPIO_EMC_B1_06_GPIO_MUX1_IO06 {
 		pinmux = <0x400e8028 5 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_06_semc_data06: IOMUXC_GPIO_EMC_B1_06_SEMC_DATA06 {
 		pinmux = <0x400e8028 0 0x0 0 0x400e826c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexio1_flexio07: IOMUXC_GPIO_EMC_B1_07_FLEXIO1_FLEXIO07 {
 		pinmux = <0x400e802c 8 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_flexpwm2_pwm0_b: IOMUXC_GPIO_EMC_B1_07_FLEXPWM2_PWM0_B {
 		pinmux = <0x400e802c 1 0x400e8524 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio7_io07: IOMUXC_GPIO_EMC_B1_07_GPIO7_IO07 {
 		pinmux = <0x400e802c 10 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_gpio_mux1_io07: IOMUXC_GPIO_EMC_B1_07_GPIO_MUX1_IO07 {
 		pinmux = <0x400e802c 5 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_07_semc_data07: IOMUXC_GPIO_EMC_B1_07_SEMC_DATA07 {
 		pinmux = <0x400e802c 0 0x0 0 0x400e8270>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexio1_flexio08: IOMUXC_GPIO_EMC_B1_08_FLEXIO1_FLEXIO08 {
 		pinmux = <0x400e8030 8 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_flexpwm2_pwm1_a: IOMUXC_GPIO_EMC_B1_08_FLEXPWM2_PWM1_A {
 		pinmux = <0x400e8030 1 0x400e851c 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio7_io08: IOMUXC_GPIO_EMC_B1_08_GPIO7_IO08 {
 		pinmux = <0x400e8030 10 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_gpio_mux1_io08: IOMUXC_GPIO_EMC_B1_08_GPIO_MUX1_IO08 {
 		pinmux = <0x400e8030 5 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_08_semc_dm00: IOMUXC_GPIO_EMC_B1_08_SEMC_DM00 {
 		pinmux = <0x400e8030 0 0x0 0 0x400e8274>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexio1_flexio09: IOMUXC_GPIO_EMC_B1_09_FLEXIO1_FLEXIO09 {
 		pinmux = <0x400e8034 8 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_flexpwm2_pwm1_b: IOMUXC_GPIO_EMC_B1_09_FLEXPWM2_PWM1_B {
 		pinmux = <0x400e8034 1 0x400e8528 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio7_io09: IOMUXC_GPIO_EMC_B1_09_GPIO7_IO09 {
 		pinmux = <0x400e8034 10 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpio_mux1_io09: IOMUXC_GPIO_EMC_B1_09_GPIO_MUX1_IO09 {
 		pinmux = <0x400e8034 5 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_gpt5_capture1: IOMUXC_GPIO_EMC_B1_09_GPT5_CAPTURE1 {
 		pinmux = <0x400e8034 2 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_09_semc_addr00: IOMUXC_GPIO_EMC_B1_09_SEMC_ADDR00 {
 		pinmux = <0x400e8034 0 0x0 0 0x400e8278>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexio1_flexio10: IOMUXC_GPIO_EMC_B1_10_FLEXIO1_FLEXIO10 {
 		pinmux = <0x400e8038 8 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_flexpwm2_pwm2_a: IOMUXC_GPIO_EMC_B1_10_FLEXPWM2_PWM2_A {
 		pinmux = <0x400e8038 1 0x400e8520 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio7_io10: IOMUXC_GPIO_EMC_B1_10_GPIO7_IO10 {
 		pinmux = <0x400e8038 10 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpio_mux1_io10: IOMUXC_GPIO_EMC_B1_10_GPIO_MUX1_IO10 {
 		pinmux = <0x400e8038 5 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_gpt5_capture2: IOMUXC_GPIO_EMC_B1_10_GPT5_CAPTURE2 {
 		pinmux = <0x400e8038 2 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_10_semc_addr01: IOMUXC_GPIO_EMC_B1_10_SEMC_ADDR01 {
 		pinmux = <0x400e8038 0 0x0 0 0x400e827c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexio1_flexio11: IOMUXC_GPIO_EMC_B1_11_FLEXIO1_FLEXIO11 {
 		pinmux = <0x400e803c 8 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_flexpwm2_pwm2_b: IOMUXC_GPIO_EMC_B1_11_FLEXPWM2_PWM2_B {
 		pinmux = <0x400e803c 1 0x400e852c 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio7_io11: IOMUXC_GPIO_EMC_B1_11_GPIO7_IO11 {
 		pinmux = <0x400e803c 10 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpio_mux1_io11: IOMUXC_GPIO_EMC_B1_11_GPIO_MUX1_IO11 {
 		pinmux = <0x400e803c 5 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_gpt5_compare1: IOMUXC_GPIO_EMC_B1_11_GPT5_COMPARE1 {
 		pinmux = <0x400e803c 2 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_11_semc_addr02: IOMUXC_GPIO_EMC_B1_11_SEMC_ADDR02 {
 		pinmux = <0x400e803c 0 0x0 0 0x400e8280>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_flexio1_flexio12: IOMUXC_GPIO_EMC_B1_12_FLEXIO1_FLEXIO12 {
 		pinmux = <0x400e8040 8 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio7_io12: IOMUXC_GPIO_EMC_B1_12_GPIO7_IO12 {
 		pinmux = <0x400e8040 10 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpio_mux1_io12: IOMUXC_GPIO_EMC_B1_12_GPIO_MUX1_IO12 {
 		pinmux = <0x400e8040 5 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_gpt5_compare2: IOMUXC_GPIO_EMC_B1_12_GPT5_COMPARE2 {
 		pinmux = <0x400e8040 2 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_semc_addr03: IOMUXC_GPIO_EMC_B1_12_SEMC_ADDR03 {
 		pinmux = <0x400e8040 0 0x0 0 0x400e8284>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_in04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_IN04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_12_xbar1_xbar_inout04: IOMUXC_GPIO_EMC_B1_12_XBAR1_XBAR_INOUT04 {
 		pinmux = <0x400e8040 1 0x0 0 0x400e8284>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_flexio1_flexio13: IOMUXC_GPIO_EMC_B1_13_FLEXIO1_FLEXIO13 {
 		pinmux = <0x400e8044 8 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio7_io13: IOMUXC_GPIO_EMC_B1_13_GPIO7_IO13 {
 		pinmux = <0x400e8044 10 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpio_mux1_io13: IOMUXC_GPIO_EMC_B1_13_GPIO_MUX1_IO13 {
 		pinmux = <0x400e8044 5 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_gpt5_compare3: IOMUXC_GPIO_EMC_B1_13_GPT5_COMPARE3 {
 		pinmux = <0x400e8044 2 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_semc_addr04: IOMUXC_GPIO_EMC_B1_13_SEMC_ADDR04 {
 		pinmux = <0x400e8044 0 0x0 0 0x400e8288>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_in05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_IN05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_13_xbar1_xbar_inout05: IOMUXC_GPIO_EMC_B1_13_XBAR1_XBAR_INOUT05 {
 		pinmux = <0x400e8044 1 0x0 0 0x400e8288>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_flexio1_flexio14: IOMUXC_GPIO_EMC_B1_14_FLEXIO1_FLEXIO14 {
 		pinmux = <0x400e8048 8 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio7_io14: IOMUXC_GPIO_EMC_B1_14_GPIO7_IO14 {
 		pinmux = <0x400e8048 10 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpio_mux1_io14: IOMUXC_GPIO_EMC_B1_14_GPIO_MUX1_IO14 {
 		pinmux = <0x400e8048 5 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_gpt5_clk: IOMUXC_GPIO_EMC_B1_14_GPT5_CLK {
 		pinmux = <0x400e8048 2 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_semc_addr05: IOMUXC_GPIO_EMC_B1_14_SEMC_ADDR05 {
 		pinmux = <0x400e8048 0 0x0 0 0x400e828c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_in06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_IN06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_14_xbar1_xbar_inout06: IOMUXC_GPIO_EMC_B1_14_XBAR1_XBAR_INOUT06 {
 		pinmux = <0x400e8048 1 0x0 0 0x400e828c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_flexio1_flexio15: IOMUXC_GPIO_EMC_B1_15_FLEXIO1_FLEXIO15 {
 		pinmux = <0x400e804c 8 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio7_io15: IOMUXC_GPIO_EMC_B1_15_GPIO7_IO15 {
 		pinmux = <0x400e804c 10 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_gpio_mux1_io15: IOMUXC_GPIO_EMC_B1_15_GPIO_MUX1_IO15 {
 		pinmux = <0x400e804c 5 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_semc_addr06: IOMUXC_GPIO_EMC_B1_15_SEMC_ADDR06 {
 		pinmux = <0x400e804c 0 0x0 0 0x400e8290>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_in07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_IN07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_15_xbar1_xbar_inout07: IOMUXC_GPIO_EMC_B1_15_XBAR1_XBAR_INOUT07 {
 		pinmux = <0x400e804c 1 0x0 0 0x400e8290>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_flexio1_flexio16: IOMUXC_GPIO_EMC_B1_16_FLEXIO1_FLEXIO16 {
 		pinmux = <0x400e8050 8 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio7_io16: IOMUXC_GPIO_EMC_B1_16_GPIO7_IO16 {
 		pinmux = <0x400e8050 10 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_gpio_mux1_io16: IOMUXC_GPIO_EMC_B1_16_GPIO_MUX1_IO16 {
 		pinmux = <0x400e8050 5 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_semc_addr07: IOMUXC_GPIO_EMC_B1_16_SEMC_ADDR07 {
 		pinmux = <0x400e8050 0 0x0 0 0x400e8294>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_in08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_IN08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_16_xbar1_xbar_inout08: IOMUXC_GPIO_EMC_B1_16_XBAR1_XBAR_INOUT08 {
 		pinmux = <0x400e8050 1 0x0 0 0x400e8294>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexio1_flexio17: IOMUXC_GPIO_EMC_B1_17_FLEXIO1_FLEXIO17 {
 		pinmux = <0x400e8054 8 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_flexpwm4_pwm3_a: IOMUXC_GPIO_EMC_B1_17_FLEXPWM4_PWM3_A {
 		pinmux = <0x400e8054 1 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio7_io17: IOMUXC_GPIO_EMC_B1_17_GPIO7_IO17 {
 		pinmux = <0x400e8054 10 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_gpio_mux1_io17: IOMUXC_GPIO_EMC_B1_17_GPIO_MUX1_IO17 {
 		pinmux = <0x400e8054 5 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_qtimer1_timer0: IOMUXC_GPIO_EMC_B1_17_QTIMER1_TIMER0 {
 		pinmux = <0x400e8054 2 0x400e863c 0 0x400e8298>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_17_semc_addr08: IOMUXC_GPIO_EMC_B1_17_SEMC_ADDR08 {
 		pinmux = <0x400e8054 0 0x0 0 0x400e8298>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexio1_flexio18: IOMUXC_GPIO_EMC_B1_18_FLEXIO1_FLEXIO18 {
 		pinmux = <0x400e8058 8 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_flexpwm4_pwm3_b: IOMUXC_GPIO_EMC_B1_18_FLEXPWM4_PWM3_B {
 		pinmux = <0x400e8058 1 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio7_io18: IOMUXC_GPIO_EMC_B1_18_GPIO7_IO18 {
 		pinmux = <0x400e8058 10 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_gpio_mux1_io18: IOMUXC_GPIO_EMC_B1_18_GPIO_MUX1_IO18 {
 		pinmux = <0x400e8058 5 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_qtimer2_timer0: IOMUXC_GPIO_EMC_B1_18_QTIMER2_TIMER0 {
 		pinmux = <0x400e8058 2 0x400e8648 0 0x400e829c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_18_semc_addr09: IOMUXC_GPIO_EMC_B1_18_SEMC_ADDR09 {
 		pinmux = <0x400e8058 0 0x0 0 0x400e829c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexio1_flexio19: IOMUXC_GPIO_EMC_B1_19_FLEXIO1_FLEXIO19 {
 		pinmux = <0x400e805c 8 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_flexpwm2_pwm3_a: IOMUXC_GPIO_EMC_B1_19_FLEXPWM2_PWM3_A {
 		pinmux = <0x400e805c 1 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio7_io19: IOMUXC_GPIO_EMC_B1_19_GPIO7_IO19 {
 		pinmux = <0x400e805c 10 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_gpio_mux1_io19: IOMUXC_GPIO_EMC_B1_19_GPIO_MUX1_IO19 {
 		pinmux = <0x400e805c 5 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_qtimer3_timer0: IOMUXC_GPIO_EMC_B1_19_QTIMER3_TIMER0 {
 		pinmux = <0x400e805c 2 0x400e8654 0 0x400e82a0>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_19_semc_addr11: IOMUXC_GPIO_EMC_B1_19_SEMC_ADDR11 {
 		pinmux = <0x400e805c 0 0x0 0 0x400e82a0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexio1_flexio20: IOMUXC_GPIO_EMC_B1_20_FLEXIO1_FLEXIO20 {
 		pinmux = <0x400e8060 8 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_flexpwm2_pwm3_b: IOMUXC_GPIO_EMC_B1_20_FLEXPWM2_PWM3_B {
 		pinmux = <0x400e8060 1 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio7_io20: IOMUXC_GPIO_EMC_B1_20_GPIO7_IO20 {
 		pinmux = <0x400e8060 10 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_gpio_mux1_io20: IOMUXC_GPIO_EMC_B1_20_GPIO_MUX1_IO20 {
 		pinmux = <0x400e8060 5 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_qtimer4_timer0: IOMUXC_GPIO_EMC_B1_20_QTIMER4_TIMER0 {
 		pinmux = <0x400e8060 2 0x400e8660 0 0x400e82a4>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_20_semc_addr12: IOMUXC_GPIO_EMC_B1_20_SEMC_ADDR12 {
 		pinmux = <0x400e8060 0 0x0 0 0x400e82a4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexio1_flexio21: IOMUXC_GPIO_EMC_B1_21_FLEXIO1_FLEXIO21 {
 		pinmux = <0x400e8064 8 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B1_21_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e8064 1 0x400e853c 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio7_io21: IOMUXC_GPIO_EMC_B1_21_GPIO7_IO21 {
 		pinmux = <0x400e8064 10 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_gpio_mux1_io21: IOMUXC_GPIO_EMC_B1_21_GPIO_MUX1_IO21 {
 		pinmux = <0x400e8064 5 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_21_semc_ba0: IOMUXC_GPIO_EMC_B1_21_SEMC_BA0 {
 		pinmux = <0x400e8064 0 0x0 0 0x400e82a8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexio1_flexio22: IOMUXC_GPIO_EMC_B1_22_FLEXIO1_FLEXIO22 {
 		pinmux = <0x400e8068 8 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B1_22_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e8068 1 0x400e854c 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio7_io22: IOMUXC_GPIO_EMC_B1_22_GPIO7_IO22 {
 		pinmux = <0x400e8068 10 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_gpio_mux1_io22: IOMUXC_GPIO_EMC_B1_22_GPIO_MUX1_IO22 {
 		pinmux = <0x400e8068 5 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_22_semc_ba1: IOMUXC_GPIO_EMC_B1_22_SEMC_BA1 {
 		pinmux = <0x400e8068 0 0x0 0 0x400e82ac>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexio1_flexio23: IOMUXC_GPIO_EMC_B1_23_FLEXIO1_FLEXIO23 {
 		pinmux = <0x400e806c 8 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_flexpwm1_pwm0_a: IOMUXC_GPIO_EMC_B1_23_FLEXPWM1_PWM0_A {
 		pinmux = <0x400e806c 1 0x400e8500 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio7_io23: IOMUXC_GPIO_EMC_B1_23_GPIO7_IO23 {
 		pinmux = <0x400e806c 10 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_gpio_mux1_io23: IOMUXC_GPIO_EMC_B1_23_GPIO_MUX1_IO23 {
 		pinmux = <0x400e806c 5 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_23_semc_addr10: IOMUXC_GPIO_EMC_B1_23_SEMC_ADDR10 {
 		pinmux = <0x400e806c 0 0x0 0 0x400e82b0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexio1_flexio24: IOMUXC_GPIO_EMC_B1_24_FLEXIO1_FLEXIO24 {
 		pinmux = <0x400e8070 8 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_flexpwm1_pwm0_b: IOMUXC_GPIO_EMC_B1_24_FLEXPWM1_PWM0_B {
 		pinmux = <0x400e8070 1 0x400e850c 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio7_io24: IOMUXC_GPIO_EMC_B1_24_GPIO7_IO24 {
 		pinmux = <0x400e8070 10 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_gpio_mux1_io24: IOMUXC_GPIO_EMC_B1_24_GPIO_MUX1_IO24 {
 		pinmux = <0x400e8070 5 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_24_semc_cas: IOMUXC_GPIO_EMC_B1_24_SEMC_CAS {
 		pinmux = <0x400e8070 0 0x0 0 0x400e82b4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexio1_flexio25: IOMUXC_GPIO_EMC_B1_25_FLEXIO1_FLEXIO25 {
 		pinmux = <0x400e8074 8 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_flexpwm1_pwm1_a: IOMUXC_GPIO_EMC_B1_25_FLEXPWM1_PWM1_A {
 		pinmux = <0x400e8074 1 0x400e8504 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio7_io25: IOMUXC_GPIO_EMC_B1_25_GPIO7_IO25 {
 		pinmux = <0x400e8074 10 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_gpio_mux1_io25: IOMUXC_GPIO_EMC_B1_25_GPIO_MUX1_IO25 {
 		pinmux = <0x400e8074 5 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_25_semc_ras: IOMUXC_GPIO_EMC_B1_25_SEMC_RAS {
 		pinmux = <0x400e8074 0 0x0 0 0x400e82b8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexio1_flexio26: IOMUXC_GPIO_EMC_B1_26_FLEXIO1_FLEXIO26 {
 		pinmux = <0x400e8078 8 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_flexpwm1_pwm1_b: IOMUXC_GPIO_EMC_B1_26_FLEXPWM1_PWM1_B {
 		pinmux = <0x400e8078 1 0x400e8510 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio7_io26: IOMUXC_GPIO_EMC_B1_26_GPIO7_IO26 {
 		pinmux = <0x400e8078 10 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_gpio_mux1_io26: IOMUXC_GPIO_EMC_B1_26_GPIO_MUX1_IO26 {
 		pinmux = <0x400e8078 5 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_26_semc_clk: IOMUXC_GPIO_EMC_B1_26_SEMC_CLK {
 		pinmux = <0x400e8078 0 0x0 0 0x400e82bc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexio1_flexio27: IOMUXC_GPIO_EMC_B1_27_FLEXIO1_FLEXIO27 {
 		pinmux = <0x400e807c 8 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_flexpwm1_pwm2_a: IOMUXC_GPIO_EMC_B1_27_FLEXPWM1_PWM2_A {
 		pinmux = <0x400e807c 1 0x400e8508 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio7_io27: IOMUXC_GPIO_EMC_B1_27_GPIO7_IO27 {
 		pinmux = <0x400e807c 10 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_gpio_mux1_io27: IOMUXC_GPIO_EMC_B1_27_GPIO_MUX1_IO27 {
 		pinmux = <0x400e807c 5 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_27_semc_cke: IOMUXC_GPIO_EMC_B1_27_SEMC_CKE {
 		pinmux = <0x400e807c 0 0x0 0 0x400e82c0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexio1_flexio28: IOMUXC_GPIO_EMC_B1_28_FLEXIO1_FLEXIO28 {
 		pinmux = <0x400e8080 8 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_flexpwm1_pwm2_b: IOMUXC_GPIO_EMC_B1_28_FLEXPWM1_PWM2_B {
 		pinmux = <0x400e8080 1 0x400e8514 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio7_io28: IOMUXC_GPIO_EMC_B1_28_GPIO7_IO28 {
 		pinmux = <0x400e8080 10 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_gpio_mux1_io28: IOMUXC_GPIO_EMC_B1_28_GPIO_MUX1_IO28 {
 		pinmux = <0x400e8080 5 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_28_semc_we: IOMUXC_GPIO_EMC_B1_28_SEMC_WE {
 		pinmux = <0x400e8080 0 0x0 0 0x400e82c4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexio1_flexio29: IOMUXC_GPIO_EMC_B1_29_FLEXIO1_FLEXIO29 {
 		pinmux = <0x400e8084 8 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B1_29_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e8084 1 0x400e8530 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio7_io29: IOMUXC_GPIO_EMC_B1_29_GPIO7_IO29 {
 		pinmux = <0x400e8084 10 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_gpio_mux1_io29: IOMUXC_GPIO_EMC_B1_29_GPIO_MUX1_IO29 {
 		pinmux = <0x400e8084 5 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_29_semc_cs0: IOMUXC_GPIO_EMC_B1_29_SEMC_CS0 {
 		pinmux = <0x400e8084 0 0x0 0 0x400e82c8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexio1_flexio30: IOMUXC_GPIO_EMC_B1_30_FLEXIO1_FLEXIO30 {
 		pinmux = <0x400e8088 8 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B1_30_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e8088 1 0x400e8540 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio7_io30: IOMUXC_GPIO_EMC_B1_30_GPIO7_IO30 {
 		pinmux = <0x400e8088 10 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_gpio_mux1_io30: IOMUXC_GPIO_EMC_B1_30_GPIO_MUX1_IO30 {
 		pinmux = <0x400e8088 5 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_30_semc_data08: IOMUXC_GPIO_EMC_B1_30_SEMC_DATA08 {
 		pinmux = <0x400e8088 0 0x0 0 0x400e82cc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexio1_flexio31: IOMUXC_GPIO_EMC_B1_31_FLEXIO1_FLEXIO31 {
 		pinmux = <0x400e808c 8 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B1_31_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e808c 1 0x400e8534 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio7_io31: IOMUXC_GPIO_EMC_B1_31_GPIO7_IO31 {
 		pinmux = <0x400e808c 10 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_gpio_mux1_io31: IOMUXC_GPIO_EMC_B1_31_GPIO_MUX1_IO31 {
 		pinmux = <0x400e808c 5 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_31_semc_data09: IOMUXC_GPIO_EMC_B1_31_SEMC_DATA09 {
 		pinmux = <0x400e808c 0 0x0 0 0x400e82d0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B1_32_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e8090 1 0x400e8544 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio8_io00: IOMUXC_GPIO_EMC_B1_32_GPIO8_IO00 {
 		pinmux = <0x400e8090 10 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_gpio_mux2_io00_cm7: IOMUXC_GPIO_EMC_B1_32_GPIO_MUX2_IO00_CM7 {
 		pinmux = <0x400e8090 5 0x0 0 0x400e82d4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_32_semc_data10: IOMUXC_GPIO_EMC_B1_32_SEMC_DATA10 {
 		pinmux = <0x400e8090 0 0x0 0 0x400e82d4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B1_33_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e8094 1 0x400e8538 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio8_io01: IOMUXC_GPIO_EMC_B1_33_GPIO8_IO01 {
 		pinmux = <0x400e8094 10 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_gpio_mux2_io01_cm7: IOMUXC_GPIO_EMC_B1_33_GPIO_MUX2_IO01_CM7 {
 		pinmux = <0x400e8094 5 0x0 0 0x400e82d8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_33_semc_data11: IOMUXC_GPIO_EMC_B1_33_SEMC_DATA11 {
 		pinmux = <0x400e8094 0 0x0 0 0x400e82d8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B1_34_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e8098 1 0x400e8548 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio8_io02: IOMUXC_GPIO_EMC_B1_34_GPIO8_IO02 {
 		pinmux = <0x400e8098 10 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_gpio_mux2_io02_cm7: IOMUXC_GPIO_EMC_B1_34_GPIO_MUX2_IO02_CM7 {
 		pinmux = <0x400e8098 5 0x0 0 0x400e82dc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_34_semc_data12: IOMUXC_GPIO_EMC_B1_34_SEMC_DATA12 {
 		pinmux = <0x400e8098 0 0x0 0 0x400e82dc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio8_io03: IOMUXC_GPIO_EMC_B1_35_GPIO8_IO03 {
 		pinmux = <0x400e809c 10 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_gpio_mux2_io03_cm7: IOMUXC_GPIO_EMC_B1_35_GPIO_MUX2_IO03_CM7 {
 		pinmux = <0x400e809c 5 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_semc_data13: IOMUXC_GPIO_EMC_B1_35_SEMC_DATA13 {
 		pinmux = <0x400e809c 0 0x0 0 0x400e82e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_in09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_IN09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_35_xbar1_xbar_inout09: IOMUXC_GPIO_EMC_B1_35_XBAR1_XBAR_INOUT09 {
 		pinmux = <0x400e809c 1 0x0 0 0x400e82e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio8_io04: IOMUXC_GPIO_EMC_B1_36_GPIO8_IO04 {
 		pinmux = <0x400e80a0 10 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_gpio_mux2_io04_cm7: IOMUXC_GPIO_EMC_B1_36_GPIO_MUX2_IO04_CM7 {
 		pinmux = <0x400e80a0 5 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_semc_data14: IOMUXC_GPIO_EMC_B1_36_SEMC_DATA14 {
 		pinmux = <0x400e80a0 0 0x0 0 0x400e82e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_in10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_IN10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_36_xbar1_xbar_inout10: IOMUXC_GPIO_EMC_B1_36_XBAR1_XBAR_INOUT10 {
 		pinmux = <0x400e80a0 1 0x0 0 0x400e82e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio8_io05: IOMUXC_GPIO_EMC_B1_37_GPIO8_IO05 {
 		pinmux = <0x400e80a4 10 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_gpio_mux2_io05_cm7: IOMUXC_GPIO_EMC_B1_37_GPIO_MUX2_IO05_CM7 {
 		pinmux = <0x400e80a4 5 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_semc_data15: IOMUXC_GPIO_EMC_B1_37_SEMC_DATA15 {
 		pinmux = <0x400e80a4 0 0x0 0 0x400e82e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_in11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_IN11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_37_xbar1_xbar_inout11: IOMUXC_GPIO_EMC_B1_37_XBAR1_XBAR_INOUT11 {
 		pinmux = <0x400e80a4 1 0x0 0 0x400e82e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_flexpwm1_pwm3_a: IOMUXC_GPIO_EMC_B1_38_FLEXPWM1_PWM3_A {
 		pinmux = <0x400e80a8 1 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio8_io06: IOMUXC_GPIO_EMC_B1_38_GPIO8_IO06 {
 		pinmux = <0x400e80a8 10 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_gpio_mux2_io06_cm7: IOMUXC_GPIO_EMC_B1_38_GPIO_MUX2_IO06_CM7 {
 		pinmux = <0x400e80a8 5 0x0 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_qtimer1_timer1: IOMUXC_GPIO_EMC_B1_38_QTIMER1_TIMER1 {
 		pinmux = <0x400e80a8 2 0x400e8640 0 0x400e82ec>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_38_semc_dm01: IOMUXC_GPIO_EMC_B1_38_SEMC_DM01 {
 		pinmux = <0x400e80a8 0 0x0 0 0x400e82ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_flexpwm1_pwm3_b: IOMUXC_GPIO_EMC_B1_39_FLEXPWM1_PWM3_B {
 		pinmux = <0x400e80ac 1 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio8_io07: IOMUXC_GPIO_EMC_B1_39_GPIO8_IO07 {
 		pinmux = <0x400e80ac 10 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_gpio_mux2_io07_cm7: IOMUXC_GPIO_EMC_B1_39_GPIO_MUX2_IO07_CM7 {
 		pinmux = <0x400e80ac 5 0x0 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_qtimer2_timer1: IOMUXC_GPIO_EMC_B1_39_QTIMER2_TIMER1 {
 		pinmux = <0x400e80ac 2 0x400e864c 0 0x400e82f0>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_39_semc_dqs: IOMUXC_GPIO_EMC_B1_39_SEMC_DQS {
 		pinmux = <0x400e80ac 0 0x0 0 0x400e82f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_ccm_clko1: IOMUXC_GPIO_EMC_B1_40_CCM_CLKO1 {
 		pinmux = <0x400e80b0 9 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_enet_1g_mdc: IOMUXC_GPIO_EMC_B1_40_ENET_1G_MDC {
 		pinmux = <0x400e80b0 7 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio8_io08: IOMUXC_GPIO_EMC_B1_40_GPIO8_IO08 {
 		pinmux = <0x400e80b0 10 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_gpio_mux2_io08_cm7: IOMUXC_GPIO_EMC_B1_40_GPIO_MUX2_IO08_CM7 {
 		pinmux = <0x400e80b0 5 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_lpuart6_tx: IOMUXC_GPIO_EMC_B1_40_LPUART6_TX {
 		pinmux = <0x400e80b0 3 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_mqs_right: IOMUXC_GPIO_EMC_B1_40_MQS_RIGHT {
 		pinmux = <0x400e80b0 2 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_semc_rdy: IOMUXC_GPIO_EMC_B1_40_SEMC_RDY {
 		pinmux = <0x400e80b0 0 0x0 0 0x400e82f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_in12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_IN12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_40_xbar1_xbar_inout12: IOMUXC_GPIO_EMC_B1_40_XBAR1_XBAR_INOUT12 {
 		pinmux = <0x400e80b0 1 0x0 0 0x400e82f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_ccm_clko2: IOMUXC_GPIO_EMC_B1_41_CCM_CLKO2 {
 		pinmux = <0x400e80b4 9 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_enet_1g_mdio: IOMUXC_GPIO_EMC_B1_41_ENET_1G_MDIO {
 		pinmux = <0x400e80b4 7 0x400e84c8 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_flexspi2_b_data07: IOMUXC_GPIO_EMC_B1_41_FLEXSPI2_B_DATA07 {
 		pinmux = <0x400e80b4 4 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio8_io09: IOMUXC_GPIO_EMC_B1_41_GPIO8_IO09 {
 		pinmux = <0x400e80b4 10 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_gpio_mux2_io09_cm7: IOMUXC_GPIO_EMC_B1_41_GPIO_MUX2_IO09_CM7 {
 		pinmux = <0x400e80b4 5 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_lpuart6_rx: IOMUXC_GPIO_EMC_B1_41_LPUART6_RX {
 		pinmux = <0x400e80b4 3 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_mqs_left: IOMUXC_GPIO_EMC_B1_41_MQS_LEFT {
 		pinmux = <0x400e80b4 2 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_semc_csx00: IOMUXC_GPIO_EMC_B1_41_SEMC_CSX00 {
 		pinmux = <0x400e80b4 0 0x0 0 0x400e82f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_in13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_IN13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b1_41_xbar1_xbar_inout13: IOMUXC_GPIO_EMC_B1_41_XBAR1_XBAR_INOUT13 {
 		pinmux = <0x400e80b4 1 0x0 0 0x400e82f8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_ccm_enet_ref_clk_25m: IOMUXC_GPIO_EMC_B2_00_CCM_ENET_REF_CLK_25M {
 		pinmux = <0x400e80b8 1 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_enet_qos_1588_event1_out: IOMUXC_GPIO_EMC_B2_00_ENET_QOS_1588_EVENT1_OUT {
 		pinmux = <0x400e80b8 7 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexpwm3_pwm0_a: IOMUXC_GPIO_EMC_B2_00_FLEXPWM3_PWM0_A {
 		pinmux = <0x400e80b8 11 0x400e8530 1 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_flexspi2_b_data06: IOMUXC_GPIO_EMC_B2_00_FLEXSPI2_B_DATA06 {
 		pinmux = <0x400e80b8 4 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio8_io10: IOMUXC_GPIO_EMC_B2_00_GPIO8_IO10 {
 		pinmux = <0x400e80b8 10 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_gpio_mux2_io10_cm7: IOMUXC_GPIO_EMC_B2_00_GPIO_MUX2_IO10_CM7 {
 		pinmux = <0x400e80b8 5 0x0 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpi2c2_scl: IOMUXC_GPIO_EMC_B2_00_LPI2C2_SCL {
 		pinmux = <0x400e80b8 9 0x400e85b4 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpspi1_sck: IOMUXC_GPIO_EMC_B2_00_LPSPI1_SCK {
 		pinmux = <0x400e80b8 8 0x400e85d0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_lpuart6_cts_b: IOMUXC_GPIO_EMC_B2_00_LPUART6_CTS_B {
 		pinmux = <0x400e80b8 3 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_00_QTIMER3_TIMER1 {
 		pinmux = <0x400e80b8 2 0x400e8658 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_semc_data16: IOMUXC_GPIO_EMC_B2_00_SEMC_DATA16 {
 		pinmux = <0x400e80b8 0 0x0 0 0x400e82fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_in20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_00_xbar1_xbar_inout20: IOMUXC_GPIO_EMC_B2_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e80b8 6 0x400e86d8 0 0x400e82fc>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_enet_qos_1588_event1_in: IOMUXC_GPIO_EMC_B2_01_ENET_QOS_1588_EVENT1_IN {
 		pinmux = <0x400e80bc 7 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexpwm3_pwm0_b: IOMUXC_GPIO_EMC_B2_01_FLEXPWM3_PWM0_B {
 		pinmux = <0x400e80bc 11 0x400e8540 1 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_flexspi2_b_data05: IOMUXC_GPIO_EMC_B2_01_FLEXSPI2_B_DATA05 {
 		pinmux = <0x400e80bc 4 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio8_io11: IOMUXC_GPIO_EMC_B2_01_GPIO8_IO11 {
 		pinmux = <0x400e80bc 10 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_gpio_mux2_io11_cm7: IOMUXC_GPIO_EMC_B2_01_GPIO_MUX2_IO11_CM7 {
 		pinmux = <0x400e80bc 5 0x0 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpi2c2_sda: IOMUXC_GPIO_EMC_B2_01_LPI2C2_SDA {
 		pinmux = <0x400e80bc 9 0x400e85b8 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpspi1_pcs0: IOMUXC_GPIO_EMC_B2_01_LPSPI1_PCS0 {
 		pinmux = <0x400e80bc 8 0x400e85cc 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_lpuart6_rts_b: IOMUXC_GPIO_EMC_B2_01_LPUART6_RTS_B {
 		pinmux = <0x400e80bc 3 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_qtimer4_timer1: IOMUXC_GPIO_EMC_B2_01_QTIMER4_TIMER1 {
 		pinmux = <0x400e80bc 2 0x400e8664 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e403c 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_semc_data17: IOMUXC_GPIO_EMC_B2_01_SEMC_DATA17 {
 		pinmux = <0x400e80bc 0 0x0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_usdhc2_cd_b: IOMUXC_GPIO_EMC_B2_01_USDHC2_CD_B {
 		pinmux = <0x400e80bc 1 0x400e86d0 0 0x400e8300>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_in21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_01_xbar1_xbar_inout21: IOMUXC_GPIO_EMC_B2_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e80bc 6 0x400e86dc 0 0x400e8300>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_enet_qos_1588_event1_aux_in: IOMUXC_GPIO_EMC_B2_02_ENET_QOS_1588_EVENT1_AUX_IN {
 		pinmux = <0x400e80c0 7 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexpwm3_pwm1_a: IOMUXC_GPIO_EMC_B2_02_FLEXPWM3_PWM1_A {
 		pinmux = <0x400e80c0 11 0x400e8534 1 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_flexspi2_b_data04: IOMUXC_GPIO_EMC_B2_02_FLEXSPI2_B_DATA04 {
 		pinmux = <0x400e80c0 4 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio8_io12: IOMUXC_GPIO_EMC_B2_02_GPIO8_IO12 {
 		pinmux = <0x400e80c0 10 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_gpio_mux2_io12_cm7: IOMUXC_GPIO_EMC_B2_02_GPIO_MUX2_IO12_CM7 {
 		pinmux = <0x400e80c0 5 0x0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_lpspi1_sdo: IOMUXC_GPIO_EMC_B2_02_LPSPI1_SDO {
 		pinmux = <0x400e80c0 8 0x400e85d8 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_semc_data18: IOMUXC_GPIO_EMC_B2_02_SEMC_DATA18 {
 		pinmux = <0x400e80c0 0 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_usdhc2_wp: IOMUXC_GPIO_EMC_B2_02_USDHC2_WP {
 		pinmux = <0x400e80c0 1 0x400e86d4 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_video_mux_csi_data23: IOMUXC_GPIO_EMC_B2_02_VIDEO_MUX_CSI_DATA23 {
 		pinmux = <0x400e80c0 3 0x0 0 0x400e8304>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_in22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_02_xbar1_xbar_inout22: IOMUXC_GPIO_EMC_B2_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e80c0 6 0x400e86e0 0 0x400e8304>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_enet_1g_tdata03: IOMUXC_GPIO_EMC_B2_03_ENET_1G_TDATA03 {
 		pinmux = <0x400e80c4 7 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexpwm3_pwm1_b: IOMUXC_GPIO_EMC_B2_03_FLEXPWM3_PWM1_B {
 		pinmux = <0x400e80c4 11 0x400e8544 1 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_flexspi2_b_data03: IOMUXC_GPIO_EMC_B2_03_FLEXSPI2_B_DATA03 {
 		pinmux = <0x400e80c4 4 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio8_io13: IOMUXC_GPIO_EMC_B2_03_GPIO8_IO13 {
 		pinmux = <0x400e80c4 10 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_gpio_mux2_io13_cm7: IOMUXC_GPIO_EMC_B2_03_GPIO_MUX2_IO13_CM7 {
 		pinmux = <0x400e80c4 5 0x0 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_lpspi1_sdi: IOMUXC_GPIO_EMC_B2_03_LPSPI1_SDI {
 		pinmux = <0x400e80c4 8 0x400e85d4 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_semc_data19: IOMUXC_GPIO_EMC_B2_03_SEMC_DATA19 {
 		pinmux = <0x400e80c4 0 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_usdhc2_vselect: IOMUXC_GPIO_EMC_B2_03_USDHC2_VSELECT {
 		pinmux = <0x400e80c4 1 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_video_mux_csi_data22: IOMUXC_GPIO_EMC_B2_03_VIDEO_MUX_CSI_DATA22 {
 		pinmux = <0x400e80c4 3 0x0 0 0x400e8308>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_in23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_03_xbar1_xbar_inout23: IOMUXC_GPIO_EMC_B2_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e80c4 6 0x400e86e4 0 0x400e8308>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_enet_1g_tdata02: IOMUXC_GPIO_EMC_B2_04_ENET_1G_TDATA02 {
 		pinmux = <0x400e80c8 7 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexpwm3_pwm2_a: IOMUXC_GPIO_EMC_B2_04_FLEXPWM3_PWM2_A {
 		pinmux = <0x400e80c8 11 0x400e8538 1 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_flexspi2_b_data02: IOMUXC_GPIO_EMC_B2_04_FLEXSPI2_B_DATA02 {
 		pinmux = <0x400e80c8 4 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio8_io14: IOMUXC_GPIO_EMC_B2_04_GPIO8_IO14 {
 		pinmux = <0x400e80c8 10 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_gpio_mux2_io14_cm7: IOMUXC_GPIO_EMC_B2_04_GPIO_MUX2_IO14_CM7 {
 		pinmux = <0x400e80c8 5 0x0 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_lpspi3_sck: IOMUXC_GPIO_EMC_B2_04_LPSPI3_SCK {
 		pinmux = <0x400e80c8 8 0x400e8600 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_sai2_mclk: IOMUXC_GPIO_EMC_B2_04_SAI2_MCLK {
 		pinmux = <0x400e80c8 2 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_semc_data20: IOMUXC_GPIO_EMC_B2_04_SEMC_DATA20 {
 		pinmux = <0x400e80c8 0 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_usdhc2_reset_b: IOMUXC_GPIO_EMC_B2_04_USDHC2_RESET_B {
 		pinmux = <0x400e80c8 1 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_video_mux_csi_data21: IOMUXC_GPIO_EMC_B2_04_VIDEO_MUX_CSI_DATA21 {
 		pinmux = <0x400e80c8 3 0x0 0 0x400e830c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_in24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_04_xbar1_xbar_inout24: IOMUXC_GPIO_EMC_B2_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e80c8 6 0x400e86e8 0 0x400e830c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_enet_1g_rx_clk: IOMUXC_GPIO_EMC_B2_05_ENET_1G_RX_CLK {
 		pinmux = <0x400e80cc 7 0x400e84cc 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexpwm3_pwm2_b: IOMUXC_GPIO_EMC_B2_05_FLEXPWM3_PWM2_B {
 		pinmux = <0x400e80cc 11 0x400e8548 1 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_flexspi2_b_data01: IOMUXC_GPIO_EMC_B2_05_FLEXSPI2_B_DATA01 {
 		pinmux = <0x400e80cc 4 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio8_io15: IOMUXC_GPIO_EMC_B2_05_GPIO8_IO15 {
 		pinmux = <0x400e80cc 10 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpio_mux2_io15_cm7: IOMUXC_GPIO_EMC_B2_05_GPIO_MUX2_IO15_CM7 {
 		pinmux = <0x400e80cc 5 0x0 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e40a0 0xf 0x1>;
 	};
-	iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_gpt3_clk: IOMUXC_GPIO_EMC_B2_05_GPT3_CLK {
 		pinmux = <0x400e80cc 1 0x400e8598 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_lpspi3_pcs0: IOMUXC_GPIO_EMC_B2_05_LPSPI3_PCS0 {
 		pinmux = <0x400e80cc 8 0x400e85f0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_pit1_trigger00: IOMUXC_GPIO_EMC_B2_05_PIT1_TRIGGER00 {
 		pinmux = <0x400e80cc 9 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_sai2_rx_sync: IOMUXC_GPIO_EMC_B2_05_SAI2_RX_SYNC {
 		pinmux = <0x400e80cc 2 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_semc_data21: IOMUXC_GPIO_EMC_B2_05_SEMC_DATA21 {
 		pinmux = <0x400e80cc 0 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_video_mux_csi_data20: IOMUXC_GPIO_EMC_B2_05_VIDEO_MUX_CSI_DATA20 {
 		pinmux = <0x400e80cc 3 0x0 0 0x400e8310>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_in25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_05_xbar1_xbar_inout25: IOMUXC_GPIO_EMC_B2_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e80cc 6 0x400e86ec 0 0x400e8310>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_enet_1g_tx_er: IOMUXC_GPIO_EMC_B2_06_ENET_1G_TX_ER {
 		pinmux = <0x400e80d0 7 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexpwm3_pwm3_a: IOMUXC_GPIO_EMC_B2_06_FLEXPWM3_PWM3_A {
 		pinmux = <0x400e80d0 11 0x400e853c 1 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_flexspi2_b_data00: IOMUXC_GPIO_EMC_B2_06_FLEXSPI2_B_DATA00 {
 		pinmux = <0x400e80d0 4 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio8_io16: IOMUXC_GPIO_EMC_B2_06_GPIO8_IO16 {
 		pinmux = <0x400e80d0 10 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpio_mux2_io16_cm7: IOMUXC_GPIO_EMC_B2_06_GPIO_MUX2_IO16_CM7 {
 		pinmux = <0x400e80d0 5 0x0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x0 0x1>;
 	};
-	iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_gpt3_capture1: IOMUXC_GPIO_EMC_B2_06_GPT3_CAPTURE1 {
 		pinmux = <0x400e80d0 1 0x400e8590 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_lpspi3_sdo: IOMUXC_GPIO_EMC_B2_06_LPSPI3_SDO {
 		pinmux = <0x400e80d0 8 0x400e8608 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_pit1_trigger01: IOMUXC_GPIO_EMC_B2_06_PIT1_TRIGGER01 {
 		pinmux = <0x400e80d0 9 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_sai2_rx_bclk: IOMUXC_GPIO_EMC_B2_06_SAI2_RX_BCLK {
 		pinmux = <0x400e80d0 2 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_semc_data22: IOMUXC_GPIO_EMC_B2_06_SEMC_DATA22 {
 		pinmux = <0x400e80d0 0 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_video_mux_csi_data19: IOMUXC_GPIO_EMC_B2_06_VIDEO_MUX_CSI_DATA19 {
 		pinmux = <0x400e80d0 3 0x0 0 0x400e8314>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_in26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_IN26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_06_xbar1_xbar_inout26: IOMUXC_GPIO_EMC_B2_06_XBAR1_XBAR_INOUT26 {
 		pinmux = <0x400e80d0 6 0x400e86f0 0 0x400e8314>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x16 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_enet_1g_rdata03: IOMUXC_GPIO_EMC_B2_07_ENET_1G_RDATA03 {
 		pinmux = <0x400e80d4 7 0x400e84dc 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexpwm3_pwm3_b: IOMUXC_GPIO_EMC_B2_07_FLEXPWM3_PWM3_B {
 		pinmux = <0x400e80d4 11 0x400e854c 1 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_flexspi2_b_dqs: IOMUXC_GPIO_EMC_B2_07_FLEXSPI2_B_DQS {
 		pinmux = <0x400e80d4 4 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio8_io17: IOMUXC_GPIO_EMC_B2_07_GPIO8_IO17 {
 		pinmux = <0x400e80d4 10 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpio_mux2_io17_cm7: IOMUXC_GPIO_EMC_B2_07_GPIO_MUX2_IO17_CM7 {
 		pinmux = <0x400e80d4 5 0x0 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x1 0x1>;
 	};
-	iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_gpt3_capture2: IOMUXC_GPIO_EMC_B2_07_GPT3_CAPTURE2 {
 		pinmux = <0x400e80d4 1 0x400e8594 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_lpspi3_sdi: IOMUXC_GPIO_EMC_B2_07_LPSPI3_SDI {
 		pinmux = <0x400e80d4 8 0x400e8604 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_pit1_trigger02: IOMUXC_GPIO_EMC_B2_07_PIT1_TRIGGER02 {
 		pinmux = <0x400e80d4 9 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_sai2_rx_data: IOMUXC_GPIO_EMC_B2_07_SAI2_RX_DATA {
 		pinmux = <0x400e80d4 2 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_semc_data23: IOMUXC_GPIO_EMC_B2_07_SEMC_DATA23 {
 		pinmux = <0x400e80d4 0 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_video_mux_csi_data18: IOMUXC_GPIO_EMC_B2_07_VIDEO_MUX_CSI_DATA18 {
 		pinmux = <0x400e80d4 3 0x0 0 0x400e8318>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_in27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_IN27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_07_xbar1_xbar_inout27: IOMUXC_GPIO_EMC_B2_07_XBAR1_XBAR_INOUT27 {
 		pinmux = <0x400e80d4 6 0x400e86f4 0 0x400e8318>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x17 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_enet_1g_rdata02: IOMUXC_GPIO_EMC_B2_08_ENET_1G_RDATA02 {
 		pinmux = <0x400e80d8 7 0x400e84d8 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_flexspi2_b_ss0_b: IOMUXC_GPIO_EMC_B2_08_FLEXSPI2_B_SS0_B {
 		pinmux = <0x400e80d8 4 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio8_io18: IOMUXC_GPIO_EMC_B2_08_GPIO8_IO18 {
 		pinmux = <0x400e80d8 10 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpio_mux2_io18_cm7: IOMUXC_GPIO_EMC_B2_08_GPIO_MUX2_IO18_CM7 {
 		pinmux = <0x400e80d8 5 0x0 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x2 0x1>;
 	};
-	iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_gpt3_compare1: IOMUXC_GPIO_EMC_B2_08_GPT3_COMPARE1 {
 		pinmux = <0x400e80d8 1 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_lpspi3_pcs1: IOMUXC_GPIO_EMC_B2_08_LPSPI3_PCS1 {
 		pinmux = <0x400e80d8 8 0x400e85f4 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_pit1_trigger03: IOMUXC_GPIO_EMC_B2_08_PIT1_TRIGGER03 {
 		pinmux = <0x400e80d8 9 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_sai2_tx_data: IOMUXC_GPIO_EMC_B2_08_SAI2_TX_DATA {
 		pinmux = <0x400e80d8 2 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_semc_dm02: IOMUXC_GPIO_EMC_B2_08_SEMC_DM02 {
 		pinmux = <0x400e80d8 0 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_video_mux_csi_data17: IOMUXC_GPIO_EMC_B2_08_VIDEO_MUX_CSI_DATA17 {
 		pinmux = <0x400e80d8 3 0x0 0 0x400e831c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_in28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_IN28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_08_xbar1_xbar_inout28: IOMUXC_GPIO_EMC_B2_08_XBAR1_XBAR_INOUT28 {
 		pinmux = <0x400e80d8 6 0x400e86f8 0 0x400e831c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x18 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_enet_1g_crs: IOMUXC_GPIO_EMC_B2_09_ENET_1G_CRS {
 		pinmux = <0x400e80dc 7 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_flexspi2_b_sclk: IOMUXC_GPIO_EMC_B2_09_FLEXSPI2_B_SCLK {
 		pinmux = <0x400e80dc 4 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio8_io19: IOMUXC_GPIO_EMC_B2_09_GPIO8_IO19 {
 		pinmux = <0x400e80dc 10 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpio_mux2_io19_cm7: IOMUXC_GPIO_EMC_B2_09_GPIO_MUX2_IO19_CM7 {
 		pinmux = <0x400e80dc 5 0x0 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x3 0x1>;
 	};
-	iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_gpt3_compare2: IOMUXC_GPIO_EMC_B2_09_GPT3_COMPARE2 {
 		pinmux = <0x400e80dc 1 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_lpspi3_pcs2: IOMUXC_GPIO_EMC_B2_09_LPSPI3_PCS2 {
 		pinmux = <0x400e80dc 8 0x400e85f8 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_qtimer1_timer0: IOMUXC_GPIO_EMC_B2_09_QTIMER1_TIMER0 {
 		pinmux = <0x400e80dc 9 0x400e863c 1 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_sai2_tx_bclk: IOMUXC_GPIO_EMC_B2_09_SAI2_TX_BCLK {
 		pinmux = <0x400e80dc 2 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_semc_data24: IOMUXC_GPIO_EMC_B2_09_SEMC_DATA24 {
 		pinmux = <0x400e80dc 0 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_video_mux_csi_data16: IOMUXC_GPIO_EMC_B2_09_VIDEO_MUX_CSI_DATA16 {
 		pinmux = <0x400e80dc 3 0x0 0 0x400e8320>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_in29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_IN29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_09_xbar1_xbar_inout29: IOMUXC_GPIO_EMC_B2_09_XBAR1_XBAR_INOUT29 {
 		pinmux = <0x400e80dc 6 0x400e86fc 0 0x400e8320>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x19 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_enet_1g_col: IOMUXC_GPIO_EMC_B2_10_ENET_1G_COL {
 		pinmux = <0x400e80e0 7 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_flexspi2_a_sclk: IOMUXC_GPIO_EMC_B2_10_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e80e0 4 0x400e858c 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio8_io20: IOMUXC_GPIO_EMC_B2_10_GPIO8_IO20 {
 		pinmux = <0x400e80e0 10 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpio_mux2_io20_cm7: IOMUXC_GPIO_EMC_B2_10_GPIO_MUX2_IO20_CM7 {
 		pinmux = <0x400e80e0 5 0x0 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x4 0x1>;
 	};
-	iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_gpt3_compare3: IOMUXC_GPIO_EMC_B2_10_GPT3_COMPARE3 {
 		pinmux = <0x400e80e0 1 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_lpspi3_pcs3: IOMUXC_GPIO_EMC_B2_10_LPSPI3_PCS3 {
 		pinmux = <0x400e80e0 8 0x400e85fc 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_qtimer1_timer1: IOMUXC_GPIO_EMC_B2_10_QTIMER1_TIMER1 {
 		pinmux = <0x400e80e0 9 0x400e8640 1 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4030 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_sai2_tx_sync: IOMUXC_GPIO_EMC_B2_10_SAI2_TX_SYNC {
 		pinmux = <0x400e80e0 2 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_semc_data25: IOMUXC_GPIO_EMC_B2_10_SEMC_DATA25 {
 		pinmux = <0x400e80e0 0 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_video_mux_csi_field: IOMUXC_GPIO_EMC_B2_10_VIDEO_MUX_CSI_FIELD {
 		pinmux = <0x400e80e0 3 0x0 0 0x400e8324>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_in30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_IN30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_10_xbar1_xbar_inout30: IOMUXC_GPIO_EMC_B2_10_XBAR1_XBAR_INOUT30 {
 		pinmux = <0x400e80e0 6 0x400e8700 0 0x400e8324>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1a 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_enet_1g_tdata00: IOMUXC_GPIO_EMC_B2_11_ENET_1G_TDATA00 {
 		pinmux = <0x400e80e4 2 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_flexspi2_a_ss0_b: IOMUXC_GPIO_EMC_B2_11_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e80e4 4 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio8_io21: IOMUXC_GPIO_EMC_B2_11_GPIO8_IO21 {
 		pinmux = <0x400e80e4 10 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_gpio_mux2_io21_cm7: IOMUXC_GPIO_EMC_B2_11_GPIO_MUX2_IO21_CM7 {
 		pinmux = <0x400e80e4 5 0x0 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x5 0x1>;
 	};
-	iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_qtimer1_timer2: IOMUXC_GPIO_EMC_B2_11_QTIMER1_TIMER2 {
 		pinmux = <0x400e80e4 9 0x400e8644 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sai3_rx_sync: IOMUXC_GPIO_EMC_B2_11_SAI3_RX_SYNC {
 		pinmux = <0x400e80e4 3 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_semc_data26: IOMUXC_GPIO_EMC_B2_11_SEMC_DATA26 {
 		pinmux = <0x400e80e4 0 0x0 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_sim1_trxd: IOMUXC_GPIO_EMC_B2_11_SIM1_TRXD {
 		pinmux = <0x400e80e4 8 0x400e869c 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_spdif_in: IOMUXC_GPIO_EMC_B2_11_SPDIF_IN {
 		pinmux = <0x400e80e4 1 0x400e86b4 0 0x400e8328>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_in31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_IN31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_11_xbar1_xbar_inout31: IOMUXC_GPIO_EMC_B2_11_XBAR1_XBAR_INOUT31 {
 		pinmux = <0x400e80e4 6 0x400e8704 0 0x400e8328>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x1b 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_enet_1g_tdata01: IOMUXC_GPIO_EMC_B2_12_ENET_1G_TDATA01 {
 		pinmux = <0x400e80e8 2 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_flexspi2_a_dqs: IOMUXC_GPIO_EMC_B2_12_FLEXSPI2_A_DQS {
 		pinmux = <0x400e80e8 4 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio8_io22: IOMUXC_GPIO_EMC_B2_12_GPIO8_IO22 {
 		pinmux = <0x400e80e8 10 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_gpio_mux2_io22_cm7: IOMUXC_GPIO_EMC_B2_12_GPIO_MUX2_IO22_CM7 {
 		pinmux = <0x400e80e8 5 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x6 0x1>;
 	};
-	iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_qtimer1_timer3: IOMUXC_GPIO_EMC_B2_12_QTIMER1_TIMER3 {
 		pinmux = <0x400e80e8 9 0x0 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4030 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sai3_rx_bclk: IOMUXC_GPIO_EMC_B2_12_SAI3_RX_BCLK {
 		pinmux = <0x400e80e8 3 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_semc_data27: IOMUXC_GPIO_EMC_B2_12_SEMC_DATA27 {
 		pinmux = <0x400e80e8 0 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_sim1_clk: IOMUXC_GPIO_EMC_B2_12_SIM1_CLK {
 		pinmux = <0x400e80e8 8 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_spdif_out: IOMUXC_GPIO_EMC_B2_12_SPDIF_OUT {
 		pinmux = <0x400e80e8 1 0x0 0 0x400e832c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_in32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_IN32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_12_xbar1_xbar_inout32: IOMUXC_GPIO_EMC_B2_12_XBAR1_XBAR_INOUT32 {
 		pinmux = <0x400e80e8 6 0x400e8708 0 0x400e832c>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x0 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_enet_1g_tx_en: IOMUXC_GPIO_EMC_B2_13_ENET_1G_TX_EN {
 		pinmux = <0x400e80ec 2 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_flexspi2_a_data00: IOMUXC_GPIO_EMC_B2_13_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e80ec 4 0x400e857c 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio8_io23: IOMUXC_GPIO_EMC_B2_13_GPIO8_IO23 {
 		pinmux = <0x400e80ec 10 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_gpio_mux2_io23_cm7: IOMUXC_GPIO_EMC_B2_13_GPIO_MUX2_IO23_CM7 {
 		pinmux = <0x400e80ec 5 0x0 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x7 0x1>;
 	};
-	iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_qtimer2_timer0: IOMUXC_GPIO_EMC_B2_13_QTIMER2_TIMER0 {
 		pinmux = <0x400e80ec 9 0x400e8648 1 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sai3_rx_data: IOMUXC_GPIO_EMC_B2_13_SAI3_RX_DATA {
 		pinmux = <0x400e80ec 3 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_semc_data28: IOMUXC_GPIO_EMC_B2_13_SEMC_DATA28 {
 		pinmux = <0x400e80ec 0 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_sim1_rst_b: IOMUXC_GPIO_EMC_B2_13_SIM1_RST_B {
 		pinmux = <0x400e80ec 8 0x0 0 0x400e8330>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_in33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_IN33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_13_xbar1_xbar_inout33: IOMUXC_GPIO_EMC_B2_13_XBAR1_XBAR_INOUT33 {
 		pinmux = <0x400e80ec 6 0x400e870c 0 0x400e8330>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x1 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_enet_1g_tx_clk_io: IOMUXC_GPIO_EMC_B2_14_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e80f0 2 0x400e84e8 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_flexspi2_a_data01: IOMUXC_GPIO_EMC_B2_14_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e80f0 4 0x400e8580 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio8_io24: IOMUXC_GPIO_EMC_B2_14_GPIO8_IO24 {
 		pinmux = <0x400e80f0 10 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_gpio_mux2_io24_cm7: IOMUXC_GPIO_EMC_B2_14_GPIO_MUX2_IO24_CM7 {
 		pinmux = <0x400e80f0 5 0x0 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x8 0x1>;
 	};
-	iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_qtimer2_timer1: IOMUXC_GPIO_EMC_B2_14_QTIMER2_TIMER1 {
 		pinmux = <0x400e80f0 9 0x400e864c 1 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4034 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sai3_tx_data: IOMUXC_GPIO_EMC_B2_14_SAI3_TX_DATA {
 		pinmux = <0x400e80f0 3 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_semc_data29: IOMUXC_GPIO_EMC_B2_14_SEMC_DATA29 {
 		pinmux = <0x400e80f0 0 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_sim1_sven: IOMUXC_GPIO_EMC_B2_14_SIM1_SVEN {
 		pinmux = <0x400e80f0 8 0x0 0 0x400e8334>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_in34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_IN34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_14_xbar1_xbar_inout34: IOMUXC_GPIO_EMC_B2_14_XBAR1_XBAR_INOUT34 {
 		pinmux = <0x400e80f0 6 0x400e8710 0 0x400e8334>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x2 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_enet_1g_rdata00: IOMUXC_GPIO_EMC_B2_15_ENET_1G_RDATA00 {
 		pinmux = <0x400e80f4 2 0x400e84d0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_flexspi2_a_data02: IOMUXC_GPIO_EMC_B2_15_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e80f4 4 0x400e8584 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio8_io25: IOMUXC_GPIO_EMC_B2_15_GPIO8_IO25 {
 		pinmux = <0x400e80f4 10 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_gpio_mux2_io25_cm7: IOMUXC_GPIO_EMC_B2_15_GPIO_MUX2_IO25_CM7 {
 		pinmux = <0x400e80f4 5 0x0 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0x9 0x1>;
 	};
-	iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_qtimer2_timer2: IOMUXC_GPIO_EMC_B2_15_QTIMER2_TIMER2 {
 		pinmux = <0x400e80f4 9 0x400e8650 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sai3_tx_bclk: IOMUXC_GPIO_EMC_B2_15_SAI3_TX_BCLK {
 		pinmux = <0x400e80f4 3 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_semc_data30: IOMUXC_GPIO_EMC_B2_15_SEMC_DATA30 {
 		pinmux = <0x400e80f4 0 0x0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_sim1_pd: IOMUXC_GPIO_EMC_B2_15_SIM1_PD {
 		pinmux = <0x400e80f4 8 0x400e86a0 0 0x400e8338>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_in35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_IN35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_15_xbar1_xbar_inout35: IOMUXC_GPIO_EMC_B2_15_XBAR1_XBAR_INOUT35 {
 		pinmux = <0x400e80f4 6 0x400e8714 0 0x400e8338>;
 		pin-pdrv;
 		gpr = <0x400e4054 0x3 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_enet_1g_rdata01: IOMUXC_GPIO_EMC_B2_16_ENET_1G_RDATA01 {
 		pinmux = <0x400e80f8 2 0x400e84d4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_flexspi2_a_data03: IOMUXC_GPIO_EMC_B2_16_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e80f8 4 0x400e8588 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio8_io26: IOMUXC_GPIO_EMC_B2_16_GPIO8_IO26 {
 		pinmux = <0x400e80f8 10 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_gpio_mux2_io26_cm7: IOMUXC_GPIO_EMC_B2_16_GPIO_MUX2_IO26_CM7 {
 		pinmux = <0x400e80f8 5 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xa 0x1>;
 	};
-	iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_qtimer2_timer3: IOMUXC_GPIO_EMC_B2_16_QTIMER2_TIMER3 {
 		pinmux = <0x400e80f8 9 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4034 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sai3_tx_sync: IOMUXC_GPIO_EMC_B2_16_SAI3_TX_SYNC {
 		pinmux = <0x400e80f8 3 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_semc_data31: IOMUXC_GPIO_EMC_B2_16_SEMC_DATA31 {
 		pinmux = <0x400e80f8 0 0x0 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_sim1_power_fail: IOMUXC_GPIO_EMC_B2_16_SIM1_POWER_FAIL {
 		pinmux = <0x400e80f8 8 0x400e86a4 0 0x400e833c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_in14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_IN14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_16_xbar1_xbar_inout14: IOMUXC_GPIO_EMC_B2_16_XBAR1_XBAR_INOUT14 {
 		pinmux = <0x400e80f8 1 0x0 0 0x400e833c>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_enet_1g_rx_en: IOMUXC_GPIO_EMC_B2_17_ENET_1G_RX_EN {
 		pinmux = <0x400e80fc 2 0x400e84e0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_flexspi2_a_data04: IOMUXC_GPIO_EMC_B2_17_FLEXSPI2_A_DATA04 {
 		pinmux = <0x400e80fc 4 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio8_io27: IOMUXC_GPIO_EMC_B2_17_GPIO8_IO27 {
 		pinmux = <0x400e80fc 10 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_gpio_mux2_io27_cm7: IOMUXC_GPIO_EMC_B2_17_GPIO_MUX2_IO27_CM7 {
 		pinmux = <0x400e80fc 5 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xb 0x1>;
 	};
-	iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_qtimer3_timer0: IOMUXC_GPIO_EMC_B2_17_QTIMER3_TIMER0 {
 		pinmux = <0x400e80fc 9 0x400e8654 1 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x8 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_sai3_mclk: IOMUXC_GPIO_EMC_B2_17_SAI3_MCLK {
 		pinmux = <0x400e80fc 3 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_semc_dm03: IOMUXC_GPIO_EMC_B2_17_SEMC_DM03 {
 		pinmux = <0x400e80fc 0 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_wdog1_wdog_any: IOMUXC_GPIO_EMC_B2_17_WDOG1_WDOG_ANY {
 		pinmux = <0x400e80fc 8 0x0 0 0x400e8340>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_in15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_IN15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_17_xbar1_xbar_inout15: IOMUXC_GPIO_EMC_B2_17_XBAR1_XBAR_INOUT15 {
 		pinmux = <0x400e80fc 1 0x0 0 0x400e8340>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_enet_1g_rx_er: IOMUXC_GPIO_EMC_B2_18_ENET_1G_RX_ER {
 		pinmux = <0x400e8100 2 0x400e84e4 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_ewm_ewm_out_b: IOMUXC_GPIO_EMC_B2_18_EWM_EWM_OUT_B {
 		pinmux = <0x400e8100 3 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi1_a_dqs: IOMUXC_GPIO_EMC_B2_18_FLEXSPI1_A_DQS {
 		pinmux = <0x400e8100 6 0x400e8550 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_flexspi2_a_data05: IOMUXC_GPIO_EMC_B2_18_FLEXSPI2_A_DATA05 {
 		pinmux = <0x400e8100 4 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio8_io28: IOMUXC_GPIO_EMC_B2_18_GPIO8_IO28 {
 		pinmux = <0x400e8100 10 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_gpio_mux2_io28_cm7: IOMUXC_GPIO_EMC_B2_18_GPIO_MUX2_IO28_CM7 {
 		pinmux = <0x400e8100 5 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xc 0x1>;
 	};
-	iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_qtimer3_timer1: IOMUXC_GPIO_EMC_B2_18_QTIMER3_TIMER1 {
 		pinmux = <0x400e8100 9 0x400e8658 1 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4038 0x9 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_semc_dqs4: IOMUXC_GPIO_EMC_B2_18_SEMC_DQS4 {
 		pinmux = <0x400e8100 0 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_wdog1_wdog_b: IOMUXC_GPIO_EMC_B2_18_WDOG1_WDOG_B {
 		pinmux = <0x400e8100 8 0x0 0 0x400e8344>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_in16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_IN16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_18_xbar1_xbar_inout16: IOMUXC_GPIO_EMC_B2_18_XBAR1_XBAR_INOUT16 {
 		pinmux = <0x400e8100 1 0x0 0 0x400e8344>;
 		pin-pdrv;
 		gpr = <0x400e4050 0xc 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_1G_MDC {
 		pinmux = <0x400e8104 2 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_1g_ref_clk1: IOMUXC_GPIO_EMC_B2_19_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e8104 3 0x400e84c4 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_MDC {
 		pinmux = <0x400e8104 1 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_enet_qos_mdc: IOMUXC_GPIO_EMC_B2_19_ENET_QOS_MDC {
 		pinmux = <0x400e8104 8 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_flexspi2_a_data06: IOMUXC_GPIO_EMC_B2_19_FLEXSPI2_A_DATA06 {
 		pinmux = <0x400e8104 4 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio8_io29: IOMUXC_GPIO_EMC_B2_19_GPIO8_IO29 {
 		pinmux = <0x400e8104 10 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_gpio_mux2_io29_cm7: IOMUXC_GPIO_EMC_B2_19_GPIO_MUX2_IO29_CM7 {
 		pinmux = <0x400e8104 5 0x0 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xd 0x1>;
 	};
-	iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_qtimer3_timer2: IOMUXC_GPIO_EMC_B2_19_QTIMER3_TIMER2 {
 		pinmux = <0x400e8104 9 0x400e865c 0 0x400e8348>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xa 0x0>;
 	};
-	iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_19_semc_clkx00: IOMUXC_GPIO_EMC_B2_19_SEMC_CLKX00 {
 		pinmux = <0x400e8104 0 0x0 0 0x400e8348>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_1g_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_1G_MDIO {
 		pinmux = <0x400e8108 2 0x400e84c8 1 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_MDIO {
 		pinmux = <0x400e8108 1 0x400e84ac 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_mdio: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_MDIO {
 		pinmux = <0x400e8108 8 0x400e84ec 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_enet_qos_ref_clk1: IOMUXC_GPIO_EMC_B2_20_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e8108 3 0x400e84a0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_flexspi2_a_data07: IOMUXC_GPIO_EMC_B2_20_FLEXSPI2_A_DATA07 {
 		pinmux = <0x400e8108 4 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio8_io30: IOMUXC_GPIO_EMC_B2_20_GPIO8_IO30 {
 		pinmux = <0x400e8108 10 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_gpio_mux2_io30_cm7: IOMUXC_GPIO_EMC_B2_20_GPIO_MUX2_IO30_CM7 {
 		pinmux = <0x400e8108 5 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e40a4 0xe 0x1>;
 	};
-	iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_qtimer3_timer3: IOMUXC_GPIO_EMC_B2_20_QTIMER3_TIMER3 {
 		pinmux = <0x400e8108 9 0x0 0 0x400e834c>;
 		pin-pdrv;
 		gpr = <0x400e4038 0xb 0x0>;
 	};
-	iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
+	/omit-if-no-ref/ iomuxc_gpio_emc_b2_20_semc_clkx01: IOMUXC_GPIO_EMC_B2_20_SEMC_CLKX01 {
 		pinmux = <0x400e8108 0 0x0 0 0x400e834c>;
 		pin-pdrv;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_can3_tx: IOMUXC_LPSR_GPIO_LPSR_00_CAN3_TX {
 		pinmux = <0x40c08000 0 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_cm4_imxrt_txev: IOMUXC_LPSR_GPIO_LPSR_00_CM4_IMXRT_TXEV {
 		pinmux = <0x40c08000 3 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio12_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO12_IO00 {
 		pinmux = <0x40c08000 10 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_gpio_mux6_io00: IOMUXC_LPSR_GPIO_LPSR_00_GPIO_MUX6_IO00 {
 		pinmux = <0x40c08000 5 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_00_LPUART12_TX {
 		pinmux = <0x40c08000 6 0x40c080b0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mic_clk: IOMUXC_LPSR_GPIO_LPSR_00_MIC_CLK {
 		pinmux = <0x40c08000 1 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_mqs_right: IOMUXC_LPSR_GPIO_LPSR_00_MQS_RIGHT {
 		pinmux = <0x40c08000 2 0x0 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_00_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_00_SAI4_MCLK {
 		pinmux = <0x40c08000 7 0x40c080c8 0 0x40c08040>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_can3_rx: IOMUXC_LPSR_GPIO_LPSR_01_CAN3_RX {
 		pinmux = <0x40c08004 0 0x40c08080 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_cm4_imxrt_rxev: IOMUXC_LPSR_GPIO_LPSR_01_CM4_IMXRT_RXEV {
 		pinmux = <0x40c08004 3 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio12_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO12_IO01 {
 		pinmux = <0x40c08004 10 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_gpio_mux6_io01: IOMUXC_LPSR_GPIO_LPSR_01_GPIO_MUX6_IO01 {
 		pinmux = <0x40c08004 5 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_01_LPUART12_RX {
 		pinmux = <0x40c08004 6 0x40c080ac 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_01_MIC_BITSTREAM00 {
 		pinmux = <0x40c08004 1 0x40c080b4 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_01_mqs_left: IOMUXC_LPSR_GPIO_LPSR_01_MQS_LEFT {
 		pinmux = <0x40c08004 2 0x0 0 0x40c08044>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio12_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO12_IO02 {
 		pinmux = <0x40c08008 10 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_gpio_mux6_io02: IOMUXC_LPSR_GPIO_LPSR_02_GPIO_MUX6_IO02 {
 		pinmux = <0x40c08008 5 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_02_LPSPI5_SCK {
 		pinmux = <0x40c08008 1 0x40c08098 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_mqs_right: IOMUXC_LPSR_GPIO_LPSR_02_MQS_RIGHT {
 		pinmux = <0x40c08008 3 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_02_SAI4_TX_DATA {
 		pinmux = <0x40c08008 2 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_02_src_boot_mode00: IOMUXC_LPSR_GPIO_LPSR_02_SRC_BOOT_MODE00 {
 		pinmux = <0x40c08008 0 0x0 0 0x40c08048>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio12_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO12_IO03 {
 		pinmux = <0x40c0800c 10 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_gpio_mux6_io03: IOMUXC_LPSR_GPIO_LPSR_03_GPIO_MUX6_IO03 {
 		pinmux = <0x40c0800c 5 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_03_LPSPI5_PCS0 {
 		pinmux = <0x40c0800c 1 0x40c08094 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_mqs_left: IOMUXC_LPSR_GPIO_LPSR_03_MQS_LEFT {
 		pinmux = <0x40c0800c 3 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_03_SAI4_TX_SYNC {
 		pinmux = <0x40c0800c 2 0x40c080dc 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_03_src_boot_mode01: IOMUXC_LPSR_GPIO_LPSR_03_SRC_BOOT_MODE01 {
 		pinmux = <0x40c0800c 0 0x0 0 0x40c0804c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio12_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO12_IO04 {
 		pinmux = <0x40c08010 10 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_gpio_mux6_io04: IOMUXC_LPSR_GPIO_LPSR_04_GPIO_MUX6_IO04 {
 		pinmux = <0x40c08010 5 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_04_LPI2C5_SDA {
 		pinmux = <0x40c08010 0 0x40c08088 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_04_LPSPI5_SDO {
 		pinmux = <0x40c08010 1 0x40c080a0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_04_LPUART11_TX {
 		pinmux = <0x40c08010 6 0x40c080a8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_lpuart12_rts_b: IOMUXC_LPSR_GPIO_LPSR_04_LPUART12_RTS_B {
 		pinmux = <0x40c08010 3 0x0 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_04_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_04_SAI4_TX_BCLK {
 		pinmux = <0x40c08010 2 0x40c080d8 0 0x40c08050>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio12_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO12_IO05 {
 		pinmux = <0x40c08014 10 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_gpio_mux6_io05: IOMUXC_LPSR_GPIO_LPSR_05_GPIO_MUX6_IO05 {
 		pinmux = <0x40c08014 5 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_05_LPI2C5_SCL {
 		pinmux = <0x40c08014 0 0x40c08084 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_05_LPSPI5_SDI {
 		pinmux = <0x40c08014 1 0x40c0809c 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_05_LPUART11_RX {
 		pinmux = <0x40c08014 6 0x40c080a4 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_lpuart12_cts_b: IOMUXC_LPSR_GPIO_LPSR_05_LPUART12_CTS_B {
 		pinmux = <0x40c08014 3 0x0 0 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_05_sai4_mclk: IOMUXC_LPSR_GPIO_LPSR_05_SAI4_MCLK {
 		pinmux = <0x40c08014 2 0x40c080c8 1 0x40c08054>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_can3_tx: IOMUXC_LPSR_GPIO_LPSR_06_CAN3_TX {
 		pinmux = <0x40c08018 6 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio12_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO12_IO06 {
 		pinmux = <0x40c08018 10 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_gpio_mux6_io06: IOMUXC_LPSR_GPIO_LPSR_06_GPIO_MUX6_IO06 {
 		pinmux = <0x40c08018 5 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_06_LPI2C6_SDA {
 		pinmux = <0x40c08018 0 0x40c08090 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi5_pcs1: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI5_PCS1 {
 		pinmux = <0x40c08018 8 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpspi6_pcs3: IOMUXC_LPSR_GPIO_LPSR_06_LPSPI6_PCS3 {
 		pinmux = <0x40c08018 4 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_06_LPUART12_TX {
 		pinmux = <0x40c08018 3 0x40c080b0 1 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_06_PIT2_TRIGGER03 {
 		pinmux = <0x40c08018 7 0x0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_06_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_06_SAI4_RX_DATA {
 		pinmux = <0x40c08018 2 0x40c080d0 0 0x40c08058>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_can3_rx: IOMUXC_LPSR_GPIO_LPSR_07_CAN3_RX {
 		pinmux = <0x40c0801c 6 0x40c08080 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio12_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO12_IO07 {
 		pinmux = <0x40c0801c 10 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_gpio_mux6_io07: IOMUXC_LPSR_GPIO_LPSR_07_GPIO_MUX6_IO07 {
 		pinmux = <0x40c0801c 5 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_07_LPI2C6_SCL {
 		pinmux = <0x40c0801c 0 0x40c0808c 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi5_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI5_PCS2 {
 		pinmux = <0x40c0801c 8 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpspi6_pcs2: IOMUXC_LPSR_GPIO_LPSR_07_LPSPI6_PCS2 {
 		pinmux = <0x40c0801c 4 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_07_LPUART12_RX {
 		pinmux = <0x40c0801c 3 0x40c080ac 1 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_07_PIT2_TRIGGER02 {
 		pinmux = <0x40c0801c 7 0x0 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_07_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_07_SAI4_RX_BCLK {
 		pinmux = <0x40c0801c 2 0x40c080cc 0 0x40c0805c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_can3_tx: IOMUXC_LPSR_GPIO_LPSR_08_CAN3_TX {
 		pinmux = <0x40c08020 1 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio12_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO12_IO08 {
 		pinmux = <0x40c08020 10 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_gpio_mux6_io08: IOMUXC_LPSR_GPIO_LPSR_08_GPIO_MUX6_IO08 {
 		pinmux = <0x40c08020 5 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpi2c5_sda: IOMUXC_LPSR_GPIO_LPSR_08_LPI2C5_SDA {
 		pinmux = <0x40c08020 6 0x40c08088 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi5_pcs3: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI5_PCS3 {
 		pinmux = <0x40c08020 8 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpspi6_pcs1: IOMUXC_LPSR_GPIO_LPSR_08_LPSPI6_PCS1 {
 		pinmux = <0x40c08020 4 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_lpuart11_tx: IOMUXC_LPSR_GPIO_LPSR_08_LPUART11_TX {
 		pinmux = <0x40c08020 0 0x40c080a8 1 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_mic_clk: IOMUXC_LPSR_GPIO_LPSR_08_MIC_CLK {
 		pinmux = <0x40c08020 3 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_08_PIT2_TRIGGER01 {
 		pinmux = <0x40c08020 7 0x0 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_08_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_08_SAI4_RX_SYNC {
 		pinmux = <0x40c08020 2 0x40c080d4 0 0x40c08060>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_can3_rx: IOMUXC_LPSR_GPIO_LPSR_09_CAN3_RX {
 		pinmux = <0x40c08024 1 0x40c08080 2 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio12_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO12_IO09 {
 		pinmux = <0x40c08024 10 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_gpio_mux6_io09: IOMUXC_LPSR_GPIO_LPSR_09_GPIO_MUX6_IO09 {
 		pinmux = <0x40c08024 5 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpi2c5_scl: IOMUXC_LPSR_GPIO_LPSR_09_LPI2C5_SCL {
 		pinmux = <0x40c08024 6 0x40c08084 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpspi6_pcs0: IOMUXC_LPSR_GPIO_LPSR_09_LPSPI6_PCS0 {
 		pinmux = <0x40c08024 4 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_lpuart11_rx: IOMUXC_LPSR_GPIO_LPSR_09_LPUART11_RX {
 		pinmux = <0x40c08024 0 0x40c080a4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_mic_bitstream00: IOMUXC_LPSR_GPIO_LPSR_09_MIC_BITSTREAM00 {
 		pinmux = <0x40c08024 3 0x40c080b4 1 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_09_PIT2_TRIGGER00 {
 		pinmux = <0x40c08024 2 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_09_sai4_tx_data: IOMUXC_LPSR_GPIO_LPSR_09_SAI4_TX_DATA {
 		pinmux = <0x40c08024 7 0x0 0 0x40c08064>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio12_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO12_IO10 {
 		pinmux = <0x40c08028 10 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_gpio_mux6_io10: IOMUXC_LPSR_GPIO_LPSR_10_GPIO_MUX6_IO10 {
 		pinmux = <0x40c08028 5 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_jtag_mux_trstb: IOMUXC_LPSR_GPIO_LPSR_10_JTAG_MUX_TRSTB {
 		pinmux = <0x40c08028 0 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c5_scls: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C5_SCLS {
 		pinmux = <0x40c08028 6 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpi2c6_sda: IOMUXC_LPSR_GPIO_LPSR_10_LPI2C6_SDA {
 		pinmux = <0x40c08028 2 0x40c08090 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpspi6_sck: IOMUXC_LPSR_GPIO_LPSR_10_LPSPI6_SCK {
 		pinmux = <0x40c08028 4 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart11_cts_b: IOMUXC_LPSR_GPIO_LPSR_10_LPUART11_CTS_B {
 		pinmux = <0x40c08028 1 0x0 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_lpuart12_tx: IOMUXC_LPSR_GPIO_LPSR_10_LPUART12_TX {
 		pinmux = <0x40c08028 8 0x40c080b0 2 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_10_MIC_BITSTREAM01 {
 		pinmux = <0x40c08028 3 0x40c080b8 0 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_10_sai4_tx_sync: IOMUXC_LPSR_GPIO_LPSR_10_SAI4_TX_SYNC {
 		pinmux = <0x40c08028 7 0x40c080dc 1 0x40c08068>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_arm_trace_swo: IOMUXC_LPSR_GPIO_LPSR_11_ARM_TRACE_SWO {
 		pinmux = <0x40c0802c 7 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio12_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO12_IO11 {
 		pinmux = <0x40c0802c 10 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_gpio_mux6_io11: IOMUXC_LPSR_GPIO_LPSR_11_GPIO_MUX6_IO11 {
 		pinmux = <0x40c0802c 5 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_jtag_mux_tdo: IOMUXC_LPSR_GPIO_LPSR_11_JTAG_MUX_TDO {
 		pinmux = <0x40c0802c 0 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c5_sdas: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C5_SDAS {
 		pinmux = <0x40c0802c 6 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpi2c6_scl: IOMUXC_LPSR_GPIO_LPSR_11_LPI2C6_SCL {
 		pinmux = <0x40c0802c 2 0x40c0808c 1 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpspi6_sdo: IOMUXC_LPSR_GPIO_LPSR_11_LPSPI6_SDO {
 		pinmux = <0x40c0802c 4 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart11_rts_b: IOMUXC_LPSR_GPIO_LPSR_11_LPUART11_RTS_B {
 		pinmux = <0x40c0802c 1 0x0 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_lpuart12_rx: IOMUXC_LPSR_GPIO_LPSR_11_LPUART12_RX {
 		pinmux = <0x40c0802c 8 0x40c080ac 2 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_11_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_11_MIC_BITSTREAM02 {
 		pinmux = <0x40c0802c 3 0x40c080bc 0 0x40c0806c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio12_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO12_IO12 {
 		pinmux = <0x40c08030 10 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_gpio_mux6_io12: IOMUXC_LPSR_GPIO_LPSR_12_GPIO_MUX6_IO12 {
 		pinmux = <0x40c08030 5 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_jtag_mux_tdi: IOMUXC_LPSR_GPIO_LPSR_12_JTAG_MUX_TDI {
 		pinmux = <0x40c08030 0 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpi2c5_hreq: IOMUXC_LPSR_GPIO_LPSR_12_LPI2C5_HREQ {
 		pinmux = <0x40c08030 6 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi5_sck: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI5_SCK {
 		pinmux = <0x40c08030 8 0x40c08098 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_lpspi6_sdi: IOMUXC_LPSR_GPIO_LPSR_12_LPSPI6_SDI {
 		pinmux = <0x40c08030 4 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_12_MIC_BITSTREAM03 {
 		pinmux = <0x40c08030 3 0x40c080c0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_pit2_trigger00: IOMUXC_LPSR_GPIO_LPSR_12_PIT2_TRIGGER00 {
 		pinmux = <0x40c08030 1 0x0 0 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_12_sai4_tx_bclk: IOMUXC_LPSR_GPIO_LPSR_12_SAI4_TX_BCLK {
 		pinmux = <0x40c08030 7 0x40c080d8 1 0x40c08070>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio12_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO12_IO13 {
 		pinmux = <0x40c08034 10 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_gpio_mux6_io13: IOMUXC_LPSR_GPIO_LPSR_13_GPIO_MUX6_IO13 {
 		pinmux = <0x40c08034 5 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_jtag_mux_mod: IOMUXC_LPSR_GPIO_LPSR_13_JTAG_MUX_MOD {
 		pinmux = <0x40c08034 0 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_lpspi5_pcs0: IOMUXC_LPSR_GPIO_LPSR_13_LPSPI5_PCS0 {
 		pinmux = <0x40c08034 8 0x40c08094 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_mic_bitstream01: IOMUXC_LPSR_GPIO_LPSR_13_MIC_BITSTREAM01 {
 		pinmux = <0x40c08034 1 0x40c080b8 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_pit2_trigger01: IOMUXC_LPSR_GPIO_LPSR_13_PIT2_TRIGGER01 {
 		pinmux = <0x40c08034 2 0x0 0 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_13_sai4_rx_data: IOMUXC_LPSR_GPIO_LPSR_13_SAI4_RX_DATA {
 		pinmux = <0x40c08034 7 0x40c080d0 1 0x40c08074>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio12_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO12_IO14 {
 		pinmux = <0x40c08038 10 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_gpio_mux6_io14: IOMUXC_LPSR_GPIO_LPSR_14_GPIO_MUX6_IO14 {
 		pinmux = <0x40c08038 5 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_jtag_mux_tck: IOMUXC_LPSR_GPIO_LPSR_14_JTAG_MUX_TCK {
 		pinmux = <0x40c08038 0 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_lpspi5_sdo: IOMUXC_LPSR_GPIO_LPSR_14_LPSPI5_SDO {
 		pinmux = <0x40c08038 8 0x40c080a0 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_mic_bitstream02: IOMUXC_LPSR_GPIO_LPSR_14_MIC_BITSTREAM02 {
 		pinmux = <0x40c08038 1 0x40c080bc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_pit2_trigger02: IOMUXC_LPSR_GPIO_LPSR_14_PIT2_TRIGGER02 {
 		pinmux = <0x40c08038 2 0x0 0 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_14_sai4_rx_bclk: IOMUXC_LPSR_GPIO_LPSR_14_SAI4_RX_BCLK {
 		pinmux = <0x40c08038 7 0x40c080cc 1 0x40c08078>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio12_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO12_IO15 {
 		pinmux = <0x40c0803c 10 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_gpio_mux6_io15: IOMUXC_LPSR_GPIO_LPSR_15_GPIO_MUX6_IO15 {
 		pinmux = <0x40c0803c 5 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_jtag_mux_tms: IOMUXC_LPSR_GPIO_LPSR_15_JTAG_MUX_TMS {
 		pinmux = <0x40c0803c 0 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_lpspi5_sdi: IOMUXC_LPSR_GPIO_LPSR_15_LPSPI5_SDI {
 		pinmux = <0x40c0803c 8 0x40c0809c 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_mic_bitstream03: IOMUXC_LPSR_GPIO_LPSR_15_MIC_BITSTREAM03 {
 		pinmux = <0x40c0803c 1 0x40c080c0 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_pit2_trigger03: IOMUXC_LPSR_GPIO_LPSR_15_PIT2_TRIGGER03 {
 		pinmux = <0x40c0803c 2 0x0 0 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
+	/omit-if-no-ref/ iomuxc_lpsr_gpio_lpsr_15_sai4_rx_sync: IOMUXC_LPSR_GPIO_LPSR_15_SAI4_RX_SYNC {
 		pinmux = <0x40c0803c 7 0x40c080d4 1 0x40c0807c>;
 		pin-lpsr;
 	};
-	iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_flexspi2_a_ss0_b: IOMUXC_GPIO_SD_B1_00_FLEXSPI2_A_SS0_B {
 		pinmux = <0x400e819c 6 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio10_io03: IOMUXC_GPIO_SD_B1_00_GPIO10_IO03 {
 		pinmux = <0x400e819c 10 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpio_mux4_io03: IOMUXC_GPIO_SD_B1_00_GPIO_MUX4_IO03 {
 		pinmux = <0x400e819c 5 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_gpt4_capture1: IOMUXC_GPIO_SD_B1_00_GPT4_CAPTURE1 {
 		pinmux = <0x400e819c 3 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_kpp_row07: IOMUXC_GPIO_SD_B1_00_KPP_ROW07 {
 		pinmux = <0x400e819c 8 0x400e85a8 1 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_usdhc1_cmd: IOMUXC_GPIO_SD_B1_00_USDHC1_CMD {
 		pinmux = <0x400e819c 0 0x0 0 0x400e83e0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_in20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_IN20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_00_xbar1_xbar_inout20: IOMUXC_GPIO_SD_B1_00_XBAR1_XBAR_INOUT20 {
 		pinmux = <0x400e819c 2 0x400e86d8 1 0x400e83e0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x10 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_flexspi2_a_sclk: IOMUXC_GPIO_SD_B1_01_FLEXSPI2_A_SCLK {
 		pinmux = <0x400e81a0 6 0x400e858c 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio10_io04: IOMUXC_GPIO_SD_B1_01_GPIO10_IO04 {
 		pinmux = <0x400e81a0 10 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpio_mux4_io04: IOMUXC_GPIO_SD_B1_01_GPIO_MUX4_IO04 {
 		pinmux = <0x400e81a0 5 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_gpt4_capture2: IOMUXC_GPIO_SD_B1_01_GPT4_CAPTURE2 {
 		pinmux = <0x400e81a0 3 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_kpp_col07: IOMUXC_GPIO_SD_B1_01_KPP_COL07 {
 		pinmux = <0x400e81a0 8 0x400e85a0 1 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_usdhc1_clk: IOMUXC_GPIO_SD_B1_01_USDHC1_CLK {
 		pinmux = <0x400e81a0 0 0x0 0 0x400e83e4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_in21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_IN21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_01_xbar1_xbar_inout21: IOMUXC_GPIO_SD_B1_01_XBAR1_XBAR_INOUT21 {
 		pinmux = <0x400e81a0 2 0x400e86dc 1 0x400e83e4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x11 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B1_02_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81a4 9 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_flexspi2_a_data00: IOMUXC_GPIO_SD_B1_02_FLEXSPI2_A_DATA00 {
 		pinmux = <0x400e81a4 6 0x400e857c 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio10_io05: IOMUXC_GPIO_SD_B1_02_GPIO10_IO05 {
 		pinmux = <0x400e81a4 10 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpio_mux4_io05: IOMUXC_GPIO_SD_B1_02_GPIO_MUX4_IO05 {
 		pinmux = <0x400e81a4 5 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_gpt4_compare1: IOMUXC_GPIO_SD_B1_02_GPT4_COMPARE1 {
 		pinmux = <0x400e81a4 3 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_kpp_row06: IOMUXC_GPIO_SD_B1_02_KPP_ROW06 {
 		pinmux = <0x400e81a4 8 0x400e85a4 1 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_usdhc1_data0: IOMUXC_GPIO_SD_B1_02_USDHC1_DATA0 {
 		pinmux = <0x400e81a4 0 0x0 0 0x400e83e8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_in22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_IN22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_02_xbar1_xbar_inout22: IOMUXC_GPIO_SD_B1_02_XBAR1_XBAR_INOUT22 {
 		pinmux = <0x400e81a4 2 0x400e86e0 1 0x400e83e8>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x12 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi1_b_ss1_b: IOMUXC_GPIO_SD_B1_03_FLEXSPI1_B_SS1_B {
 		pinmux = <0x400e81a8 9 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_flexspi2_a_data01: IOMUXC_GPIO_SD_B1_03_FLEXSPI2_A_DATA01 {
 		pinmux = <0x400e81a8 6 0x400e8580 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio10_io06: IOMUXC_GPIO_SD_B1_03_GPIO10_IO06 {
 		pinmux = <0x400e81a8 10 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpio_mux4_io06: IOMUXC_GPIO_SD_B1_03_GPIO_MUX4_IO06 {
 		pinmux = <0x400e81a8 5 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_gpt4_compare2: IOMUXC_GPIO_SD_B1_03_GPT4_COMPARE2 {
 		pinmux = <0x400e81a8 3 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_kpp_col06: IOMUXC_GPIO_SD_B1_03_KPP_COL06 {
 		pinmux = <0x400e81a8 8 0x400e859c 1 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_usdhc1_data1: IOMUXC_GPIO_SD_B1_03_USDHC1_DATA1 {
 		pinmux = <0x400e81a8 0 0x0 0 0x400e83ec>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_in23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_IN23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_03_xbar1_xbar_inout23: IOMUXC_GPIO_SD_B1_03_XBAR1_XBAR_INOUT23 {
 		pinmux = <0x400e81a8 2 0x400e86e4 1 0x400e83ec>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x13 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_enet_qos_1588_event2_aux_in: IOMUXC_GPIO_SD_B1_04_ENET_QOS_1588_EVENT2_AUX_IN {
 		pinmux = <0x400e81ac 9 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B1_04_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81ac 8 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_flexspi2_a_data02: IOMUXC_GPIO_SD_B1_04_FLEXSPI2_A_DATA02 {
 		pinmux = <0x400e81ac 6 0x400e8584 1 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio10_io07: IOMUXC_GPIO_SD_B1_04_GPIO10_IO07 {
 		pinmux = <0x400e81ac 10 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpio_mux4_io07: IOMUXC_GPIO_SD_B1_04_GPIO_MUX4_IO07 {
 		pinmux = <0x400e81ac 5 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_gpt4_compare3: IOMUXC_GPIO_SD_B1_04_GPT4_COMPARE3 {
 		pinmux = <0x400e81ac 3 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_usdhc1_data2: IOMUXC_GPIO_SD_B1_04_USDHC1_DATA2 {
 		pinmux = <0x400e81ac 0 0x0 0 0x400e83f0>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_in24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_IN24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_04_xbar1_xbar_inout24: IOMUXC_GPIO_SD_B1_04_XBAR1_XBAR_INOUT24 {
 		pinmux = <0x400e81ac 2 0x400e86e8 1 0x400e83f0>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x14 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_enet_qos_1588_event3_aux_in: IOMUXC_GPIO_SD_B1_05_ENET_QOS_1588_EVENT3_AUX_IN {
 		pinmux = <0x400e81b0 9 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi1_b_dqs: IOMUXC_GPIO_SD_B1_05_FLEXSPI1_B_DQS {
 		pinmux = <0x400e81b0 8 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_flexspi2_a_data03: IOMUXC_GPIO_SD_B1_05_FLEXSPI2_A_DATA03 {
 		pinmux = <0x400e81b0 6 0x400e8588 1 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio10_io08: IOMUXC_GPIO_SD_B1_05_GPIO10_IO08 {
 		pinmux = <0x400e81b0 10 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpio_mux4_io08: IOMUXC_GPIO_SD_B1_05_GPIO_MUX4_IO08 {
 		pinmux = <0x400e81b0 5 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_gpt4_clk: IOMUXC_GPIO_SD_B1_05_GPT4_CLK {
 		pinmux = <0x400e81b0 3 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_usdhc1_data3: IOMUXC_GPIO_SD_B1_05_USDHC1_DATA3 {
 		pinmux = <0x400e81b0 0 0x0 0 0x400e83f4>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_in25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_IN25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b1_05_xbar1_xbar_inout25: IOMUXC_GPIO_SD_B1_05_XBAR1_XBAR_INOUT25 {
 		pinmux = <0x400e81b0 2 0x400e86ec 1 0x400e83f4>;
 		pin-pdrv;
 		gpr = <0x400e4050 0x15 0x0>;
 	};
-	iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_enet_1g_rx_en: IOMUXC_GPIO_SD_B2_00_ENET_1G_RX_EN {
 		pinmux = <0x400e81b4 2 0x400e84e0 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_flexspi1_b_data03: IOMUXC_GPIO_SD_B2_00_FLEXSPI1_B_DATA03 {
 		pinmux = <0x400e81b4 1 0x400e8570 1 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio10_io09: IOMUXC_GPIO_SD_B2_00_GPIO10_IO09 {
 		pinmux = <0x400e81b4 10 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_gpio_mux4_io09: IOMUXC_GPIO_SD_B2_00_GPIO_MUX4_IO09 {
 		pinmux = <0x400e81b4 5 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpspi4_sck: IOMUXC_GPIO_SD_B2_00_LPSPI4_SCK {
 		pinmux = <0x400e81b4 4 0x400e8610 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_lpuart9_tx: IOMUXC_GPIO_SD_B2_00_LPUART9_TX {
 		pinmux = <0x400e81b4 3 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_00_usdhc2_data3: IOMUXC_GPIO_SD_B2_00_USDHC2_DATA3 {
 		pinmux = <0x400e81b4 0 0x0 0 0x400e83f8>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_enet_1g_rx_clk: IOMUXC_GPIO_SD_B2_01_ENET_1G_RX_CLK {
 		pinmux = <0x400e81b8 2 0x400e84cc 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_flexspi1_b_data02: IOMUXC_GPIO_SD_B2_01_FLEXSPI1_B_DATA02 {
 		pinmux = <0x400e81b8 1 0x400e856c 1 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio10_io10: IOMUXC_GPIO_SD_B2_01_GPIO10_IO10 {
 		pinmux = <0x400e81b8 10 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_gpio_mux4_io10: IOMUXC_GPIO_SD_B2_01_GPIO_MUX4_IO10 {
 		pinmux = <0x400e81b8 5 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpspi4_pcs0: IOMUXC_GPIO_SD_B2_01_LPSPI4_PCS0 {
 		pinmux = <0x400e81b8 4 0x400e860c 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_lpuart9_rx: IOMUXC_GPIO_SD_B2_01_LPUART9_RX {
 		pinmux = <0x400e81b8 3 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_01_usdhc2_data2: IOMUXC_GPIO_SD_B2_01_USDHC2_DATA2 {
 		pinmux = <0x400e81b8 0 0x0 0 0x400e83fc>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_enet_1g_rdata00: IOMUXC_GPIO_SD_B2_02_ENET_1G_RDATA00 {
 		pinmux = <0x400e81bc 2 0x400e84d0 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_flexspi1_b_data01: IOMUXC_GPIO_SD_B2_02_FLEXSPI1_B_DATA01 {
 		pinmux = <0x400e81bc 1 0x400e8568 1 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio10_io11: IOMUXC_GPIO_SD_B2_02_GPIO10_IO11 {
 		pinmux = <0x400e81bc 10 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_gpio_mux4_io11: IOMUXC_GPIO_SD_B2_02_GPIO_MUX4_IO11 {
 		pinmux = <0x400e81bc 5 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpspi4_sdo: IOMUXC_GPIO_SD_B2_02_LPSPI4_SDO {
 		pinmux = <0x400e81bc 4 0x400e8618 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_lpuart9_cts_b: IOMUXC_GPIO_SD_B2_02_LPUART9_CTS_B {
 		pinmux = <0x400e81bc 3 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_02_usdhc2_data1: IOMUXC_GPIO_SD_B2_02_USDHC2_DATA1 {
 		pinmux = <0x400e81bc 0 0x0 0 0x400e8400>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_enet_1g_rdata01: IOMUXC_GPIO_SD_B2_03_ENET_1G_RDATA01 {
 		pinmux = <0x400e81c0 2 0x400e84d4 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_flexspi1_b_data00: IOMUXC_GPIO_SD_B2_03_FLEXSPI1_B_DATA00 {
 		pinmux = <0x400e81c0 1 0x400e8564 1 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio10_io12: IOMUXC_GPIO_SD_B2_03_GPIO10_IO12 {
 		pinmux = <0x400e81c0 10 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_gpio_mux4_io12: IOMUXC_GPIO_SD_B2_03_GPIO_MUX4_IO12 {
 		pinmux = <0x400e81c0 5 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpspi4_sdi: IOMUXC_GPIO_SD_B2_03_LPSPI4_SDI {
 		pinmux = <0x400e81c0 4 0x400e8614 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_lpuart9_rts_b: IOMUXC_GPIO_SD_B2_03_LPUART9_RTS_B {
 		pinmux = <0x400e81c0 3 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_03_usdhc2_data0: IOMUXC_GPIO_SD_B2_03_USDHC2_DATA0 {
 		pinmux = <0x400e81c0 0 0x0 0 0x400e8404>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_enet_1g_rdata02: IOMUXC_GPIO_SD_B2_04_ENET_1G_RDATA02 {
 		pinmux = <0x400e81c4 2 0x400e84d8 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_a_ss1_b: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_A_SS1_B {
 		pinmux = <0x400e81c4 3 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_flexspi1_b_sclk: IOMUXC_GPIO_SD_B2_04_FLEXSPI1_B_SCLK {
 		pinmux = <0x400e81c4 1 0x400e8578 1 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio10_io13: IOMUXC_GPIO_SD_B2_04_GPIO10_IO13 {
 		pinmux = <0x400e81c4 10 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_gpio_mux4_io13: IOMUXC_GPIO_SD_B2_04_GPIO_MUX4_IO13 {
 		pinmux = <0x400e81c4 5 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_lpspi4_pcs1: IOMUXC_GPIO_SD_B2_04_LPSPI4_PCS1 {
 		pinmux = <0x400e81c4 4 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_04_usdhc2_clk: IOMUXC_GPIO_SD_B2_04_USDHC2_CLK {
 		pinmux = <0x400e81c4 0 0x0 0 0x400e8408>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_enet_1g_rdata03: IOMUXC_GPIO_SD_B2_05_ENET_1G_RDATA03 {
 		pinmux = <0x400e81c8 2 0x400e84dc 1 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_a_dqs: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_A_DQS {
 		pinmux = <0x400e81c8 1 0x400e8550 2 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_flexspi1_b_ss0_b: IOMUXC_GPIO_SD_B2_05_FLEXSPI1_B_SS0_B {
 		pinmux = <0x400e81c8 3 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio10_io14: IOMUXC_GPIO_SD_B2_05_GPIO10_IO14 {
 		pinmux = <0x400e81c8 10 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_gpio_mux4_io14: IOMUXC_GPIO_SD_B2_05_GPIO_MUX4_IO14 {
 		pinmux = <0x400e81c8 5 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_lpspi4_pcs2: IOMUXC_GPIO_SD_B2_05_LPSPI4_PCS2 {
 		pinmux = <0x400e81c8 4 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_05_usdhc2_cmd: IOMUXC_GPIO_SD_B2_05_USDHC2_CMD {
 		pinmux = <0x400e81c8 0 0x0 0 0x400e840c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_enet_1g_tdata03: IOMUXC_GPIO_SD_B2_06_ENET_1G_TDATA03 {
 		pinmux = <0x400e81cc 2 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_flexspi1_a_ss0_b: IOMUXC_GPIO_SD_B2_06_FLEXSPI1_A_SS0_B {
 		pinmux = <0x400e81cc 1 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio10_io15: IOMUXC_GPIO_SD_B2_06_GPIO10_IO15 {
 		pinmux = <0x400e81cc 10 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpio_mux4_io15: IOMUXC_GPIO_SD_B2_06_GPIO_MUX4_IO15 {
 		pinmux = <0x400e81cc 5 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_gpt6_capture1: IOMUXC_GPIO_SD_B2_06_GPT6_CAPTURE1 {
 		pinmux = <0x400e81cc 4 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_lpspi4_pcs3: IOMUXC_GPIO_SD_B2_06_LPSPI4_PCS3 {
 		pinmux = <0x400e81cc 3 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_06_usdhc2_reset_b: IOMUXC_GPIO_SD_B2_06_USDHC2_RESET_B {
 		pinmux = <0x400e81cc 0 0x0 0 0x400e8410>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_1g_tdata02: IOMUXC_GPIO_SD_B2_07_ENET_1G_TDATA02 {
 		pinmux = <0x400e81d0 2 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_qos_ref_clk1: IOMUXC_GPIO_SD_B2_07_ENET_QOS_REF_CLK1 {
 		pinmux = <0x400e81d0 9 0x400e84a0 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_enet_tx_er: IOMUXC_GPIO_SD_B2_07_ENET_TX_ER {
 		pinmux = <0x400e81d0 8 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_flexspi1_a_sclk: IOMUXC_GPIO_SD_B2_07_FLEXSPI1_A_SCLK {
 		pinmux = <0x400e81d0 1 0x400e8574 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio10_io16: IOMUXC_GPIO_SD_B2_07_GPIO10_IO16 {
 		pinmux = <0x400e81d0 10 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpio_mux4_io16: IOMUXC_GPIO_SD_B2_07_GPIO_MUX4_IO16 {
 		pinmux = <0x400e81d0 5 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_gpt6_capture2: IOMUXC_GPIO_SD_B2_07_GPT6_CAPTURE2 {
 		pinmux = <0x400e81d0 4 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpspi2_sck: IOMUXC_GPIO_SD_B2_07_LPSPI2_SCK {
 		pinmux = <0x400e81d0 6 0x400e85e4 1 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_lpuart3_cts_b: IOMUXC_GPIO_SD_B2_07_LPUART3_CTS_B {
 		pinmux = <0x400e81d0 3 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_07_usdhc2_strobe: IOMUXC_GPIO_SD_B2_07_USDHC2_STROBE {
 		pinmux = <0x400e81d0 0 0x0 0 0x400e8414>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_enet_1g_tdata01: IOMUXC_GPIO_SD_B2_08_ENET_1G_TDATA01 {
 		pinmux = <0x400e81d4 2 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_flexspi1_a_data00: IOMUXC_GPIO_SD_B2_08_FLEXSPI1_A_DATA00 {
 		pinmux = <0x400e81d4 1 0x400e8554 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio10_io17: IOMUXC_GPIO_SD_B2_08_GPIO10_IO17 {
 		pinmux = <0x400e81d4 10 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpio_mux4_io17: IOMUXC_GPIO_SD_B2_08_GPIO_MUX4_IO17 {
 		pinmux = <0x400e81d4 5 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_gpt6_compare1: IOMUXC_GPIO_SD_B2_08_GPT6_COMPARE1 {
 		pinmux = <0x400e81d4 4 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpspi2_pcs0: IOMUXC_GPIO_SD_B2_08_LPSPI2_PCS0 {
 		pinmux = <0x400e81d4 6 0x400e85dc 1 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_lpuart3_rts_b: IOMUXC_GPIO_SD_B2_08_LPUART3_RTS_B {
 		pinmux = <0x400e81d4 3 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_08_usdhc2_data4: IOMUXC_GPIO_SD_B2_08_USDHC2_DATA4 {
 		pinmux = <0x400e81d4 0 0x0 0 0x400e8418>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_enet_1g_tdata00: IOMUXC_GPIO_SD_B2_09_ENET_1G_TDATA00 {
 		pinmux = <0x400e81d8 2 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_flexspi1_a_data01: IOMUXC_GPIO_SD_B2_09_FLEXSPI1_A_DATA01 {
 		pinmux = <0x400e81d8 1 0x400e8558 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio10_io18: IOMUXC_GPIO_SD_B2_09_GPIO10_IO18 {
 		pinmux = <0x400e81d8 10 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpio_mux4_io18: IOMUXC_GPIO_SD_B2_09_GPIO_MUX4_IO18 {
 		pinmux = <0x400e81d8 5 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_gpt6_compare2: IOMUXC_GPIO_SD_B2_09_GPT6_COMPARE2 {
 		pinmux = <0x400e81d8 4 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpspi2_sdo: IOMUXC_GPIO_SD_B2_09_LPSPI2_SDO {
 		pinmux = <0x400e81d8 6 0x400e85ec 1 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_lpuart5_cts_b: IOMUXC_GPIO_SD_B2_09_LPUART5_CTS_B {
 		pinmux = <0x400e81d8 3 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_09_usdhc2_data5: IOMUXC_GPIO_SD_B2_09_USDHC2_DATA5 {
 		pinmux = <0x400e81d8 0 0x0 0 0x400e841c>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_enet_1g_tx_en: IOMUXC_GPIO_SD_B2_10_ENET_1G_TX_EN {
 		pinmux = <0x400e81dc 2 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_flexspi1_a_data02: IOMUXC_GPIO_SD_B2_10_FLEXSPI1_A_DATA02 {
 		pinmux = <0x400e81dc 1 0x400e855c 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio10_io19: IOMUXC_GPIO_SD_B2_10_GPIO10_IO19 {
 		pinmux = <0x400e81dc 10 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpio_mux4_io19: IOMUXC_GPIO_SD_B2_10_GPIO_MUX4_IO19 {
 		pinmux = <0x400e81dc 5 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_gpt6_compare3: IOMUXC_GPIO_SD_B2_10_GPT6_COMPARE3 {
 		pinmux = <0x400e81dc 4 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpspi2_sdi: IOMUXC_GPIO_SD_B2_10_LPSPI2_SDI {
 		pinmux = <0x400e81dc 6 0x400e85e8 1 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_lpuart5_rts_b: IOMUXC_GPIO_SD_B2_10_LPUART5_RTS_B {
 		pinmux = <0x400e81dc 3 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_10_usdhc2_data6: IOMUXC_GPIO_SD_B2_10_USDHC2_DATA6 {
 		pinmux = <0x400e81dc 0 0x0 0 0x400e8420>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_ref_clk1: IOMUXC_GPIO_SD_B2_11_ENET_1G_REF_CLK1 {
 		pinmux = <0x400e81e0 3 0x400e84c4 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_enet_1g_tx_clk_io: IOMUXC_GPIO_SD_B2_11_ENET_1G_TX_CLK_IO {
 		pinmux = <0x400e81e0 2 0x400e84e8 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_flexspi1_a_data03: IOMUXC_GPIO_SD_B2_11_FLEXSPI1_A_DATA03 {
 		pinmux = <0x400e81e0 1 0x400e8560 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio10_io20: IOMUXC_GPIO_SD_B2_11_GPIO10_IO20 {
 		pinmux = <0x400e81e0 10 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpio_mux4_io20: IOMUXC_GPIO_SD_B2_11_GPIO_MUX4_IO20 {
 		pinmux = <0x400e81e0 5 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_gpt6_clk: IOMUXC_GPIO_SD_B2_11_GPT6_CLK {
 		pinmux = <0x400e81e0 4 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_lpspi2_pcs1: IOMUXC_GPIO_SD_B2_11_LPSPI2_PCS1 {
 		pinmux = <0x400e81e0 6 0x400e85e0 1 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
+	/omit-if-no-ref/ iomuxc_gpio_sd_b2_11_usdhc2_data7: IOMUXC_GPIO_SD_B2_11_USDHC2_DATA7 {
 		pinmux = <0x400e81e0 0 0x0 0 0x400e8424>;
 		pin-pdrv;
 	};
-	iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_gpio13_io03: IOMUXC_SNVS_GPIO_SNVS_00_GPIO13_IO03 {
 		pinmux = <0x40c9400c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_00_snvs_lp_tamper00: IOMUXC_SNVS_GPIO_SNVS_00_SNVS_LP_TAMPER00 {
 		pinmux = <0x40c9400c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_gpio13_io04: IOMUXC_SNVS_GPIO_SNVS_01_GPIO13_IO04 {
 		pinmux = <0x40c94010 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_01_snvs_lp_tamper01: IOMUXC_SNVS_GPIO_SNVS_01_SNVS_LP_TAMPER01 {
 		pinmux = <0x40c94010 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_gpio13_io05: IOMUXC_SNVS_GPIO_SNVS_02_GPIO13_IO05 {
 		pinmux = <0x40c94014 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_02_snvs_lp_tamper02: IOMUXC_SNVS_GPIO_SNVS_02_SNVS_LP_TAMPER02 {
 		pinmux = <0x40c94014 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_gpio13_io06: IOMUXC_SNVS_GPIO_SNVS_03_GPIO13_IO06 {
 		pinmux = <0x40c94018 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_03_snvs_lp_tamper03: IOMUXC_SNVS_GPIO_SNVS_03_SNVS_LP_TAMPER03 {
 		pinmux = <0x40c94018 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_gpio13_io07: IOMUXC_SNVS_GPIO_SNVS_04_GPIO13_IO07 {
 		pinmux = <0x40c9401c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_04_snvs_lp_tamper04: IOMUXC_SNVS_GPIO_SNVS_04_SNVS_LP_TAMPER04 {
 		pinmux = <0x40c9401c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_gpio13_io08: IOMUXC_SNVS_GPIO_SNVS_05_GPIO13_IO08 {
 		pinmux = <0x40c94020 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_05_snvs_lp_tamper05: IOMUXC_SNVS_GPIO_SNVS_05_SNVS_LP_TAMPER05 {
 		pinmux = <0x40c94020 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_gpio13_io09: IOMUXC_SNVS_GPIO_SNVS_06_GPIO13_IO09 {
 		pinmux = <0x40c94024 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_06_snvs_lp_tamper06: IOMUXC_SNVS_GPIO_SNVS_06_SNVS_LP_TAMPER06 {
 		pinmux = <0x40c94024 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_gpio13_io10: IOMUXC_SNVS_GPIO_SNVS_07_GPIO13_IO10 {
 		pinmux = <0x40c94028 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_07_snvs_lp_tamper07: IOMUXC_SNVS_GPIO_SNVS_07_SNVS_LP_TAMPER07 {
 		pinmux = <0x40c94028 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_gpio13_io11: IOMUXC_SNVS_GPIO_SNVS_08_GPIO13_IO11 {
 		pinmux = <0x40c9402c 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_08_snvs_lp_tamper08: IOMUXC_SNVS_GPIO_SNVS_08_SNVS_LP_TAMPER08 {
 		pinmux = <0x40c9402c 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_gpio13_io12: IOMUXC_SNVS_GPIO_SNVS_09_GPIO13_IO12 {
 		pinmux = <0x40c94030 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
+	/omit-if-no-ref/ iomuxc_snvs_gpio_snvs_09_snvs_lp_tamper09: IOMUXC_SNVS_GPIO_SNVS_09_SNVS_LP_TAMPER09 {
 		pinmux = <0x40c94030 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_gpio13_io01: IOMUXC_SNVS_PMIC_ON_REQ_GPIO13_IO01 {
 		pinmux = <0x40c94004 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_on_req_snvs_lp_pmic_on_req: IOMUXC_SNVS_PMIC_ON_REQ_SNVS_LP_PMIC_ON_REQ {
 		pinmux = <0x40c94004 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_gpio13_io02: IOMUXC_SNVS_PMIC_STBY_REQ_GPIO13_IO02 {
 		pinmux = <0x40c94008 5 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
+	/omit-if-no-ref/ iomuxc_snvs_pmic_stby_req_pgmc_pmic_vstby_req: IOMUXC_SNVS_PMIC_STBY_REQ_PGMC_PMIC_VSTBY_REQ {
 		pinmux = <0x40c94008 0 0x0 0 0x0>;
 		pin-snvs;
 	};
-	iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
+	/omit-if-no-ref/ iomuxc_snvs_wakeup_gpio13_io00: IOMUXC_SNVS_WAKEUP_GPIO13_IO00 {
 		pinmux = <0x40c94000 5 0x0 0 0x0>;
 		pin-snvs;
 	};


### PR DESCRIPTION
Update iMX RT pinctrl nodes with /omit-if-no-ref/ to reduce size of
generated devicetree header.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>