### PR TITLE
hal: nxp: Centralize handling of SDK custom sections

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -102,3 +102,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/hal_nxp.cmake)
 enable_language(C ASM)
 
 zephyr_library_sources_ifdef(CONFIG_SOC_LPC54114_M4 mcux-sdk/devices/${MCUX_DEVICE}/gcc/startup_LPC54114_cm4.S)
+
+zephyr_linker_sources(RWDATA quick_access.ld)
+

--- a/mcux/quick_access.ld
+++ b/mcux/quick_access.ld
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = ALIGN(4);
+KEEP(*(CodeQuickAccess))
+KEEP(*(DataQuickAccess))


### PR DESCRIPTION
SDK defines CodeQuickAccess and DataQuickAccess sections for
locating critical items that need faster access. Centralize the
handling of these sections instead of doing it per SOC.

Fixes #44452

Signed-off-by: David Leach <david.leach@nxp.com>