### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/mcux/middleware/wireless/framework_5.3.3/OSAbstraction/Source/fsl_os_abstraction_zephyr.c
+++ b/mcux/middleware/wireless/framework_5.3.3/OSAbstraction/Source/fsl_os_abstraction_zephyr.c
@@ -1,5 +1,5 @@
-#include <zephyr.h>
-#include <irq.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 #include "fsl_os_abstraction.h"

--- a/mcux/middleware/wireless/framework_5.3.3/OSAbstraction/Source/fsl_os_abstraction_zephyr.c
+++ b/mcux/middleware/wireless/framework_5.3.3/OSAbstraction/Source/fsl_os_abstraction_zephyr.c
@@ -1,4 +1,4 @@
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/irq.h>
 #include <soc.h>
 


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.