### PR TITLE
Rename INPUTMUX_PINT_SEL count

### DIFF
--- a/mcux/mcux-sdk/devices/MIMXRT533S/MIMXRT533S.h
+++ b/mcux/mcux-sdk/devices/MIMXRT533S/MIMXRT533S.h
@@ -29059,7 +29059,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - Fusion DSP Interrupt Input Multiplexer */
 /*! @{ */

--- a/mcux/mcux-sdk/devices/MIMXRT555S/MIMXRT555S.h
+++ b/mcux/mcux-sdk/devices/MIMXRT555S/MIMXRT555S.h
@@ -29062,7 +29062,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - Fusion DSP Interrupt Input Multiplexer */
 /*! @{ */

--- a/mcux/mcux-sdk/devices/MIMXRT595S/MIMXRT595S_cm33.h
+++ b/mcux/mcux-sdk/devices/MIMXRT595S/MIMXRT595S_cm33.h
@@ -29063,7 +29063,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - Fusion DSP Interrupt Input Multiplexer */
 /*! @{ */

--- a/mcux/mcux-sdk/devices/MIMXRT595S/MIMXRT595S_dsp.h
+++ b/mcux/mcux-sdk/devices/MIMXRT595S/MIMXRT595S_dsp.h
@@ -22039,7 +22039,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - Fusion DSP Interrupt Input Multiplexer */
 /*! @{ */

--- a/mcux/mcux-sdk/devices/MIMXRT633S/MIMXRT633S.h
+++ b/mcux/mcux-sdk/devices/MIMXRT633S/MIMXRT633S.h
@@ -19404,7 +19404,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINT_SEL_COUNT                  (8U)
+#define INPUTMUX_PINTSEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - DSP Interrupt Input Multiplexers N */
 /*! @{ */


### PR DESCRIPTION
Rename the GPIO INPUTMUX_PINT_SEL from INPUTMUX_PINT_SEL_COUNT
to INPUTMUX_PINTSEL_COUNT.

Signed-off-by: Navin Sankar Velliangiri <navin@linumiz.com>