### PR TITLE
MIMXRT685S: Revert Rename of INPUTMUX_PINT_SEL

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -58,7 +58,3 @@ Patch List:
 
    * Add USB device controller drivers, the drivers are based on MCUXpresso SDK release tag REL_2.5.0_REL9_RFP_RC3_7_1.
 
-   * Rename GPIO INPUTMUX_PINT_SEL on MIMXRT685. The following files that are touched by this commit:
-      mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_cm33.h
-      mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_dsp.h
-

--- a/mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_cm33.h
+++ b/mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_cm33.h
@@ -19404,7 +19404,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINTSEL_COUNT                  (8U)
+#define INPUTMUX_PINT_SEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - DSP Interrupt Input Multiplexers N */
 /*! @{ */

--- a/mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_dsp.h
+++ b/mcux/mcux-sdk/devices/MIMXRT685S/MIMXRT685S_dsp.h
@@ -12501,7 +12501,7 @@ typedef struct {
 /*! @} */
 
 /* The count of INPUTMUX_PINT_SEL */
-#define INPUTMUX_PINTSEL_COUNT                  (8U)
+#define INPUTMUX_PINT_SEL_COUNT                  (8U)
 
 /*! @name DSP_INT_SEL - DSP Interrupt Input Multiplexers N */
 /*! @{ */


### PR DESCRIPTION
This variation in the macro name is now handled inside zephyr soc.h file as this will not be fixed inside mcux-sdk. 