### PR TITLE
mcux: Link SDK symbols NonCacheable

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -104,3 +104,7 @@ zephyr_linker_sources_ifdef(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
   RAMFUNC_SECTION
   quick_access_code.ld
 )
+zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
+  NOCACHE_SECTION
+  nocache.ld
+)

--- a/mcux/nocache.ld
+++ b/mcux/nocache.ld
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+. = ALIGN(4);
+KEEP(*(NonCacheable))


### PR DESCRIPTION
Link SDK NonCacheable symbol into the nocache section. This is dependent on Zephyr PR#[49368](https://github.com/zephyrproject-rtos/zephyr/pull/49368)
