### PR TITLE
caam: Fixes RNG descriptors

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -60,3 +60,4 @@ License Link:
 Patch List:
   1. Delete the .a binary archive files after an SDK update before committing the changes. These files are still present in the SDK github repo but have been
      deleted from the Zephyr HAL
+  2. Move used job descriptors in the CAAM driver (mcux-sdk/drivers/caam/fsl_caam.c) from the stack to noncacheable section. At time of writing, there should be four being used for entropy in zephyr.

--- a/mcux/mcux-sdk/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk/drivers/caam/fsl_caam.c
@@ -198,6 +198,10 @@ static uint32_t s_jrIndex2              = 0;    /*!< Current index in the input 
 static caam_job_ring_interface_t *s_jr3 = NULL; /*!< Pointer to job ring interface 3. */
 static uint32_t s_jrIndex3              = 0;    /*!< Current index in the input job ring 3. */
 
+AT_NONCACHEABLE_SECTION(static caam_rng_config_t rngConfig);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngGenSeckey);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngInstantiate);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t descBuf);
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -1755,7 +1759,6 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
      * for FIFO STORE command to be able to store Key register as Black key
      * for example during AES XCBC-MAC context switch (need to store derived key K1 to memory)
      */
-    caam_rng_config_t rngConfig;
     (void)CAAM_RNG_GetDefaultConfig(&rngConfig);
 
     /* reset RNG */
@@ -3422,7 +3425,6 @@ status_t CAAM_RNG_Init(CAAM_Type *base,
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngInstantiate = {0};
     rngInstantiate[0]              = 0xB0800006u;
     rngInstantiate[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngInstantiate[2]              = (uint32_t)ADD_OFFSET((uint32_t)config->personalString);
@@ -3518,7 +3520,6 @@ status_t CAAM_RNG_GenerateSecureKey(CAAM_Type *base, caam_handle_t *handle, caam
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngGenSeckey = {0};
     rngGenSeckey[0]              = 0xB0800004u; /* HEADER */
     rngGenSeckey[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngGenSeckey[2]              = ADD_OFFSET((uint32_t)additionalEntropy);
@@ -3625,7 +3626,6 @@ status_t CAAM_RNG_GetRandomData(CAAM_Type *base,
                                 caam_rng_generic256_t additionalEntropy)
 {
     status_t status;
-    caam_desc_rng_t descBuf;
 
     do
     {


### PR DESCRIPTION
Moves CAAM initialization and RNG related job descriptors to a non-cacheable region instead of being on the write-back stack. Currently the CAAM and core(s) are accessing these descriptors incoherently.

Signed-off-by: Declan Snyder <declan.snyder@nxp.com>