### PR TITLE
mcux-sdk: s/ARRAY_SIZE/FSL_ARRAY_SIZE

### DIFF
--- a/mcux/mcux-sdk/boards/evkmimxrt595/board.c
+++ b/mcux/mcux-sdk/boards/evkmimxrt595/board.c
@@ -236,7 +236,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/boards/evkmimxrt595/project_template/board.c
+++ b/mcux/mcux-sdk/boards/evkmimxrt595/project_template/board.c
@@ -236,7 +236,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/boards/evkmimxrt685/board.c
+++ b/mcux/mcux-sdk/boards/evkmimxrt685/board.c
@@ -240,7 +240,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/boards/evkmimxrt685/project_template/board.c
+++ b/mcux/mcux-sdk/boards/evkmimxrt685/project_template/board.c
@@ -240,7 +240,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/boards/evkmimxrt685/wireless_config_template/sdmmc_config.c
+++ b/mcux/mcux-sdk/boards/evkmimxrt685/wireless_config_template/sdmmc_config.c
@@ -107,13 +107,13 @@ void BOARD_SDCardIoVoltageControlInit(void)
     pca9420Config.I2C_SendFunc    = BOARD_PMIC_I2C_Send;
     pca9420Config.I2C_ReceiveFunc = BOARD_PMIC_I2C_Receive;
     PCA9420_Init(&pca9420Handle, &pca9420Config);
-    for (i = 0; i < ARRAY_SIZE(pca9420ModeCfg); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(pca9420ModeCfg); i++)
     {
         PCA9420_GetDefaultModeConfig(&pca9420ModeCfg[i]);
     }
     pca9420ModeCfg[0].ldo2OutVolt = kPCA9420_Ldo2OutVolt3V300;
     pca9420ModeCfg[1].ldo2OutVolt = kPCA9420_Ldo2OutVolt1V800;
-    PCA9420_WriteModeConfigs(&pca9420Handle, kPCA9420_Mode0, &pca9420ModeCfg[0], ARRAY_SIZE(pca9420ModeCfg));
+    PCA9420_WriteModeConfigs(&pca9420Handle, kPCA9420_Mode0, &pca9420ModeCfg[0], FSL_ARRAY_SIZE(pca9420ModeCfg));
 }
 
 void BOARD_SDCardIoVoltageControl(sdmmc_operation_voltage_t voltage)

--- a/mcux/mcux-sdk/boards/mimxrt685audevk/board.c
+++ b/mcux/mcux-sdk/boards/mimxrt685audevk/board.c
@@ -236,7 +236,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/boards/mimxrt685audevk/project_template/board.c
+++ b/mcux/mcux-sdk/boards/mimxrt685audevk/project_template/board.c
@@ -236,7 +236,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/components/audio/fsl_adapter_flexcomm_i2s.c
+++ b/mcux/mcux-sdk/components/audio/fsl_adapter_flexcomm_i2s.c
@@ -43,7 +43,7 @@ typedef struct _hal_audio_state
 static I2S_Type *const s_i2sBases[] = I2S_BASE_PTRS;
 #if (defined(HAL_AUDIO_DMA_INIT_ENABLE) && (HAL_AUDIO_DMA_INIT_ENABLE > 0U))
 /*! @brief Resource for each i2s instance. */
-static uint8_t s_dmaOccupied[ARRAY_SIZE((DMA_Type *[])DMA_BASE_PTRS)];
+static uint8_t s_dmaOccupied[FSL_ARRAY_SIZE((DMA_Type *[])DMA_BASE_PTRS)];
 #endif /* HAL_AUDIO_DMA_INIT_ENABLE */
 
 /*******************************************************************************
@@ -112,8 +112,8 @@ static hal_audio_status_t HAL_AudioCommonInit(hal_audio_handle_t handle,
        If modified, please modify the value of HAL_AUDIO_QUEUE_SIZE defined in the fsl_adapter_audio.h to be the same as
        I2S_NUM_BUFFERS. */
     assert(HAL_AUDIO_HANDLE_SIZE >= sizeof(hal_audio_state_t));
-    assert(config->instance < ARRAY_SIZE(s_i2sBases));
-    assert(config->dmaConfig->instance < ARRAY_SIZE(dmaBases));
+    assert(config->instance < FSL_ARRAY_SIZE(s_i2sBases));
+    assert(config->dmaConfig->instance < FSL_ARRAY_SIZE(dmaBases));
 
     dmaConfig   = (hal_audio_dma_config_t *)config->dmaConfig;
     audioHandle = (hal_audio_state_t *)handle;

--- a/mcux/mcux-sdk/components/audio/fsl_adapter_sai.c
+++ b/mcux/mcux-sdk/components/audio/fsl_adapter_sai.c
@@ -60,14 +60,14 @@ typedef struct _hal_audio_state
 /*! @brief Pointers to audio bases for each instance. */
 static I2S_Type *const s_i2sBases[] = I2S_BASE_PTRS;
 /*! @brief Resource for each i2s instance. */
-static uint8_t s_i2sOccupied[ARRAY_SIZE(s_i2sBases)];
+static uint8_t s_i2sOccupied[FSL_ARRAY_SIZE(s_i2sBases)];
 #if (defined(HAL_AUDIO_DMA_INIT_ENABLE) && (HAL_AUDIO_DMA_INIT_ENABLE > 0U))
 /*! @brief Resource for each dma instance. */
-static uint8_t s_dmaOccupied[ARRAY_SIZE((DMA_Type *[])DMA_BASE_PTRS)];
+static uint8_t s_dmaOccupied[FSL_ARRAY_SIZE((DMA_Type *[])DMA_BASE_PTRS)];
 #if (defined(FSL_FEATURE_SOC_EDMA_COUNT) && (FSL_FEATURE_SOC_EDMA_COUNT > 0U))
 #if (defined(FSL_FEATURE_SOC_DMAMUX_COUNT) && (FSL_FEATURE_SOC_DMAMUX_COUNT > 0U))
 /*! @brief Resource for each dma mux instance. */
-static uint8_t s_dmaMuxOccupied[ARRAY_SIZE((DMAMUX_Type *[])DMAMUX_BASE_PTRS)];
+static uint8_t s_dmaMuxOccupied[FSL_ARRAY_SIZE((DMAMUX_Type *[])DMAMUX_BASE_PTRS)];
 #endif /* FSL_FEATURE_SOC_DMAMUX_COUNT */
 #endif /* FSL_FEATURE_SOC_EDMA_COUNT */
 #endif /* HAL_AUDIO_DMA_INIT_ENABLE */
@@ -259,8 +259,8 @@ static hal_audio_status_t HAL_AudioCommonInit(hal_audio_handle_t handle,
        If modified, please modify the value of HAL_AUDIO_QUEUE_SIZE defined in the fsl_adapter_audio.h to be the same as
        SAI_XFER_QUEUE_SIZE. */
     assert(HAL_AUDIO_HANDLE_SIZE >= sizeof(hal_audio_state_t));
-    assert(config->instance < ARRAY_SIZE(s_i2sBases));
-    assert(config->dmaConfig->instance < ARRAY_SIZE(dmaBases));
+    assert(config->instance < FSL_ARRAY_SIZE(s_i2sBases));
+    assert(config->dmaConfig->instance < FSL_ARRAY_SIZE(dmaBases));
 
     dmaConfig     = (hal_audio_dma_config_t *)config->dmaConfig;
     featureConfig = (hal_audio_ip_config_t *)config->ipConfig;

--- a/mcux/mcux-sdk/components/exception_handling/cm7/fsl_component_exception_handling.c
+++ b/mcux/mcux-sdk/components/exception_handling/cm7/fsl_component_exception_handling.c
@@ -299,7 +299,7 @@ static void EXCEPTION_HardFaultRegisterPrint(void)
 {
     (void)EXCEPTION_ConfigurableFaultStatusRegisterPrint();
     (void)EXCEPTION_HardFaultStatusRegisterPrint();
-    for (uint32_t i = 0; i < ARRAY_SIZE(scb_data_text); i++)
+    for (uint32_t i = 0; i < FSL_ARRAY_SIZE(scb_data_text); i++)
     {
         if (32U == scb_data_text[i].type)
         {

--- a/mcux/mcux-sdk/components/flash/nand/flexspi/fsl_flexspi_nand_flash.c
+++ b/mcux/mcux-sdk/components/flash/nand/flexspi/fsl_flexspi_nand_flash.c
@@ -223,7 +223,7 @@ status_t Nand_Flash_Init(nand_config_t *config, nand_handle_t *handle)
 
                                /* Update LUT table. */
         FLEXSPI_UpdateLUT((FLEXSPI_Type *)config->driverBaseAddr, 0, memConfig->lookupTable,
-                          ARRAY_SIZE(memConfig->lookupTable));
+                          FSL_ARRAY_SIZE(memConfig->lookupTable));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset((FLEXSPI_Type *)config->driverBaseAddr);

--- a/mcux/mcux-sdk/components/gpio/fsl_adapter_lpc_gpio.c
+++ b/mcux/mcux-sdk/components/gpio/fsl_adapter_lpc_gpio.c
@@ -246,7 +246,7 @@ hal_gpio_status_t HAL_GpioInit(hal_gpio_handle_t gpioHandle, hal_gpio_pin_config
         /*! @brief Array to map FGPIO instance number to clock name. */
         const clock_ip_name_t gpioClockName[] = GPIO_CLOCKS;
 
-        assert(gpioState->pin.port < ARRAY_SIZE(gpioClockName));
+        assert(gpioState->pin.port < FSL_ARRAY_SIZE(gpioClockName));
         CLOCK_EnableClock(gpioClockName[gpioState->pin.port]);
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 

--- a/mcux/mcux-sdk/components/gpio/fsl_adapter_rt_gpio.c
+++ b/mcux/mcux-sdk/components/gpio/fsl_adapter_rt_gpio.c
@@ -239,7 +239,7 @@ hal_gpio_status_t HAL_GpioInit(hal_gpio_handle_t gpioHandle, hal_gpio_pin_config
         /*! @brief Array to map FGPIO instance number to clock name. */
         const clock_ip_name_t gpioClockName[] = GPIO_CLOCKS;
 
-        assert(gpioState->pin.port < ARRAY_SIZE(gpioClockName));
+        assert(gpioState->pin.port < FSL_ARRAY_SIZE(gpioClockName));
         CLOCK_EnableClock(gpioClockName[gpioState->pin.port]);
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 

--- a/mcux/mcux-sdk/components/i3c_bus/fsl_component_i3c_adapter.c
+++ b/mcux/mcux-sdk/components/i3c_bus/fsl_component_i3c_adapter.c
@@ -651,7 +651,7 @@ static void I3C_MasterAdapterRegisterIBI(i3c_device_t *master, uint8_t ibiAddres
         ibiRule.ibiHasPayload = true;
     }
 
-    for (uint32_t count = 0; count < ARRAY_SIZE(ibiRule.address); count++)
+    for (uint32_t count = 0; count < FSL_ARRAY_SIZE(ibiRule.address); count++)
     {
         if (0U == ibiRule.address[count])
         {

--- a/mcux/mcux-sdk/components/log/fsl_component_log.c
+++ b/mcux/mcux-sdk/components/log/fsl_component_log.c
@@ -220,14 +220,14 @@ static int log_sprintf_internal(log_print_buffer_t *printBuf, char const *format
 
 static char const *log_get_level_name(log_level_t level)
 {
-    assert(((uint8_t)level < ARRAY_SIZE(s_logLevelName)));
+    assert(((uint8_t)level < FSL_ARRAY_SIZE(s_logLevelName)));
     return s_logLevelName[(int)level];
 }
 
 #if LOG_ENABLE_COLOR
 static char const *log_get_color(log_level_t level)
 {
-    assert(((uint8_t)level < ARRAY_SIZE(s_logColor)));
+    assert(((uint8_t)level < FSL_ARRAY_SIZE(s_logColor)));
     return s_logColor[(int)level];
 }
 #endif

--- a/mcux/mcux-sdk/components/log/fsl_component_log.h
+++ b/mcux/mcux-sdk/components/log/fsl_component_log.h
@@ -231,7 +231,7 @@ typedef struct log_backend
     if (((logLevel > kLOG_LevelNone) && ((logger)->level >= logLevel)))                                       \
     {                                                                                                         \
         LOG_ARGUMENT_TYPE argValueList[] = {LOG_LIST_ARGUMENT(__VA_ARGS__)};                                  \
-        LOG_AsyncPrintf(logger, logLevel, LOG_TIMESTAMP_GET, format, ARRAY_SIZE(argValueList), argValueList); \
+        LOG_AsyncPrintf(logger, logLevel, LOG_TIMESTAMP_GET, format, FSL_ARRAY_SIZE(argValueList), argValueList); \
     }
 #else
 /*!

--- a/mcux/mcux-sdk/components/pca9420/fsl_pca9420.h
+++ b/mcux/mcux-sdk/components/pca9420/fsl_pca9420.h
@@ -682,13 +682,13 @@ void PCA9420_GetRegulatorVolt(pca9420_modecfg_t *config, pca9420_regulator_mv_t 
  * @code
  *   pca9420_modecfg_t pca9420ModeCfg[4];
  *   uint32_t i;
- *   for (i = 0; i < ARRAY_SIZE(pca9420ModeCfg); i++)
+ *   for (i = 0; i < FSL_ARRAY_SIZE(pca9420ModeCfg); i++)
  *   {
  *       PCA9420_GetDefaultModeConfig(&pca9420ModeCfg[i]);
  *   }
  *   ...
  *   PCA9420_WriteModeConfigs(&pca9420Handle, kPCA9420_Mode0, &pca9420ModeCfg[0],
- * ARRAY_SIZE(pca9420ModeCfg));
+ * FSL_ARRAY_SIZE(pca9420ModeCfg));
  *   ...
  *   PCA9420_WriteModeConfigs(&pca9420Handle, kPCA9420_Mode2, &pca9420ModeCfg[2], 1);
  * @endcode

--- a/mcux/mcux-sdk/components/srtm/services/srtm_sai_sdma_adapter.c
+++ b/mcux/mcux-sdk/components/srtm/services/srtm_sai_sdma_adapter.c
@@ -1342,7 +1342,7 @@ static srtm_status_t SRTM_SaiSdmaAdapter_SetParam(
         return SRTM_Status_InvalidState;
     }
 
-    if ((format > (uint8_t)SRTM_Audio_DSD32bits) || (channels >= ARRAY_SIZE(saiChannelMap)))
+    if ((format > (uint8_t)SRTM_Audio_DSD32bits) || (channels >= FSL_ARRAY_SIZE(saiChannelMap)))
     {
         SRTM_DEBUG_MESSAGE(SRTM_DEBUG_VERBOSE_ERROR, "%s: %s unsupported format or channels %d, %d!\r\n", __func__,
                            saiDirection[dir], format, channels);

--- a/mcux/mcux-sdk/components/video/camera/device/max9286/fsl_max9286.c
+++ b/mcux/mcux-sdk/components/video/camera/device/max9286/fsl_max9286.c
@@ -461,7 +461,7 @@ static const ov10635_resolution_config_t *OV10635_GetResolutionConfig(const came
     uint8_t i;
     const ov10635_resolution_config_t *config = NULL;
 
-    for (i = 0; i < ARRAY_SIZE(s_ov10635ResolutionConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_ov10635ResolutionConfigs); i++)
     {
         if ((cameraConfig->resolution == s_ov10635ResolutionConfigs[i].resolution) &&
             (cameraConfig->framePerSec == s_ov10635ResolutionConfigs[i].framePerSec))
@@ -540,7 +540,7 @@ static status_t OV10635_Init(camera_device_handle_t *handle, uint8_t index)
         return kStatus_Fail;
     }
 
-    for (i = 0; i < ARRAY_SIZE(ov10635Firmware); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(ov10635Firmware); i++)
     {
         status = OV10635_Write(handle, i2cAddr, ov10635Firmware[i].reg, ov10635Firmware[i].value);
         if (status != kStatus_Success)

--- a/mcux/mcux-sdk/components/video/camera/device/mt9m114/fsl_mt9m114.c
+++ b/mcux/mcux-sdk/components/video/camera/device/mt9m114/fsl_mt9m114.c
@@ -314,7 +314,7 @@ status_t MT9M114_Init(camera_device_handle_t *handle, const camera_config_t *con
         return status;
     }
 
-    status = MT9M114_MultiWrite(handle, mt9m114InitConfig, ARRAY_SIZE(mt9m114InitConfig));
+    status = MT9M114_MultiWrite(handle, mt9m114InitConfig, FSL_ARRAY_SIZE(mt9m114InitConfig));
     if (kStatus_Success != status)
     {
         return status;
@@ -362,11 +362,11 @@ status_t MT9M114_Init(camera_device_handle_t *handle, const camera_config_t *con
     /* Resolution */
     if (config->resolution == FSL_VIDEO_RESOLUTION(480, 272))
     {
-        status = MT9M114_MultiWrite(handle, mt9m114_480_272, ARRAY_SIZE(mt9m114_480_272));
+        status = MT9M114_MultiWrite(handle, mt9m114_480_272, FSL_ARRAY_SIZE(mt9m114_480_272));
     }
     else
     {
-        status = MT9M114_MultiWrite(handle, mt9m114_720p, ARRAY_SIZE(mt9m114_720p));
+        status = MT9M114_MultiWrite(handle, mt9m114_720p, FSL_ARRAY_SIZE(mt9m114_720p));
     }
 
     if (kStatus_Success != status)

--- a/mcux/mcux-sdk/components/video/camera/device/ov5640/fsl_ov5640.c
+++ b/mcux/mcux-sdk/components/video/camera/device/ov5640/fsl_ov5640.c
@@ -724,7 +724,7 @@ static status_t OV5640_SoftwareReset(camera_device_handle_t *handle)
 {
     ov5640_reg_val_t param[] = {{0x3103, 0x11}, {0x3008, 0x82}};
 
-    return OV5640_LoadRegVal(handle, param, ARRAY_SIZE(param));
+    return OV5640_LoadRegVal(handle, param, FSL_ARRAY_SIZE(param));
 }
 
 static const uint8_t *OV5640_GetResolutionParam(uint32_t resolution)
@@ -735,7 +735,7 @@ static const uint8_t *OV5640_GetResolutionParam(uint32_t resolution)
      */
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(resolutionParam); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(resolutionParam); i++)
     {
         if (resolution == resolutionParam[i].resolution)
         {
@@ -752,7 +752,7 @@ static const ov5640_clock_config_t *OV5640_GetClockConfig(const camera_config_t 
 
     if (kCAMERA_InterfaceMIPI == config->interface)
     {
-        for (i = 0; i < ARRAY_SIZE(s_ov5640MipiClockConfigs); i++)
+        for (i = 0; i < FSL_ARRAY_SIZE(s_ov5640MipiClockConfigs); i++)
         {
             if ((config->framePerSec == s_ov5640MipiClockConfigs[i].framePerSec) &&
                 (config->resolution == s_ov5640MipiClockConfigs[i].resolution))
@@ -763,7 +763,7 @@ static const ov5640_clock_config_t *OV5640_GetClockConfig(const camera_config_t 
     }
     else
     {
-        for (i = 0; i < ARRAY_SIZE(s_ov5640DvpClockConfigs); i++)
+        for (i = 0; i < FSL_ARRAY_SIZE(s_ov5640DvpClockConfigs); i++)
         {
             if ((config->framePerSec == s_ov5640DvpClockConfigs[i].framePerSec) &&
                 (config->resolution == s_ov5640DvpClockConfigs[i].resolution))
@@ -862,7 +862,7 @@ status_t OV5640_Init(camera_device_handle_t *handle, const camera_config_t *conf
     OV5640_DelayMs(5);
 
     /* Initialize. */
-    status = OV5640_LoadRegVal(handle, ov5640InitParam, ARRAY_SIZE(ov5640InitParam));
+    status = OV5640_LoadRegVal(handle, ov5640InitParam, FSL_ARRAY_SIZE(ov5640InitParam));
     if (kStatus_Success != status)
     {
         return status;
@@ -966,7 +966,7 @@ status_t OV5640_Deinit(camera_device_handle_t *handle)
 
 status_t OV5640_Control(camera_device_handle_t *handle, camera_device_cmd_t cmd, int32_t arg)
 {
-    for (uint8_t i = 0; i < ARRAY_SIZE(s_ov5640CmdFuncMap); i++)
+    for (uint8_t i = 0; i < FSL_ARRAY_SIZE(s_ov5640CmdFuncMap); i++)
     {
         if (s_ov5640CmdFuncMap[i].cmd == cmd)
         {
@@ -1075,7 +1075,7 @@ status_t OV5640_SetLightMode(camera_device_handle_t *handle, int32_t lightMode)
     status_t status;
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_ov5640LightModeConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_ov5640LightModeConfigs); i++)
     {
         if (lightMode == (int32_t)s_ov5640LightModeConfigs[i].lightMode)
         {
@@ -1103,7 +1103,7 @@ status_t OV5640_SetSpecialEffect(camera_device_handle_t *handle, int32_t effect)
     status_t status;
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_ov5640SpecialEffectConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_ov5640SpecialEffectConfigs); i++)
     {
         if (effect == (int32_t)s_ov5640SpecialEffectConfigs[i].effect)
         {

--- a/mcux/mcux-sdk/components/video/camera/device/ov7725/fsl_ov7725.c
+++ b/mcux/mcux-sdk/components/video/camera/device/ov7725/fsl_ov7725.c
@@ -319,7 +319,7 @@ static status_t OV7725_SetClockConfig(camera_device_handle_t *handle, uint32_t f
 {
     status_t status;
 
-    for (uint32_t i = 0; i < ARRAY_SIZE(ov7725ClockConfigs); i++)
+    for (uint32_t i = 0; i < FSL_ARRAY_SIZE(ov7725ClockConfigs); i++)
     {
         if ((ov7725ClockConfigs[i].frameRate_Hz == frameRate_Hz) && (ov7725ClockConfigs[i].inputClk_Hz == inputClk_Hz))
         {
@@ -339,7 +339,7 @@ static status_t OV7725_SetClockConfig(camera_device_handle_t *handle, uint32_t f
 
 static status_t OV7725_SetPixelFormat(camera_device_handle_t *handle, video_pixel_format_t fmt)
 {
-    for (uint8_t i = 0; i < ARRAY_SIZE(ov7725PixelFormatConfigs); i++)
+    for (uint8_t i = 0; i < FSL_ARRAY_SIZE(ov7725PixelFormatConfigs); i++)
     {
         if (ov7725PixelFormatConfigs[i].fmt == fmt)
         {
@@ -419,7 +419,7 @@ status_t OV7725_Init(camera_device_handle_t *handle, const camera_config_t *conf
     OV7725_DelayMs(2);
 
     /* Start configuration */
-    status = OV7725_WriteRegs(handle, ov7725InitRegs, ARRAY_SIZE(ov7725InitRegs));
+    status = OV7725_WriteRegs(handle, ov7725InitRegs, FSL_ARRAY_SIZE(ov7725InitRegs));
     if (kStatus_Success != status)
     {
         return status;
@@ -514,7 +514,7 @@ status_t OV7725_SetSpecialEffect(camera_device_handle_t *handle, int32_t effect)
     uint8_t i;
     status_t status;
 
-    for (i = 0; i < ARRAY_SIZE(ov7725SpecialEffectConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(ov7725SpecialEffectConfigs); i++)
     {
         if (effect == (int32_t)ov7725SpecialEffectConfigs[i].effect)
         {
@@ -586,7 +586,7 @@ status_t OV7725_SetLightMode(camera_device_handle_t *handle, int32_t lightMode)
     uint8_t i;
     status_t status;
 
-    for (i = 0; i < ARRAY_SIZE(ov7725LightModeConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(ov7725LightModeConfigs); i++)
     {
         if (lightMode == (int32_t)ov7725LightModeConfigs[i].lightMode)
         {
@@ -607,7 +607,7 @@ status_t OV7725_SetNightMode(camera_device_handle_t *handle, int32_t nightMode)
 {
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(ov7725NightModeConfigs); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(ov7725NightModeConfigs); i++)
     {
         if (nightMode == (int32_t)ov7725NightModeConfigs[i].nightMode)
         {
@@ -628,7 +628,7 @@ status_t OV7725_Deinit(camera_device_handle_t *handle)
 
 status_t OV7725_Control(camera_device_handle_t *handle, camera_device_cmd_t cmd, int32_t arg)
 {
-    for (uint8_t i = 0; i < ARRAY_SIZE(ov7725CmdFuncMap); i++)
+    for (uint8_t i = 0; i < FSL_ARRAY_SIZE(ov7725CmdFuncMap); i++)
     {
         if (ov7725CmdFuncMap[i].cmd == cmd)
         {

--- a/mcux/mcux-sdk/components/video/camera/receiver/isi/fsl_isi_camera_adapter.c
+++ b/mcux/mcux-sdk/components/video/camera/receiver/isi/fsl_isi_camera_adapter.c
@@ -93,7 +93,7 @@ static status_t ISI_ADAPTER_GetIsiOutFormat(video_pixel_format_t fourccFormat, i
 {
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_isiOutputFormatMap); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_isiOutputFormatMap); i++)
     {
         if (s_isiOutputFormatMap[i].fourccFormat == fourccFormat)
         {

--- a/mcux/mcux-sdk/components/video/display/adv7535/fsl_adv7535.c
+++ b/mcux/mcux-sdk/components/video/display/adv7535/fsl_adv7535.c
@@ -159,10 +159,10 @@ status_t ADV7535_Init(display_handle_t *handle, const display_config_t *config)
      */
     ADV7535_CHECK_RET(ADV7535_I2C_ModifyReg(handle, ADV7535_DSI_CEC_ADDR, 0x03, (0x01U << 1U), 0U << 1));
 
-    ADV7535_CHECK_RET(ADV7535_I2C_ModifyRegs(handle, mainI2cAddr, s_adv7533FixedRegs, ARRAY_SIZE(s_adv7533FixedRegs)));
+    ADV7535_CHECK_RET(ADV7535_I2C_ModifyRegs(handle, mainI2cAddr, s_adv7533FixedRegs, FSL_ARRAY_SIZE(s_adv7533FixedRegs)));
 
     status =
-        ADV7535_I2C_ModifyRegs(handle, ADV7535_DSI_CEC_ADDR, s_adv7533CecFixedRegs, ARRAY_SIZE(s_adv7533CecFixedRegs));
+        ADV7535_I2C_ModifyRegs(handle, ADV7535_DSI_CEC_ADDR, s_adv7533CecFixedRegs, FSL_ARRAY_SIZE(s_adv7533CecFixedRegs));
     if (kStatus_Success != status)
     {
         return status;

--- a/mcux/mcux-sdk/components/video/display/dc/elcdif/fsl_dc_fb_elcdif.c
+++ b/mcux/mcux-sdk/components/video/display/dc/elcdif/fsl_dc_fb_elcdif.c
@@ -54,7 +54,7 @@ static status_t DC_FB_ELCDIF_GetPixelFormat(video_pixel_format_t input, elcdif_p
 {
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_elcdifPixelFormatMap); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_elcdifPixelFormatMap); i++)
     {
         if (s_elcdifPixelFormatMap[i].videoFormat == input)
         {

--- a/mcux/mcux-sdk/components/video/display/dc/lcdif/fsl_dc_fb_lcdif.c
+++ b/mcux/mcux-sdk/components/video/display/dc/lcdif/fsl_dc_fb_lcdif.c
@@ -51,7 +51,7 @@ static status_t DC_FB_LCDIF_GetPixelFormat(video_pixel_format_t input, lcdif_fb_
 {
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_lcdifPixelFormatMap); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_lcdifPixelFormatMap); i++)
     {
         if (s_lcdifPixelFormatMap[i].videoFormat == input)
         {

--- a/mcux/mcux-sdk/components/video/display/dc/lcdifv2/fsl_dc_fb_lcdifv2.c
+++ b/mcux/mcux-sdk/components/video/display/dc/lcdifv2/fsl_dc_fb_lcdifv2.c
@@ -56,7 +56,7 @@ static status_t DC_FB_LCDIFV2_GetPixelFormat(video_pixel_format_t input, lcdifv2
 {
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_lcdifv2PixelFormatMap); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_lcdifv2PixelFormatMap); i++)
     {
         if (s_lcdifv2PixelFormatMap[i].videoFormat == input)
         {

--- a/mcux/mcux-sdk/components/video/display/hx8394/fsl_hx8394.c
+++ b/mcux/mcux-sdk/components/video/display/hx8394/fsl_hx8394.c
@@ -131,7 +131,7 @@ status_t HX8394_Init(display_handle_t *handle, const display_config_t *config)
 
     if (kStatus_Success == status)
     {
-        for (i = 0; i < ARRAY_SIZE(s_hx8394Cmds); i++)
+        for (i = 0; i < FSL_ARRAY_SIZE(s_hx8394Cmds); i++)
         {
             status = MIPI_DSI_GenericWrite(dsiDevice, s_hx8394Cmds[i].cmd, (int32_t)s_hx8394Cmds[i].cmdLen);
 

--- a/mcux/mcux-sdk/components/video/display/rm67162/fsl_rm67162.c
+++ b/mcux/mcux-sdk/components/video/display/rm67162/fsl_rm67162.c
@@ -370,12 +370,12 @@ status_t RM67162_Init(display_handle_t *handle, const display_config_t *config)
     if (config->resolution == FSL_VIDEO_RESOLUTION(400, 400))
     {
         initSetting     = rm67162InitSetting_400x400;
-        initSettingSize = ARRAY_SIZE(rm67162InitSetting_400x400);
+        initSettingSize = FSL_ARRAY_SIZE(rm67162InitSetting_400x400);
     }
     else if (config->resolution == FSL_VIDEO_RESOLUTION(400, 392))
     {
         initSetting     = rm67162InitSetting_400x392;
-        initSettingSize = ARRAY_SIZE(rm67162InitSetting_400x392);
+        initSettingSize = FSL_ARRAY_SIZE(rm67162InitSetting_400x392);
     }
     else
     {

--- a/mcux/mcux-sdk/components/video/display/rm67191/fsl_rm67191.c
+++ b/mcux/mcux-sdk/components/video/display/rm67191/fsl_rm67191.c
@@ -69,7 +69,7 @@ status_t RM67191_Init(display_handle_t *handle, const display_config_t *config)
     RM67191_DelayMs(20);
 
     /* Set the LCM init settings. */
-    for (i = 0; i < ARRAY_SIZE(lcmInitSetting); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(lcmInitSetting); i++)
     {
         status = MIPI_DSI_GenericWrite(dsiDevice, lcmInitSetting[i], 2);
 
@@ -81,7 +81,7 @@ status_t RM67191_Init(display_handle_t *handle, const display_config_t *config)
 
     /* Change to send user command. */
     const uint8_t rm67191UserCmdEntry[] = {RM67191_WRMAUCCTR, 0x00};
-    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191UserCmdEntry, (int32_t)ARRAY_SIZE(rm67191UserCmdEntry));
+    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191UserCmdEntry, (int32_t)FSL_ARRAY_SIZE(rm67191UserCmdEntry));
     if (kStatus_Success != status)
     {
         return status;
@@ -98,7 +98,7 @@ status_t RM67191_Init(display_handle_t *handle, const display_config_t *config)
 
     /* Set DSI mode */
     const uint8_t rm67191DsiMode[] = {RM67191_SETDSIMODE, 0x03};
-    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191DsiMode, (int32_t)ARRAY_SIZE(rm67191DsiMode));
+    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191DsiMode, (int32_t)FSL_ARRAY_SIZE(rm67191DsiMode));
     if (kStatus_Success != status)
     {
         return status;
@@ -106,7 +106,7 @@ status_t RM67191_Init(display_handle_t *handle, const display_config_t *config)
 
     /* Brightness. */
     const uint8_t rm67191Brightness[] = {RM67191_WRDISBV, 0xff};
-    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191Brightness, (int32_t)ARRAY_SIZE(rm67191Brightness));
+    status = MIPI_DSI_GenericWrite(dsiDevice, rm67191Brightness, (int32_t)FSL_ARRAY_SIZE(rm67191Brightness));
     if (kStatus_Success != status)
     {
         return status;

--- a/mcux/mcux-sdk/components/video/display/rm68191/fsl_rm68191.c
+++ b/mcux/mcux-sdk/components/video/display/rm68191/fsl_rm68191.c
@@ -188,7 +188,7 @@ status_t RM68191_Init(display_handle_t *handle, const display_config_t *config)
     RM68191_DelayMs(5);
 
     /* Set the LCM init settings. */
-    for (i = 0; i < ARRAY_SIZE(s_rm68191InitSetting); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_rm68191InitSetting); i++)
     {
         status = MIPI_DSI_DCS_Write(dsiDevice, s_rm68191InitSetting[i].value, (int32_t)s_rm68191InitSetting[i].len);
 

--- a/mcux/mcux-sdk/components/video/display/rm68200/fsl_rm68200.c
+++ b/mcux/mcux-sdk/components/video/display/rm68200/fsl_rm68200.c
@@ -317,7 +317,7 @@ status_t RM68200_Init(display_handle_t *handle, const display_config_t *config)
     RM68200_DelayMs(5);
 
     /* Set the LCM page0 init settings. */
-    for (i = 0; i < ARRAY_SIZE(lcmInitPage0Setting); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(lcmInitPage0Setting); i++)
     {
         status = MIPI_DSI_GenericWrite(dsiDevice, lcmInitPage0Setting[i], 2);
 
@@ -337,7 +337,7 @@ status_t RM68200_Init(display_handle_t *handle, const display_config_t *config)
     }
 
     /* Set the LCM init settings. */
-    for (i = 0; i < ARRAY_SIZE(lcmInitSetting); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(lcmInitSetting); i++)
     {
         status = MIPI_DSI_GenericWrite(dsiDevice, lcmInitSetting[i], 2);
 

--- a/mcux/mcux-sdk/devices/MIMXRT1165/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1165/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1165/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1165/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1166/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1166/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1166/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1166/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1171/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1171/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1171/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1171/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1172/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1172/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1172/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1172/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1173/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1173/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1173/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1173/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1175/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1175/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1175/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1175/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT1176/drivers/fsl_dcdc.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1176/drivers/fsl_dcdc.c
@@ -51,7 +51,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/devices/MIMXRT1176/drivers/fsl_pmu.c
+++ b/mcux/mcux-sdk/devices/MIMXRT1176/drivers/fsl_pmu.c
@@ -465,7 +465,7 @@ void PMU_GPCSetLpsrDigLdoTargetVoltage(uint32_t setpointMap, pmu_lpsr_dig_target
     uint8_t temp8;
     uint32_t i;
 
-    for (regIndex = 0U; regIndex < ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
+    for (regIndex = 0U; regIndex < FSL_ARRAY_SIZE(lpsrDigTrgRegArray); regIndex++)
     {
         temp8 = (((uint8_t)(setpointMap >> (PMU_LDO_LPSR_DIG_TRG_SPX_REG_SETPOINT_COUNTS * regIndex))) & 0xFU);
         if (temp8 != 0UL)

--- a/mcux/mcux-sdk/devices/MIMXRT595S/project_template/board.c
+++ b/mcux/mcux-sdk/devices/MIMXRT595S/project_template/board.c
@@ -248,7 +248,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/devices/MIMXRT633S/drivers/fsl_power.c
+++ b/mcux/mcux-sdk/devices/MIMXRT633S/drivers/fsl_power.c
@@ -187,7 +187,7 @@ static uint32_t POWER_CalcVoltLevel(const uint32_t *freqLevels, uint32_t num, ui
     }
     else
     {
-        volt = powerLdoVoltLevel[i + ARRAY_SIZE(powerLdoVoltLevel) - num - 1U];
+        volt = powerLdoVoltLevel[i + FSL_ARRAY_SIZE(powerLdoVoltLevel) - num - 1U];
     }
 
     return volt;

--- a/mcux/mcux-sdk/devices/MIMXRT685S/drivers/fsl_power.c
+++ b/mcux/mcux-sdk/devices/MIMXRT685S/drivers/fsl_power.c
@@ -187,7 +187,7 @@ static uint32_t POWER_CalcVoltLevel(const uint32_t *freqLevels, uint32_t num, ui
     }
     else
     {
-        volt = powerLdoVoltLevel[i + ARRAY_SIZE(powerLdoVoltLevel) - num - 1U];
+        volt = powerLdoVoltLevel[i + FSL_ARRAY_SIZE(powerLdoVoltLevel) - num - 1U];
     }
 
     return volt;

--- a/mcux/mcux-sdk/devices/MIMXRT685S/project_template/board.c
+++ b/mcux/mcux-sdk/devices/MIMXRT685S/project_template/board.c
@@ -227,7 +227,7 @@ status_t BOARD_InitPsRam(void)
     FLEXSPI_SetFlashConfig(BOARD_FLEXSPI_PSRAM, &deviceconfig, kFLEXSPI_PortA1);
 
     /* Update LUT table. */
-    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, ARRAY_SIZE(customLUT));
+    FLEXSPI_UpdateLUT(BOARD_FLEXSPI_PSRAM, 0, customLUT, FSL_ARRAY_SIZE(customLUT));
 
     /* Do software reset. */
     FLEXSPI_SoftwareReset(BOARD_FLEXSPI_PSRAM);

--- a/mcux/mcux-sdk/drivers/acmp/fsl_acmp.c
+++ b/mcux/mcux-sdk/drivers/acmp/fsl_acmp.c
@@ -46,7 +46,7 @@ static uint32_t ACMP_GetInstance(CMP_Type *base)
     uint32_t instance = 0U;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_acmpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_acmpBases); instance++)
     {
         if (s_acmpBases[instance] == base)
         {
@@ -54,7 +54,7 @@ static uint32_t ACMP_GetInstance(CMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_acmpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_acmpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/acmp_1/fsl_acmp.c
+++ b/mcux/mcux-sdk/drivers/acmp_1/fsl_acmp.c
@@ -45,7 +45,7 @@ static uint32_t ACMP_GetInstance(ACMP_Type *base)
     uint32_t instance = 0U;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_acmpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_acmpBases); instance++)
     {
         if (s_acmpBases[instance] == base)
         {
@@ -53,7 +53,7 @@ static uint32_t ACMP_GetInstance(ACMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_acmpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_acmpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/adc12/fsl_adc12.c
+++ b/mcux/mcux-sdk/drivers/adc12/fsl_adc12.c
@@ -76,7 +76,7 @@ static uint32_t ADC12_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_adc12Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_adc12Bases); instance++)
     {
         if (s_adc12Bases[instance] == base)
         {
@@ -84,7 +84,7 @@ static uint32_t ADC12_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_adc12Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_adc12Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/adc16/fsl_adc16.c
+++ b/mcux/mcux-sdk/drivers/adc16/fsl_adc16.c
@@ -42,7 +42,7 @@ static uint32_t ADC16_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_adc16Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_adc16Bases); instance++)
     {
         if (s_adc16Bases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t ADC16_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_adc16Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_adc16Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/adc_12b1msps_sar/fsl_adc.c
+++ b/mcux/mcux-sdk/drivers/adc_12b1msps_sar/fsl_adc.c
@@ -42,7 +42,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_adcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_adcBases); instance++)
     {
         if (s_adcBases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_adcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_adcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/adc_5v12b_ll18_015/fsl_adc.c
+++ b/mcux/mcux-sdk/drivers/adc_5v12b_ll18_015/fsl_adc.c
@@ -41,7 +41,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_adcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_adcBases); instance++)
     {
         if (s_adcBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_adcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_adcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/afe/fsl_afe.c
+++ b/mcux/mcux-sdk/drivers/afe/fsl_afe.c
@@ -32,14 +32,14 @@ static uint32_t AFE_GetInstance(AFE_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_AFEBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_AFEBases); instance++)
     {
         if (s_AFEBases[instance] == base)
         {
             break;
         }
     }
-    assert(instance < ARRAY_SIZE(s_AFEBases));
+    assert(instance < FSL_ARRAY_SIZE(s_AFEBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/anactrl/fsl_anactrl.c
+++ b/mcux/mcux-sdk/drivers/anactrl/fsl_anactrl.c
@@ -46,7 +46,7 @@ static uint32_t ANACTRL_GetInstance(ANACTRL_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_anactrlBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_anactrlBases); instance++)
     {
         if (s_anactrlBases[instance] == base)
         {
@@ -54,7 +54,7 @@ static uint32_t ANACTRL_GetInstance(ANACTRL_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_anactrlBases));
+    assert(instance < FSL_ARRAY_SIZE(s_anactrlBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/aoi/fsl_aoi.c
+++ b/mcux/mcux-sdk/drivers/aoi/fsl_aoi.c
@@ -42,7 +42,7 @@ static uint32_t AOI_GetInstance(AOI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_aoiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_aoiBases); instance++)
     {
         if (s_aoiBases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t AOI_GetInstance(AOI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_aoiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_aoiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/asrc/fsl_asrc.c
+++ b/mcux/mcux-sdk/drivers/asrc/fsl_asrc.c
@@ -78,7 +78,7 @@ static status_t ASRC_ProcessSelection(uint32_t inSampleRate,
 /* Base pointer array */
 static ASRC_Type *const s_asrcBases[] = ASRC_BASE_PTRS;
 /*!@brief asrc handle pointer */
-static asrc_handle_t *s_asrcHandle[ARRAY_SIZE(s_asrcBases)][FSL_ASRC_CHANNEL_PAIR_COUNT];
+static asrc_handle_t *s_asrcHandle[FSL_ARRAY_SIZE(s_asrcBases)][FSL_ASRC_CHANNEL_PAIR_COUNT];
 /* IRQ number array */
 static const IRQn_Type s_asrcIRQ[] = ASRC_IRQS;
 
@@ -96,7 +96,7 @@ uint32_t ASRC_GetInstance(ASRC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_asrcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_asrcBases); instance++)
     {
         if (s_asrcBases[instance] == base)
         {
@@ -104,7 +104,7 @@ uint32_t ASRC_GetInstance(ASRC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_asrcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_asrcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk/drivers/caam/fsl_caam.c
@@ -437,7 +437,7 @@ static status_t caam_in_job_ring_add(CAAM_Type *base, caam_job_ring_t jobRing, u
     {
         s_jr0->inputJobRing[s_jrIndex0] = (ADD_OFFSET((uint32_t)descaddr));
         s_jrIndex0++;
-        if (s_jrIndex0 >= ARRAY_SIZE(s_jr0->inputJobRing))
+        if (s_jrIndex0 >= FSL_ARRAY_SIZE(s_jr0->inputJobRing))
         {
             s_jrIndex0 = 0;
         }
@@ -446,7 +446,7 @@ static status_t caam_in_job_ring_add(CAAM_Type *base, caam_job_ring_t jobRing, u
     {
         s_jr1->inputJobRing[s_jrIndex1] = ADD_OFFSET((uint32_t)descaddr);
         s_jrIndex1++;
-        if (s_jrIndex1 >= ARRAY_SIZE(s_jr1->inputJobRing))
+        if (s_jrIndex1 >= FSL_ARRAY_SIZE(s_jr1->inputJobRing))
         {
             s_jrIndex1 = 0;
         }
@@ -455,7 +455,7 @@ static status_t caam_in_job_ring_add(CAAM_Type *base, caam_job_ring_t jobRing, u
     {
         s_jr2->inputJobRing[s_jrIndex2] = ADD_OFFSET((uint32_t)descaddr);
         s_jrIndex2++;
-        if (s_jrIndex2 >= ARRAY_SIZE(s_jr2->inputJobRing))
+        if (s_jrIndex2 >= FSL_ARRAY_SIZE(s_jr2->inputJobRing))
         {
             s_jrIndex2 = 0;
         }
@@ -464,7 +464,7 @@ static status_t caam_in_job_ring_add(CAAM_Type *base, caam_job_ring_t jobRing, u
     {
         s_jr3->inputJobRing[s_jrIndex3] = ADD_OFFSET((uint32_t)descaddr);
         s_jrIndex3++;
-        if (s_jrIndex3 >= ARRAY_SIZE(s_jr3->inputJobRing))
+        if (s_jrIndex3 >= FSL_ARRAY_SIZE(s_jr3->inputJobRing))
         {
             s_jrIndex3 = 0;
         }
@@ -533,22 +533,22 @@ static status_t caam_out_job_ring_test_and_remove(
     if (jobRing == kCAAM_JobRing0)
     {
         jr        = s_jr0->outputJobRing;
-        jrEntries = ARRAY_SIZE(s_jr0->outputJobRing);
+        jrEntries = FSL_ARRAY_SIZE(s_jr0->outputJobRing);
     }
     else if (jobRing == kCAAM_JobRing1)
     {
         jr        = s_jr1->outputJobRing;
-        jrEntries = ARRAY_SIZE(s_jr1->outputJobRing);
+        jrEntries = FSL_ARRAY_SIZE(s_jr1->outputJobRing);
     }
     else if (jobRing == kCAAM_JobRing2)
     {
         jr        = s_jr2->outputJobRing;
-        jrEntries = ARRAY_SIZE(s_jr2->outputJobRing);
+        jrEntries = FSL_ARRAY_SIZE(s_jr2->outputJobRing);
     }
     else if (jobRing == kCAAM_JobRing3)
     {
         jr        = s_jr3->outputJobRing;
-        jrEntries = ARRAY_SIZE(s_jr3->outputJobRing);
+        jrEntries = FSL_ARRAY_SIZE(s_jr3->outputJobRing);
     }
     else
     {
@@ -753,7 +753,7 @@ status_t caam_aes_gcm_non_blocking(CAAM_Type *base,
     }
 
     /* get template descriptor and it's size */
-    uint32_t descriptorSize = ARRAY_SIZE(templateAesGcm);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateAesGcm);
     (void)caam_memcpy(descriptor, templateAesGcm, sizeof(templateAesGcm));
 
     /* add descriptor size */
@@ -984,7 +984,7 @@ status_t caam_aes_ccm_non_blocking(CAAM_Type *base,
     status_t status;
 
     /* get template descriptor and it's size */
-    uint32_t descriptorSize = ARRAY_SIZE(templateAesCcm);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateAesCcm);
     (void)caam_memcpy(descriptor, templateAesCcm, sizeof(templateAesCcm));
 
     status = caam_aes_ccm_check_input_args(base, input, iv, key, output, ivSize, aadSize, keySize, tagSize);
@@ -1239,7 +1239,7 @@ status_t CAAM_AES_CryptCtrNonBlocking(CAAM_Type *base,
     }
 
     /* get template descriptor and it's size */
-    descriptorSize = ARRAY_SIZE(templateAesCtr);
+    descriptorSize = FSL_ARRAY_SIZE(templateAesCtr);
     (void)caam_memcpy(descriptor, templateAesCtr, sizeof(templateAesCtr));
 
     /* add descriptor size */
@@ -1356,7 +1356,7 @@ status_t CAAM_AES_EncryptEcbNonBlocking(CAAM_Type *base,
         return kStatus_InvalidArgument;
     }
 
-    descriptorSize = ARRAY_SIZE(templateAesEcb);
+    descriptorSize = FSL_ARRAY_SIZE(templateAesEcb);
     (void)caam_memcpy(descriptor, templateAesEcb, sizeof(templateAesEcb));
     descriptor[0] |= (descriptorSize & DESC_SIZE_MASK);
     descriptor[1] |= (keySize & DESC_KEY_SIZE_MASK);
@@ -1408,7 +1408,7 @@ status_t CAAM_AES_DecryptEcbNonBlocking(CAAM_Type *base,
         return kStatus_InvalidArgument;
     }
 
-    descriptorSize = ARRAY_SIZE(templateAesEcb);
+    descriptorSize = FSL_ARRAY_SIZE(templateAesEcb);
     (void)caam_memcpy(descriptor, templateAesEcb, sizeof(templateAesEcb));
     descriptor[0] |= (descriptorSize & DESC_SIZE_MASK);
     descriptor[1] |= (keySize & DESC_KEY_SIZE_MASK);
@@ -1479,7 +1479,7 @@ status_t CAAM_AES_EncryptCbcNonBlocking(CAAM_Type *base,
     }
 
     /* get template descriptor and it's size */
-    descriptorSize = ARRAY_SIZE(templateAesCbc);
+    descriptorSize = FSL_ARRAY_SIZE(templateAesCbc);
     (void)caam_memcpy(descriptor, templateAesCbc, sizeof(templateAesCbc));
 
     /* add descriptor size */
@@ -1547,7 +1547,7 @@ status_t CAAM_AES_DecryptCbcNonBlocking(CAAM_Type *base,
     }
 
     /* get template descriptor and it's size */
-    descriptorSize = ARRAY_SIZE(templateAesCbc);
+    descriptorSize = FSL_ARRAY_SIZE(templateAesCbc);
     (void)caam_memcpy(descriptor, templateAesCbc, sizeof(templateAesCbc));
 
     /* add descriptor size */
@@ -1716,8 +1716,8 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
     s_jr0 = config->jobRingInterface[0];
     (void)memset(s_jr0, 0, sizeof(*s_jr0));
     s_jrIndex0 = 0;
-    caam_job_ring_set_base_address_and_size(base, kCAAM_JobRing0, s_jr0->inputJobRing, ARRAY_SIZE(s_jr0->inputJobRing),
-                                            s_jr0->outputJobRing, ARRAY_SIZE(s_jr0->outputJobRing) / 2U);
+    caam_job_ring_set_base_address_and_size(base, kCAAM_JobRing0, s_jr0->inputJobRing, FSL_ARRAY_SIZE(s_jr0->inputJobRing),
+                                            s_jr0->outputJobRing, FSL_ARRAY_SIZE(s_jr0->outputJobRing) / 2U);
 
     if (config->jobRingInterface[1] != NULL)
     {
@@ -1725,8 +1725,8 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
         (void)memset(s_jr1, 0, sizeof(*s_jr1));
         s_jrIndex1 = 0;
         caam_job_ring_set_base_address_and_size(base, kCAAM_JobRing1, s_jr1->inputJobRing,
-                                                ARRAY_SIZE(s_jr1->inputJobRing), s_jr1->outputJobRing,
-                                                ARRAY_SIZE(s_jr1->outputJobRing) / 2U);
+                                                FSL_ARRAY_SIZE(s_jr1->inputJobRing), s_jr1->outputJobRing,
+                                                FSL_ARRAY_SIZE(s_jr1->outputJobRing) / 2U);
     }
 
     if (config->jobRingInterface[2] != NULL)
@@ -1735,8 +1735,8 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
         (void)memset(s_jr2, 0, sizeof(*s_jr2));
         s_jrIndex2 = 0;
         caam_job_ring_set_base_address_and_size(base, kCAAM_JobRing2, s_jr2->inputJobRing,
-                                                ARRAY_SIZE(s_jr2->inputJobRing), s_jr2->outputJobRing,
-                                                ARRAY_SIZE(s_jr2->outputJobRing) / 2U);
+                                                FSL_ARRAY_SIZE(s_jr2->inputJobRing), s_jr2->outputJobRing,
+                                                FSL_ARRAY_SIZE(s_jr2->outputJobRing) / 2U);
     }
 
     if (config->jobRingInterface[3] != NULL)
@@ -1745,8 +1745,8 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
         (void)memset(s_jr3, 0, sizeof(*s_jr3));
         s_jrIndex3 = 0;
         caam_job_ring_set_base_address_and_size(base, kCAAM_JobRing3, s_jr3->inputJobRing,
-                                                ARRAY_SIZE(s_jr3->inputJobRing), s_jr3->outputJobRing,
-                                                ARRAY_SIZE(s_jr3->outputJobRing) / 2U);
+                                                FSL_ARRAY_SIZE(s_jr3->inputJobRing), s_jr3->outputJobRing,
+                                                FSL_ARRAY_SIZE(s_jr3->outputJobRing) / 2U);
     }
 
     /*
@@ -2741,7 +2741,7 @@ static status_t caam_hash_schedule_input_data(CAAM_Type *base,
                                               uint32_t keySize)
 {
     BUILD_ASSURE(sizeof(templateHash) <= sizeof(caam_desc_hash_t), caam_desc_hash_t_size);
-    uint32_t descriptorSize = ARRAY_SIZE(templateHash);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateHash);
     uint32_t algOutSize     = 0;
 
     bool isSha = caam_hash_alg_is_sha(algo); /* MDHA engine */
@@ -2966,7 +2966,7 @@ status_t CAAM_HASH_Init(CAAM_Type *base,
     }
 
     ctxInternal->blksz = 0u;
-    for (i = 0; i < ARRAY_SIZE(ctxInternal->blk.w); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(ctxInternal->blk.w); i++)
     {
         ctxInternal->blk.w[i] = 0u;
     }
@@ -3687,7 +3687,7 @@ status_t CAAM_RNG_GetRandomDataNonBlocking(CAAM_Type *base,
 {
     /* create job descriptor */
     BUILD_ASSURE(sizeof(templateRng) <= sizeof(caam_desc_rng_t), caam_desc_rng_t_size);
-    uint32_t descriptorSize = ARRAY_SIZE(templateRng);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateRng);
 
     (void)caam_memcpy(descriptor, templateRng, sizeof(templateRng));
     descriptor[0] |= (descriptorSize & DESC_SIZE_MASK);
@@ -3809,7 +3809,7 @@ status_t CAAM_DES_EncryptEcbNonBlocking(CAAM_Type *base,
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
     BUILD_ASSURE(sizeof(caam_desc_cipher_des_t) >= sizeof(templateCipherDes), caam_desc_cipher_des_t_size);
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -3893,7 +3893,7 @@ status_t CAAM_DES_DecryptEcbNonBlocking(CAAM_Type *base,
                                         size_t size,
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -3983,7 +3983,7 @@ status_t CAAM_DES_EncryptCbcNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4074,7 +4074,7 @@ status_t CAAM_DES_DecryptCbcNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4163,7 +4163,7 @@ status_t CAAM_DES_EncryptCfbNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4252,7 +4252,7 @@ status_t CAAM_DES_DecryptCfbNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4343,7 +4343,7 @@ status_t CAAM_DES_EncryptOfbNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4434,7 +4434,7 @@ status_t CAAM_DES_DecryptOfbNonBlocking(CAAM_Type *base,
                                         const uint8_t iv[CAAM_DES_IV_SIZE],
                                         const uint8_t key[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4523,7 +4523,7 @@ status_t CAAM_DES2_EncryptEcbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4613,7 +4613,7 @@ status_t CAAM_DES2_DecryptEcbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4709,7 +4709,7 @@ status_t CAAM_DES2_EncryptCbcNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4806,7 +4806,7 @@ status_t CAAM_DES2_DecryptCbcNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4900,7 +4900,7 @@ status_t CAAM_DES2_EncryptCfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -4995,7 +4995,7 @@ status_t CAAM_DES2_DecryptCfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5091,7 +5091,7 @@ status_t CAAM_DES2_EncryptOfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5188,7 +5188,7 @@ status_t CAAM_DES2_DecryptOfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key1[CAAM_DES_KEY_SIZE],
                                          const uint8_t key2[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5282,7 +5282,7 @@ status_t CAAM_DES3_EncryptEcbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5377,7 +5377,7 @@ status_t CAAM_DES3_DecryptEcbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5479,7 +5479,7 @@ status_t CAAM_DES3_EncryptCbcNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5581,7 +5581,7 @@ status_t CAAM_DES3_DecryptCbcNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5679,7 +5679,7 @@ status_t CAAM_DES3_EncryptCfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5779,7 +5779,7 @@ status_t CAAM_DES3_DecryptCfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5879,7 +5879,7 @@ status_t CAAM_DES3_EncryptOfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -5981,7 +5981,7 @@ status_t CAAM_DES3_DecryptOfbNonBlocking(CAAM_Type *base,
                                          const uint8_t key2[CAAM_DES_KEY_SIZE],
                                          const uint8_t key3[CAAM_DES_KEY_SIZE])
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateCipherDes);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateCipherDes);
 
     /* DES do not support EXTENDED lenght in FIFO LOAD/STORE command.
      * Data lenght limit is 2^16 bytes = 65 536 bytes.
@@ -6225,7 +6225,7 @@ static status_t caam_pkha_algorithm_operation_command(CAAM_Type *base,
                                                       size_t *resultSize)
 {
     uint32_t clearMask      = 0;
-    uint32_t descriptorSize = ARRAY_SIZE(templateArithmeticPKHA);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateArithmeticPKHA);
     BUILD_ASSURE(sizeof(caam_desc_pkha_t) >= sizeof(templateArithmeticPKHA), caam_desc_pkha_t_size_too_low);
 
     /* initialize descriptor from template */
@@ -6358,7 +6358,7 @@ static status_t caam_pkha_ecc_algorithm_operation_command(CAAM_Type *base,
                                                           caam_pkha_ecc_point_t *result,
                                                           caam_pkha_mode_params_t *params)
 {
-    uint32_t descriptorSize = ARRAY_SIZE(templateArithmeticECC);
+    uint32_t descriptorSize = FSL_ARRAY_SIZE(templateArithmeticECC);
     BUILD_ASSURE(sizeof(caam_desc_pkha_ecc_t) >= sizeof(templateArithmeticECC), caam_desc_pkha_ecc_t_size_too_low);
 
     /* initialize descriptor from template */

--- a/mcux/mcux-sdk/drivers/cache/cache64/fsl_cache.c
+++ b/mcux/mcux-sdk/drivers/cache/cache64/fsl_cache.c
@@ -53,7 +53,7 @@ uint32_t CACHE64_GetInstance(CACHE64_POLSEL_Type *base)
 {
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_cache64polselBases); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_cache64polselBases); i++)
     {
         if (base == s_cache64polselBases[i])
         {
@@ -61,7 +61,7 @@ uint32_t CACHE64_GetInstance(CACHE64_POLSEL_Type *base)
         }
     }
 
-    assert(i < ARRAY_SIZE(s_cache64polselBases));
+    assert(i < FSL_ARRAY_SIZE(s_cache64polselBases));
 
     return i;
 }
@@ -77,7 +77,7 @@ uint32_t CACHE64_GetInstanceByAddr(uint32_t address)
 {
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_cache64ctrlBases); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_cache64ctrlBases); i++)
     {
         if ((address >= s_cache64PhymemBases[i]) && (address < s_cache64PhymemBases[i] + s_cache64PhymemSizes[i]))
         {
@@ -212,7 +212,7 @@ void CACHE64_InvalidateCacheByRange(uint32_t address, uint32_t size_byte)
     uint32_t endLim;
     CACHE64_CTRL_Type *base;
 
-    if (instance >= ARRAY_SIZE(s_cache64ctrlBases))
+    if (instance >= FSL_ARRAY_SIZE(s_cache64ctrlBases))
     {
         return;
     }
@@ -275,7 +275,7 @@ void CACHE64_CleanCacheByRange(uint32_t address, uint32_t size_byte)
     uint32_t endLim;
     CACHE64_CTRL_Type *base;
 
-    if (instance >= ARRAY_SIZE(s_cache64ctrlBases))
+    if (instance >= FSL_ARRAY_SIZE(s_cache64ctrlBases))
     {
         return;
     }
@@ -340,7 +340,7 @@ void CACHE64_CleanInvalidateCacheByRange(uint32_t address, uint32_t size_byte)
     uint32_t endLim;
     CACHE64_CTRL_Type *base;
 
-    if (instance >= ARRAY_SIZE(s_cache64ctrlBases))
+    if (instance >= FSL_ARRAY_SIZE(s_cache64ctrlBases))
     {
         return;
     }

--- a/mcux/mcux-sdk/drivers/capt/fsl_capt.c
+++ b/mcux/mcux-sdk/drivers/capt/fsl_capt.c
@@ -50,7 +50,7 @@ static uint32_t CAPT_GetInstance(CAPT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_captBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_captBases); instance++)
     {
         if (s_captBases[instance] == base)
         {
@@ -58,7 +58,7 @@ static uint32_t CAPT_GetInstance(CAPT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_captBases));
+    assert(instance < FSL_ARRAY_SIZE(s_captBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/cau3/fsl_cau3.c
+++ b/mcux/mcux-sdk/drivers/cau3/fsl_cau3.c
@@ -4517,7 +4517,7 @@ status_t CAU3_CHACHA20_POLY1305_SetKey(CAU3_Type *base, cau3_handle_t *handle, c
         uint32_t w[8];
     } tempKey;
 
-    for (uint32_t i = 0; i < ARRAY_SIZE(tempKey.w); i++)
+    for (uint32_t i = 0; i < FSL_ARRAY_SIZE(tempKey.w); i++)
     {
         tempKey.w[i] = __REV(((const uint32_t *)(uintptr_t)key)[i]);
     }

--- a/mcux/mcux-sdk/drivers/cmp/fsl_cmp.c
+++ b/mcux/mcux-sdk/drivers/cmp/fsl_cmp.c
@@ -41,7 +41,7 @@ static uint32_t CMP_GetInstance(CMP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_cmpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_cmpBases); instance++)
     {
         if (s_cmpBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t CMP_GetInstance(CMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_cmpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_cmpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/cmt/fsl_cmt.c
+++ b/mcux/mcux-sdk/drivers/cmt/fsl_cmt.c
@@ -65,7 +65,7 @@ static uint32_t CMT_GetInstance(CMT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_cmtBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_cmtBases); instance++)
     {
         if (s_cmtBases[instance] == base)
         {
@@ -73,7 +73,7 @@ static uint32_t CMT_GetInstance(CMT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_cmtBases));
+    assert(instance < FSL_ARRAY_SIZE(s_cmtBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/common/fsl_common.h
+++ b/mcux/mcux-sdk/drivers/common/fsl_common.h
@@ -232,9 +232,7 @@ typedef int32_t status_t;
 /* @} */
 
 /*! @brief Computes the number of elements in an array. */
-#if !defined(ARRAY_SIZE)
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
-#endif
+#define FSL_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 /*! @name UINT16_MAX/UINT32_MAX value */
 /* @{ */

--- a/mcux/mcux-sdk/drivers/csi/fsl_csi.c
+++ b/mcux/mcux-sdk/drivers/csi/fsl_csi.c
@@ -147,9 +147,9 @@ static const clock_ip_name_t s_csiClocks[] = CSI_CLOCKS;
 
 /* Array for the CSI driver handle. */
 #if !CSI_DRIVER_FRAG_MODE
-static csi_handle_t *s_csiHandle[ARRAY_SIZE(s_csiBases)];
+static csi_handle_t *s_csiHandle[FSL_ARRAY_SIZE(s_csiBases)];
 #else
-static csi_frag_handle_t *s_csiHandle[ARRAY_SIZE(s_csiBases)];
+static csi_frag_handle_t *s_csiHandle[FSL_ARRAY_SIZE(s_csiBases)];
 #endif
 
 /* Array of CSI IRQ number. */
@@ -170,7 +170,7 @@ static uint32_t CSI_GetInstance(CSI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_csiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_csiBases); instance++)
     {
         if (s_csiBases[instance] == base)
         {
@@ -178,7 +178,7 @@ static uint32_t CSI_GetInstance(CSI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_csiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_csiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dac/fsl_dac.c
+++ b/mcux/mcux-sdk/drivers/dac/fsl_dac.c
@@ -41,7 +41,7 @@ static uint32_t DAC_GetInstance(DAC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dacBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dacBases); instance++)
     {
         if (s_dacBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t DAC_GetInstance(DAC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dacBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dacBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dac12/fsl_dac12.c
+++ b/mcux/mcux-sdk/drivers/dac12/fsl_dac12.c
@@ -42,7 +42,7 @@ static uint32_t DAC12_GetInstance(DAC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dac12Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dac12Bases); instance++)
     {
         if (s_dac12Bases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t DAC12_GetInstance(DAC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dac12Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_dac12Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dac32/fsl_dac32.c
+++ b/mcux/mcux-sdk/drivers/dac32/fsl_dac32.c
@@ -41,7 +41,7 @@ static uint32_t DAC32_GetInstance(DAC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dac32Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dac32Bases); instance++)
     {
         if (s_dac32Bases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t DAC32_GetInstance(DAC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dac32Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_dac32Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dac_1/fsl_dac.c
+++ b/mcux/mcux-sdk/drivers/dac_1/fsl_dac.c
@@ -42,7 +42,7 @@ static uint32_t DAC_GetInstance(LPDAC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dacBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dacBases); instance++)
     {
         if (s_dacBases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t DAC_GetInstance(LPDAC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dacBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dacBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dcdc_1/fsl_dcdc.c
+++ b/mcux/mcux-sdk/drivers/dcdc_1/fsl_dcdc.c
@@ -52,7 +52,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcdcBases); instance++)
     {
         if (s_dcdcBases[instance] == base)
         {
@@ -60,7 +60,7 @@ static uint32_t DCDC_GetInstance(DCDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dcic/fsl_dcic.c
+++ b/mcux/mcux-sdk/drivers/dcic/fsl_dcic.c
@@ -49,7 +49,7 @@ static uint32_t DCIC_GetInstance(DCIC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dcicBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dcicBases); instance++)
     {
         if (s_dcicBases[instance] == base)
         {
@@ -57,7 +57,7 @@ static uint32_t DCIC_GetInstance(DCIC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dcicBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dcicBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dma/fsl_dma.c
+++ b/mcux/mcux-sdk/drivers/dma/fsl_dma.c
@@ -54,7 +54,7 @@ static uint32_t DMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dmaBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dmaBases); instance++)
     {
         if (s_dmaBases[instance] == base)
         {
@@ -62,7 +62,7 @@ static uint32_t DMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dmaBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dmaBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dma3/fsl_edma.c
+++ b/mcux/mcux-sdk/drivers/dma3/fsl_edma.c
@@ -75,7 +75,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_edmaBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_edmaBases); instance++)
     {
         if (s_edmaBases[instance] == base)
         {
@@ -83,7 +83,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_edmaBases));
+    assert(instance < FSL_ARRAY_SIZE(s_edmaBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dmamux/fsl_dmamux.c
+++ b/mcux/mcux-sdk/drivers/dmamux/fsl_dmamux.c
@@ -48,7 +48,7 @@ static uint32_t DMAMUX_GetInstance(DMAMUX_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dmamuxBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dmamuxBases); instance++)
     {
         if (s_dmamuxBases[instance] == base)
         {
@@ -56,7 +56,7 @@ static uint32_t DMAMUX_GetInstance(DMAMUX_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dmamuxBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dmamuxBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dmic/fsl_dmic.c
+++ b/mcux/mcux-sdk/drivers/dmic/fsl_dmic.c
@@ -57,7 +57,7 @@ uint32_t DMIC_GetInstance(DMIC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dmicBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dmicBases); instance++)
     {
         if (s_dmicBases[instance] == base)
         {
@@ -65,7 +65,7 @@ uint32_t DMIC_GetInstance(DMIC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dmicBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dmicBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/dpu/fsl_dpu.c
+++ b/mcux/mcux-sdk/drivers/dpu/fsl_dpu.c
@@ -1007,7 +1007,7 @@ static const clock_ip_name_t s_dpuClock[] = DPU_CLOCKS;
 uint32_t DPU_GetInstance(IRIS_MVPL_Type *base)
 {
     uint32_t instance;
-    const uint32_t dpuArrayCount = ARRAY_SIZE(s_dpuBases);
+    const uint32_t dpuArrayCount = FSL_ARRAY_SIZE(s_dpuBases);
 
     /* Find the instance index from base address mappings. */
     for (instance = 0; instance < dpuArrayCount; instance++)
@@ -1041,7 +1041,7 @@ static bool DPU_CheckBufferAlignment(uint8_t bitsPerPixel, uint32_t baseAddr, ui
     };
 
     /* Find the mask to compare. */
-    for (i = 0U; i < ARRAY_SIZE(s_dpuBufferAlignMask); i++)
+    for (i = 0U; i < FSL_ARRAY_SIZE(s_dpuBufferAlignMask); i++)
     {
         if (s_dpuBufferAlignMask[i][0] == bitsPerPixel)
         {
@@ -1067,7 +1067,7 @@ static uint32_t DPU_GetDynamicRegOffset(dpu_unit_t unit)
     uint32_t offset = 0U;
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_dpuUnitDynamicRegOffsetTable); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_dpuUnitDynamicRegOffsetTable); i++)
     {
         if (s_dpuUnitDynamicRegOffsetTable[i].unit == unit)
         {
@@ -1215,7 +1215,7 @@ void DPU_PreparePathConfig(IRIS_MVPL_Type *base)
     };
 
     /* Disable shadow for all pipelines. */
-    for (uint32_t i = 0; i < ARRAY_SIZE(dpuPipeLines); i++)
+    for (uint32_t i = 0; i < FSL_ARRAY_SIZE(dpuPipeLines); i++)
     {
         (void)DPU_EnableShadowLoad(base, dpuPipeLines[i], false);
     }
@@ -1228,7 +1228,7 @@ void DPU_PreparePathConfig(IRIS_MVPL_Type *base)
         kDPU_LayerBlend0,  kDPU_LayerBlend1,  kDPU_LayerBlend2, kDPU_LayerBlend3,
     };
 
-    for (uint32_t i = 0; i < ARRAY_SIZE(dpuUnits); i++)
+    for (uint32_t i = 0; i < FSL_ARRAY_SIZE(dpuUnits); i++)
     {
         DPU_SetUnitSrc(base, dpuUnits[i], 0U);
     }

--- a/mcux/mcux-sdk/drivers/dspi/fsl_dspi.c
+++ b/mcux/mcux-sdk/drivers/dspi/fsl_dspi.c
@@ -106,7 +106,7 @@ static clock_ip_name_t const s_dspiClock[] = DSPI_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to dspi handles for each instance. */
-static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
+static void *g_dspiHandle[FSL_ARRAY_SIZE(s_dspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
@@ -115,7 +115,7 @@ static dspi_master_isr_t s_dspiMasterIsr;
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
+volatile uint8_t g_dspiDummyData[FSL_ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
  * Code
  *********************************************************************************************************************/
@@ -129,7 +129,7 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dspiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dspiBases); instance++)
     {
         if (s_dspiBases[instance] == base)
         {
@@ -137,7 +137,7 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dspiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dspiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/easrc/fsl_asrc.c
+++ b/mcux/mcux-sdk/drivers/easrc/fsl_asrc.c
@@ -208,7 +208,7 @@ uint32_t ASRC_GetInstance(ASRC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_asrcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_asrcBases); instance++)
     {
         if (s_asrcBases[instance] == base)
         {
@@ -216,7 +216,7 @@ uint32_t ASRC_GetInstance(ASRC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_asrcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_asrcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi.c
+++ b/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi.c
@@ -97,7 +97,7 @@ static void ECSPI_CommonIRQHandler(ECSPI_Type *base, ecspi_master_handle_t *hand
 /*! @brief Base pointer array */
 static ECSPI_Type *const s_ecspiBases[] = ECSPI_BASE_PTRS;
 /*! @brief ECSPI internal handle pointer array */
-static ecspi_master_handle_t *s_ecspiHandle[ARRAY_SIZE(s_ecspiBases)];
+static ecspi_master_handle_t *s_ecspiHandle[FSL_ARRAY_SIZE(s_ecspiBases)];
 /*! @brief IRQ name array */
 static const IRQn_Type s_ecspiIRQ[] = ECSPI_IRQS;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -123,14 +123,14 @@ uint32_t ECSPI_GetInstance(ECSPI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_ecspiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_ecspiBases); instance++)
     {
         if (s_ecspiBases[instance] == base)
         {
             break;
         }
     }
-    assert(instance <= ARRAY_SIZE(s_ecspiBases));
+    assert(instance <= FSL_ARRAY_SIZE(s_ecspiBases));
     return instance;
 }
 

--- a/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi_sdma.c
+++ b/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi_sdma.c
@@ -42,8 +42,8 @@ enum _ecspi_sdma_states_t
 /*! @brief Base pointer array */
 static ECSPI_Type *const s_ecspiBases[] = ECSPI_BASE_PTRS;
 /*<! Private handle only used for internally. */
-static ecspi_master_sdma_private_handle_t s_ecspiMasterSdmaPrivateHandle[ARRAY_SIZE(s_ecspiBases)];
-static ecspi_slave_sdma_private_handle_t s_ecspiSlaveSdmaPrivateHandle[ARRAY_SIZE(s_ecspiBases)];
+static ecspi_master_sdma_private_handle_t s_ecspiMasterSdmaPrivateHandle[FSL_ARRAY_SIZE(s_ecspiBases)];
+static ecspi_slave_sdma_private_handle_t s_ecspiSlaveSdmaPrivateHandle[FSL_ARRAY_SIZE(s_ecspiBases)];
 /*******************************************************************************
  * Prototypes
  ******************************************************************************/

--- a/mcux/mcux-sdk/drivers/edma/fsl_edma.c
+++ b/mcux/mcux-sdk/drivers/edma/fsl_edma.c
@@ -65,7 +65,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_edmaBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_edmaBases); instance++)
     {
         if (s_edmaBases[instance] == base)
         {
@@ -73,7 +73,7 @@ static uint32_t EDMA_GetInstance(DMA_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_edmaBases));
+    assert(instance < FSL_ARRAY_SIZE(s_edmaBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/eeprom/fsl_eeprom.c
+++ b/mcux/mcux-sdk/drivers/eeprom/fsl_eeprom.c
@@ -48,7 +48,7 @@ static uint32_t EEPROM_GetInstance(EEPROM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_eepromBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_eepromBases); instance++)
     {
         if (s_eepromBases[instance] == base)
         {
@@ -56,7 +56,7 @@ static uint32_t EEPROM_GetInstance(EEPROM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_eepromBases));
+    assert(instance < FSL_ARRAY_SIZE(s_eepromBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/elcdif/fsl_elcdif.c
+++ b/mcux/mcux-sdk/drivers/elcdif/fsl_elcdif.c
@@ -77,7 +77,7 @@ static uint32_t ELCDIF_GetInstance(LCDIF_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_elcdifBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_elcdifBases); instance++)
     {
         if (s_elcdifBases[instance] == base)
         {
@@ -85,7 +85,7 @@ static uint32_t ELCDIF_GetInstance(LCDIF_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_elcdifBases));
+    assert(instance < FSL_ARRAY_SIZE(s_elcdifBases));
 
     return instance;
 }
@@ -102,7 +102,7 @@ static uint32_t ELCDIF_GetInstance(LCDIF_Type *base)
 void ELCDIF_RgbModeInit(LCDIF_Type *base, const elcdif_rgb_mode_config_t *config)
 {
     assert(NULL != config);
-    assert((uint32_t)config->pixelFormat < ARRAY_SIZE(s_pixelFormatReg));
+    assert((uint32_t)config->pixelFormat < FSL_ARRAY_SIZE(s_pixelFormatReg));
 
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     uint32_t instance = ELCDIF_GetInstance(base);
@@ -205,7 +205,7 @@ void ELCDIF_RgbModeGetDefaultConfig(elcdif_rgb_mode_config_t *config)
  */
 void ELCDIF_RgbModeSetPixelFormat(LCDIF_Type *base, elcdif_pixel_format_t pixelFormat)
 {
-    assert((uint32_t)pixelFormat < ARRAY_SIZE(s_pixelFormatReg));
+    assert((uint32_t)pixelFormat < FSL_ARRAY_SIZE(s_pixelFormatReg));
 
     base->CTRL = (base->CTRL & ~(LCDIF_CTRL_WORD_LENGTH_MASK | LCDIF_CTRL_DATA_FORMAT_24_BIT_MASK |
                                  LCDIF_CTRL_DATA_FORMAT_18_BIT_MASK | LCDIF_CTRL_DATA_FORMAT_16_BIT_MASK)) |

--- a/mcux/mcux-sdk/drivers/emc/fsl_emc.c
+++ b/mcux/mcux-sdk/drivers/emc/fsl_emc.c
@@ -91,7 +91,7 @@ static uint32_t EMC_GetInstance(EMC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_EMCBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_EMCBases); instance++)
     {
         if (s_EMCBases[instance] == base)
         {
@@ -99,7 +99,7 @@ static uint32_t EMC_GetInstance(EMC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_EMCBases));
+    assert(instance < FSL_ARRAY_SIZE(s_EMCBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/enc/fsl_enc.c
+++ b/mcux/mcux-sdk/drivers/enc/fsl_enc.c
@@ -53,7 +53,7 @@ static uint32_t ENC_GetInstance(ENC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_encBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_encBases); instance++)
     {
         if (s_encBases[instance] == base)
         {
@@ -61,7 +61,7 @@ static uint32_t ENC_GetInstance(ENC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_encBases));
+    assert(instance < FSL_ARRAY_SIZE(s_encBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/enet/fsl_enet.c
+++ b/mcux/mcux-sdk/drivers/enet/fsl_enet.c
@@ -67,19 +67,19 @@ static const IRQn_Type s_enetErrIrqId[] = ENET_Error_IRQS;
 static ENET_Type *const s_enetBases[] = ENET_BASE_PTRS;
 
 /*! @brief Pointers to enet handles for each instance. */
-static enet_handle_t *s_ENETHandle[ARRAY_SIZE(s_enetBases)];
+static enet_handle_t *s_ENETHandle[FSL_ARRAY_SIZE(s_enetBases)];
 
 /* ENET ISR for transactional APIs. */
 #if FSL_FEATURE_ENET_QUEUE > 1
-static enet_isr_ring_t s_enetTxIsr[ARRAY_SIZE(s_enetBases)];
-static enet_isr_ring_t s_enetRxIsr[ARRAY_SIZE(s_enetBases)];
+static enet_isr_ring_t s_enetTxIsr[FSL_ARRAY_SIZE(s_enetBases)];
+static enet_isr_ring_t s_enetRxIsr[FSL_ARRAY_SIZE(s_enetBases)];
 #else
-static enet_isr_t s_enetTxIsr[ARRAY_SIZE(s_enetBases)];
-static enet_isr_t s_enetRxIsr[ARRAY_SIZE(s_enetBases)];
+static enet_isr_t s_enetTxIsr[FSL_ARRAY_SIZE(s_enetBases)];
+static enet_isr_t s_enetRxIsr[FSL_ARRAY_SIZE(s_enetBases)];
 #endif /* FSL_FEATURE_ENET_QUEUE > 1 */
-static enet_isr_t s_enetErrIsr[ARRAY_SIZE(s_enetBases)];
-static enet_isr_t s_enetTsIsr[ARRAY_SIZE(s_enetBases)];
-static enet_isr_t s_enet1588TimerIsr[ARRAY_SIZE(s_enetBases)];
+static enet_isr_t s_enetErrIsr[FSL_ARRAY_SIZE(s_enetBases)];
+static enet_isr_t s_enetTsIsr[FSL_ARRAY_SIZE(s_enetBases)];
+static enet_isr_t s_enet1588TimerIsr[FSL_ARRAY_SIZE(s_enetBases)];
 
 /*******************************************************************************
  * Prototypes
@@ -177,7 +177,7 @@ uint32_t ENET_GetInstance(ENET_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_enetBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_enetBases); instance++)
     {
         if (s_enetBases[instance] == base)
         {
@@ -185,7 +185,7 @@ uint32_t ENET_GetInstance(ENET_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_enetBases));
+    assert(instance < FSL_ARRAY_SIZE(s_enetBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/enet_qos/fsl_enet_qos.c
+++ b/mcux/mcux-sdk/drivers/enet_qos/fsl_enet_qos.c
@@ -180,11 +180,11 @@ static const IRQn_Type s_enetqosIrqId[] = ENET_QOS_IRQS;
 static enet_qos_isr_t s_enetqosIsr;
 
 /*! @brief Pointers to enet handles for each instance. */
-static enet_qos_handle_t *s_ENETHandle[ARRAY_SIZE(s_enetqosBases)] = {NULL};
+static enet_qos_handle_t *s_ENETHandle[FSL_ARRAY_SIZE(s_enetqosBases)] = {NULL};
 
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to enet clocks for each instance. */
-const clock_ip_name_t s_enetqosClock[ARRAY_SIZE(s_enetqosBases)] = ENETQOS_CLOCKS;
+const clock_ip_name_t s_enetqosClock[FSL_ARRAY_SIZE(s_enetqosBases)] = ENETQOS_CLOCKS;
 #endif /*  FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*******************************************************************************
@@ -775,7 +775,7 @@ uint32_t ENET_QOS_GetInstance(ENET_QOS_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_enetqosBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_enetqosBases); instance++)
     {
         if (s_enetqosBases[instance] == base)
         {
@@ -783,7 +783,7 @@ uint32_t ENET_QOS_GetInstance(ENET_QOS_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_enetqosBases));
+    assert(instance < FSL_ARRAY_SIZE(s_enetqosBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexbus/fsl_flexbus.c
+++ b/mcux/mcux-sdk/drivers/flexbus/fsl_flexbus.c
@@ -47,7 +47,7 @@ static uint32_t FLEXBUS_GetInstance(FB_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_flexbusBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_flexbusBases); instance++)
     {
         if (s_flexbusBases[instance] == base)
         {
@@ -55,7 +55,7 @@ static uint32_t FLEXBUS_GetInstance(FB_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_flexbusBases));
+    assert(instance < FSL_ARRAY_SIZE(s_flexbusBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c
+++ b/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c
@@ -347,7 +347,7 @@ static const IRQn_Type s_flexcanBusOffIRQ[]    = CAN_Bus_Off_IRQS;
 static const IRQn_Type s_flexcanMbIRQ[]        = CAN_ORed_Message_buffer_IRQS;
 
 /* Array of FlexCAN handle. */
-static flexcan_handle_t *s_flexcanHandle[ARRAY_SIZE(s_flexcanBases)];
+static flexcan_handle_t *s_flexcanHandle[FSL_ARRAY_SIZE(s_flexcanBases)];
 
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /* Array of FlexCAN clock name. */
@@ -396,7 +396,7 @@ uint32_t FLEXCAN_GetInstance(CAN_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_flexcanBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_flexcanBases); instance++)
     {
         if (s_flexcanBases[instance] == base)
         {
@@ -404,7 +404,7 @@ uint32_t FLEXCAN_GetInstance(CAN_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_flexcanBases));
+    assert(instance < FSL_ARRAY_SIZE(s_flexcanBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan_edma.c
+++ b/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan_edma.c
@@ -38,7 +38,7 @@ enum _flexcan_edma_tansfer_state
 static CAN_Type *const s_flexcanBases[] = CAN_BASE_PTRS;
 
 /* Private handle only used for internally. */
-static flexcan_edma_private_handle_t s_flexcanEdmaPrivateHandle[ARRAY_SIZE(s_flexcanBases)];
+static flexcan_edma_private_handle_t s_flexcanEdmaPrivateHandle[FSL_ARRAY_SIZE(s_flexcanBases)];
 
 /*******************************************************************************
  * Prototypes

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_flexcomm.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_flexcomm.c
@@ -44,10 +44,10 @@ static bool FLEXCOMM_PeripheralIsPresent(FLEXCOMM_Type *base, FLEXCOMM_PERIPH_T 
 static const uint32_t s_flexcommBaseAddrs[] = FLEXCOMM_BASE_ADDRS;
 
 /*! @brief Pointers to real IRQ handlers installed by drivers for each instance. */
-static flexcomm_irq_handler_t s_flexcommIrqHandler[ARRAY_SIZE(s_flexcommBaseAddrs)];
+static flexcomm_irq_handler_t s_flexcommIrqHandler[FSL_ARRAY_SIZE(s_flexcommBaseAddrs)];
 
 /*! @brief Pointers to handles for each instance to provide context to interrupt routines */
-static void *s_flexcommHandle[ARRAY_SIZE(s_flexcommBaseAddrs)];
+static void *s_flexcommHandle[FSL_ARRAY_SIZE(s_flexcommBaseAddrs)];
 
 /*! @brief Array to map FLEXCOMM instance number to IRQ number. */
 IRQn_Type const kFlexcommIrqs[] = FLEXCOMM_IRQS;

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c_dma.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c_dma.c
@@ -77,7 +77,7 @@ static status_t I2C_RunTransferStateMachineDMA(I2C_Type *base, i2c_master_dma_ha
 static const IRQn_Type s_i2cIRQ[] = I2C_IRQS;
 
 /*<! Private handle only used for internally. */
-static i2c_master_dma_private_handle_t s_dmaPrivateHandle[ARRAY_SIZE(s_i2cIRQ)];
+static i2c_master_dma_private_handle_t s_dmaPrivateHandle[FSL_ARRAY_SIZE(s_i2cIRQ)];
 
 /*******************************************************************************
  * Codes

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_i2s.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_i2s.c
@@ -74,7 +74,7 @@ static const IRQn_Type s_i2sIRQ[] = I2S_IRQS;
 static uint32_t I2S_GetInstance(I2S_Type *base)
 {
     uint32_t i;
-    for (i = 0; i < (uint32_t)ARRAY_SIZE(s_i2sBaseAddrs); i++)
+    for (i = 0; i < (uint32_t)FSL_ARRAY_SIZE(s_i2sBaseAddrs); i++)
     {
         if ((uint32_t)base == s_i2sBaseAddrs[i])
         {

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_i2s_dma.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_i2s_dma.c
@@ -152,7 +152,7 @@ static uint32_t I2S_GetInstance(I2S_Type *base)
 {
     uint32_t i;
 
-    for (i = 0U; i < ARRAY_SIZE(s_I2sBaseAddrs); i++)
+    for (i = 0U; i < FSL_ARRAY_SIZE(s_I2sBaseAddrs); i++)
     {
         if ((uint32_t)base == s_I2sBaseAddrs[i])
         {

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_spi_dma.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_spi_dma.c
@@ -41,7 +41,7 @@ typedef struct _spi_dma_txdummy
 static const uint32_t s_spiBaseAddrs[] = SPI_BASE_ADDRS;
 
 /*<! Private handle only used for internally. */
-static spi_dma_private_handle_t s_dmaPrivateHandle[ARRAY_SIZE(s_spiBaseAddrs)];
+static spi_dma_private_handle_t s_dmaPrivateHandle[FSL_ARRAY_SIZE(s_spiBaseAddrs)];
 
 /*******************************************************************************
  * Prototypes
@@ -68,32 +68,32 @@ static void SPI_RxDMACallback(dma_handle_t *handle, void *userData, bool transfe
  ******************************************************************************/
 #if defined(__ICCARM__)
 #pragma data_alignment                                         = 4
-static spi_dma_txdummy_t s_txDummy[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+static spi_dma_txdummy_t s_txDummy[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #elif defined(__CC_ARM) || defined(__ARMCC_VERSION)
-__attribute__((aligned(4))) static spi_dma_txdummy_t s_txDummy[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+__attribute__((aligned(4))) static spi_dma_txdummy_t s_txDummy[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #elif defined(__GNUC__)
-__attribute__((aligned(4))) static spi_dma_txdummy_t s_txDummy[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+__attribute__((aligned(4))) static spi_dma_txdummy_t s_txDummy[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #endif
 
 #if defined(__ICCARM__)
 #pragma data_alignment = 4
 static uint16_t s_rxDummy;
-static uint32_t s_txLastWord[ARRAY_SIZE(s_spiBaseAddrs)];
+static uint32_t s_txLastWord[FSL_ARRAY_SIZE(s_spiBaseAddrs)];
 #elif defined(__CC_ARM) || defined(__ARMCC_VERSION)
 __attribute__((aligned(4))) static uint16_t s_rxDummy;
-__attribute__((aligned(4))) static uint32_t s_txLastWord[ARRAY_SIZE(s_spiBaseAddrs)];
+__attribute__((aligned(4))) static uint32_t s_txLastWord[FSL_ARRAY_SIZE(s_spiBaseAddrs)];
 #elif defined(__GNUC__)
 __attribute__((aligned(4))) static uint16_t s_rxDummy;
-__attribute__((aligned(4))) static uint32_t s_txLastWord[ARRAY_SIZE(s_spiBaseAddrs)];
+__attribute__((aligned(4))) static uint32_t s_txLastWord[FSL_ARRAY_SIZE(s_spiBaseAddrs)];
 #endif
 
 #if defined(__ICCARM__)
 #pragma data_alignment                                                     = 16
-static dma_descriptor_t s_spi_descriptor_table[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+static dma_descriptor_t s_spi_descriptor_table[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #elif defined(__CC_ARM) || defined(__ARMCC_VERSION)
-__attribute__((aligned(16))) static dma_descriptor_t s_spi_descriptor_table[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+__attribute__((aligned(16))) static dma_descriptor_t s_spi_descriptor_table[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #elif defined(__GNUC__)
-__attribute__((aligned(16))) static dma_descriptor_t s_spi_descriptor_table[ARRAY_SIZE(s_spiBaseAddrs)] = {0};
+__attribute__((aligned(16))) static dma_descriptor_t s_spi_descriptor_table[FSL_ARRAY_SIZE(s_spiBaseAddrs)] = {0};
 #endif
 
 /*******************************************************************************

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_usart_dma.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_usart_dma.c
@@ -55,7 +55,7 @@ static const IRQn_Type s_usartIRQ[] = USART_IRQS;
 /*! @brief Array to map USART instance number to base address. */
 static const uint32_t s_usartBaseAddrs[] = USART_BASE_ADDRS;
 /*<! Private handle only used for internally. */
-static usart_dma_private_handle_t s_dmaPrivateHandle[ARRAY_SIZE(s_usartBaseAddrs)];
+static usart_dma_private_handle_t s_dmaPrivateHandle[FSL_ARRAY_SIZE(s_usartBaseAddrs)];
 
 /*******************************************************************************
  * Prototypes

--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
@@ -57,7 +57,7 @@ uint32_t FLEXIO_GetInstance(FLEXIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_flexioBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_flexioBases); instance++)
     {
         if (s_flexioBases[instance] == base)
         {
@@ -65,7 +65,7 @@ uint32_t FLEXIO_GetInstance(FLEXIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_flexioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_flexioBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexram/fsl_flexram.c
+++ b/mcux/mcux-sdk/drivers/flexram/fsl_flexram.c
@@ -61,7 +61,7 @@ static uint32_t FLEXRAM_GetInstance(FLEXRAM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_flexramBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_flexramBases); instance++)
     {
         if (s_flexramBases[instance] == base)
         {
@@ -69,7 +69,7 @@ static uint32_t FLEXRAM_GetInstance(FLEXRAM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_flexramBases));
+    assert(instance < FSL_ARRAY_SIZE(s_flexramBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi.c
+++ b/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi.c
@@ -96,7 +96,7 @@ static const clock_ip_name_t s_flexspiClock[] = FLEXSPI_CLOCKS;
 
 #if defined(FSL_DRIVER_TRANSFER_DOUBLE_WEAK_IRQ) && FSL_DRIVER_TRANSFER_DOUBLE_WEAK_IRQ
 /*! @brief Pointers to flexspi handles for each instance. */
-static flexspi_handle_t *s_flexspiHandle[ARRAY_SIZE(s_flexspiBases)];
+static flexspi_handle_t *s_flexspiHandle[FSL_ARRAY_SIZE(s_flexspiBases)];
 #endif
 
 #if defined(FSL_FEATURE_FLEXSPI_HAS_RESET) && FSL_FEATURE_FLEXSPI_HAS_RESET
@@ -132,7 +132,7 @@ uint32_t FLEXSPI_GetInstance(FLEXSPI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_flexspiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_flexspiBases); instance++)
     {
         if (s_flexspiBases[instance] == base)
         {
@@ -140,7 +140,7 @@ uint32_t FLEXSPI_GetInstance(FLEXSPI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_flexspiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_flexspiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi_dma.c
+++ b/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi_dma.c
@@ -38,7 +38,7 @@ enum
 static FLEXSPI_Type *const s_flexspiBases[] = FLEXSPI_BASE_PTRS;
 
 /*<! Private handle only used for internally. */
-static flexspi_dma_private_handle_t s_dmaPrivateHandle[ARRAY_SIZE(s_flexspiBases)];
+static flexspi_dma_private_handle_t s_dmaPrivateHandle[FSL_ARRAY_SIZE(s_flexspiBases)];
 
 #if defined(FSL_FEATURE_FLEXSPI_DMA_MULTIPLE_DES) && FSL_FEATURE_FLEXSPI_DMA_MULTIPLE_DES
 /*<! Private DMA descriptor array used for internally to fix FLEXSPI+DMA ERRATA.

--- a/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi_edma.c
+++ b/mcux/mcux-sdk/drivers/flexspi/fsl_flexspi_edma.c
@@ -39,7 +39,7 @@ enum
 static FLEXSPI_Type *const s_flexspiBases[] = FLEXSPI_BASE_PTRS;
 
 /*<! Private handle only used for internally. */
-static flexspi_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_flexspiBases)];
+static flexspi_edma_private_handle_t s_edmaPrivateHandle[FSL_ARRAY_SIZE(s_flexspiBases)];
 
 /*******************************************************************************
  * Prototypes

--- a/mcux/mcux-sdk/drivers/gint/fsl_gint.c
+++ b/mcux/mcux-sdk/drivers/gint/fsl_gint.c
@@ -44,7 +44,7 @@ static uint32_t GINT_GetInstance(GINT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_gintBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_gintBases); instance++)
     {
         if (s_gintBases[instance] == base)
         {
@@ -52,7 +52,7 @@ static uint32_t GINT_GetInstance(GINT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_gintBases));
+    assert(instance < FSL_ARRAY_SIZE(s_gintBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/gpio/fsl_gpio.c
+++ b/mcux/mcux-sdk/drivers/gpio/fsl_gpio.c
@@ -56,7 +56,7 @@ static uint32_t GPIO_GetInstance(GPIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_gpioBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_gpioBases); instance++)
     {
         if (s_gpioBases[instance] == base)
         {
@@ -64,7 +64,7 @@ static uint32_t GPIO_GetInstance(GPIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_gpioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_gpioBases));
 
     return instance;
 }
@@ -258,7 +258,7 @@ static uint32_t FGPIO_GetInstance(FGPIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_fgpioBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_fgpioBases); instance++)
     {
         if (s_fgpioBases[instance] == base)
         {
@@ -266,7 +266,7 @@ static uint32_t FGPIO_GetInstance(FGPIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_fgpioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_fgpioBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/gpt/fsl_gpt.c
+++ b/mcux/mcux-sdk/drivers/gpt/fsl_gpt.c
@@ -35,7 +35,7 @@ static uint32_t GPT_GetInstance(GPT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_gptBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_gptBases); instance++)
     {
         if (s_gptBases[instance] == base)
         {
@@ -43,7 +43,7 @@ static uint32_t GPT_GetInstance(GPT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_gptBases));
+    assert(instance < FSL_ARRAY_SIZE(s_gptBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/hsadc/fsl_hsadc.c
+++ b/mcux/mcux-sdk/drivers/hsadc/fsl_hsadc.c
@@ -72,7 +72,7 @@ static uint32_t HSADC_GetInstance(HSADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_hsadcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_hsadcBases); instance++)
     {
         if (s_hsadcBases[instance] == base)
         {
@@ -80,7 +80,7 @@ static uint32_t HSADC_GetInstance(HSADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_hsadcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_hsadcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/hscmp/fsl_hscmp.c
+++ b/mcux/mcux-sdk/drivers/hscmp/fsl_hscmp.c
@@ -46,7 +46,7 @@ static uint32_t HSCMP_GetInstance(HSCMP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_hscmpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_hscmpBases); instance++)
     {
         if (s_hscmpBases[instance] == base)
         {
@@ -54,7 +54,7 @@ static uint32_t HSCMP_GetInstance(HSCMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_hscmpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_hscmpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/i2c/fsl_i2c.c
+++ b/mcux/mcux-sdk/drivers/i2c/fsl_i2c.c
@@ -147,7 +147,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -155,7 +155,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_i2cBases));
+    assert(instance < FSL_ARRAY_SIZE(s_i2cBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/i3c/fsl_i3c.c
+++ b/mcux/mcux-sdk/drivers/i3c/fsl_i3c.c
@@ -122,13 +122,13 @@ static i3c_device_info_t devList[I3C_MAX_DEVCNT]; /*!< I3C slave record list */
 i3c_master_isr_t s_i3cMasterIsr;
 
 /*! @brief Pointers to master handles for each instance. */
-void *s_i3cMasterHandle[ARRAY_SIZE(kI3cBases)];
+void *s_i3cMasterHandle[FSL_ARRAY_SIZE(kI3cBases)];
 
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static i3c_slave_isr_t s_i3cSlaveIsr;
 
 /*! @brief Pointers to slave handles for each instance. */
-i3c_slave_handle_t *s_i3cSlaveHandle[ARRAY_SIZE(kI3cBases)];
+i3c_slave_handle_t *s_i3cSlaveHandle[FSL_ARRAY_SIZE(kI3cBases)];
 
 /*******************************************************************************
  * Code
@@ -146,7 +146,7 @@ i3c_slave_handle_t *s_i3cSlaveHandle[ARRAY_SIZE(kI3cBases)];
 uint32_t I3C_GetInstance(I3C_Type *base)
 {
     uint32_t instance;
-    for (instance = 0; instance < ARRAY_SIZE(kI3cBases); ++instance)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(kI3cBases); ++instance)
     {
         if (kI3cBases[instance] == base)
         {
@@ -154,7 +154,7 @@ uint32_t I3C_GetInstance(I3C_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(kI3cBases));
+    assert(instance < FSL_ARRAY_SIZE(kI3cBases));
 
     return instance;
 }
@@ -1060,7 +1060,7 @@ void I3C_MasterRegisterIBI(I3C_Type *base, i3c_register_ibi_addr_t *ibiRule)
     assert(NULL != ibiRule);
     uint32_t ruleValue = I3C_MIBIRULES_MSB0_MASK;
 
-    for (uint32_t count = 0; count < ARRAY_SIZE(ibiRule->address); count++)
+    for (uint32_t count = 0; count < FSL_ARRAY_SIZE(ibiRule->address); count++)
     {
         ruleValue |= ((uint32_t)ibiRule->address[count]) << (count * I3C_MIBIRULES_ADDR1_SHIFT);
     }
@@ -1087,7 +1087,7 @@ void I3C_MasterGetIBIRules(I3C_Type *base, i3c_register_ibi_addr_t *ibiRule)
 
     uint32_t ruleValue = base->MIBIRULES;
 
-    for (uint32_t count = 0; count < ARRAY_SIZE(ibiRule->address); count++)
+    for (uint32_t count = 0; count < FSL_ARRAY_SIZE(ibiRule->address); count++)
     {
         ibiRule->address[count] =
             (uint8_t)(ruleValue >> (count * I3C_MIBIRULES_ADDR1_SHIFT)) & I3C_MIBIRULES_ADDR0_MASK;

--- a/mcux/mcux-sdk/drivers/igpio/fsl_gpio.c
+++ b/mcux/mcux-sdk/drivers/igpio/fsl_gpio.c
@@ -49,7 +49,7 @@ static uint32_t GPIO_GetInstance(GPIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_gpioBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_gpioBases); instance++)
     {
         if (s_gpioBases[instance] == base)
         {
@@ -57,7 +57,7 @@ static uint32_t GPIO_GetInstance(GPIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_gpioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_gpioBases));
 
     return instance;
 }
@@ -79,7 +79,7 @@ void GPIO_PinInit(GPIO_Type *base, uint32_t pin, const gpio_pin_config_t *Config
     uint32_t instance = GPIO_GetInstance(base);
 
     /* If The clock IP is valid, enable the clock gate. */
-    if ((instance < ARRAY_SIZE(s_gpioClock)) && (kCLOCK_IpInvalid != s_gpioClock[instance]))
+    if ((instance < FSL_ARRAY_SIZE(s_gpioClock)) && (kCLOCK_IpInvalid != s_gpioClock[instance]))
     {
         (void)CLOCK_EnableClock(s_gpioClock[instance]);
     }

--- a/mcux/mcux-sdk/drivers/ii2c/fsl_i2c.c
+++ b/mcux/mcux-sdk/drivers/ii2c/fsl_i2c.c
@@ -123,7 +123,7 @@ static const clock_ip_name_t s_i2cClocks[] = I2C_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to i2c handles for each instance. */
-static void *s_i2cHandle[ARRAY_SIZE(s_i2cBases)];
+static void *s_i2cHandle[FSL_ARRAY_SIZE(s_i2cBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static i2c_isr_t s_i2cMasterIsr;
@@ -140,7 +140,7 @@ static uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_i2cBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -148,7 +148,7 @@ static uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_i2cBases));
+    assert(instance < FSL_ARRAY_SIZE(s_i2cBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/intmux/fsl_intmux.c
+++ b/mcux/mcux-sdk/drivers/intmux/fsl_intmux.c
@@ -69,7 +69,7 @@ static uint32_t INTMUX_GetInstance(INTMUX_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_intmuxBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_intmuxBases); instance++)
     {
         if (s_intmuxBases[instance] == base)
         {
@@ -77,7 +77,7 @@ static uint32_t INTMUX_GetInstance(INTMUX_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_intmuxBases));
+    assert(instance < FSL_ARRAY_SIZE(s_intmuxBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/irq/fsl_irq.c
+++ b/mcux/mcux-sdk/drivers/irq/fsl_irq.c
@@ -44,7 +44,7 @@ uint32_t IRQ_GetInstance(IRQ_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_irqBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_irqBases); instance++)
     {
         if (s_irqBases[instance] == base)
         {
@@ -52,7 +52,7 @@ uint32_t IRQ_GetInstance(IRQ_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_irqBases));
+    assert(instance < FSL_ARRAY_SIZE(s_irqBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/irqsteer/fsl_irqsteer.c
+++ b/mcux/mcux-sdk/drivers/irqsteer/fsl_irqsteer.c
@@ -52,7 +52,7 @@ static uint32_t IRQSTEER_GetInstance(IRQSTEER_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_irqsteerBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_irqsteerBases); instance++)
     {
         if (s_irqsteerBases[instance] == base)
         {
@@ -60,7 +60,7 @@ static uint32_t IRQSTEER_GetInstance(IRQSTEER_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_irqsteerBases));
+    assert(instance < FSL_ARRAY_SIZE(s_irqsteerBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/isi/fsl_isi.c
+++ b/mcux/mcux-sdk/drivers/isi/fsl_isi.c
@@ -123,7 +123,7 @@ static uint32_t ISI_GetInstance(ISI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_isiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_isiBases); instance++)
     {
         if (s_isiBases[instance] == base)
         {
@@ -131,7 +131,7 @@ static uint32_t ISI_GetInstance(ISI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_isiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_isiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/iuart/fsl_uart.c
+++ b/mcux/mcux-sdk/drivers/iuart/fsl_uart.c
@@ -89,7 +89,7 @@ uart_isr_t s_uartIsr = (uart_isr_t)DefaultISR;
 uart_isr_t s_uartIsr;
 #endif
 
-void *s_uartHandle[ARRAY_SIZE(s_uartBases)];
+void *s_uartHandle[FSL_ARRAY_SIZE(s_uartBases)];
 
 /*******************************************************************************
  * Code

--- a/mcux/mcux-sdk/drivers/iuart/fsl_uart_sdma.c
+++ b/mcux/mcux-sdk/drivers/iuart/fsl_uart_sdma.c
@@ -37,7 +37,7 @@ enum _uart_sdma_tansfer_states
 
 /*<! Private handle only used for internally. */
 static UART_Type *const s_uartSdmaBases[] = UART_BASE_PTRS;
-static uart_sdma_private_handle_t s_sdmaPrivateHandle[ARRAY_SIZE(s_uartSdmaBases)];
+static uart_sdma_private_handle_t s_sdmaPrivateHandle[FSL_ARRAY_SIZE(s_uartSdmaBases)];
 
 /*******************************************************************************
  * Prototypes

--- a/mcux/mcux-sdk/drivers/kbi/fsl_kbi.c
+++ b/mcux/mcux-sdk/drivers/kbi/fsl_kbi.c
@@ -42,7 +42,7 @@ static uint32_t KBI_GetInstance(KBI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_kbiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_kbiBases); instance++)
     {
         if (s_kbiBases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t KBI_GetInstance(KBI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_kbiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_kbiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/kpp/fsl_kpp.c
+++ b/mcux/mcux-sdk/drivers/kpp/fsl_kpp.c
@@ -43,7 +43,7 @@ static uint32_t KPP_GetInstance(KPP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_kppBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_kppBases); instance++)
     {
         if (s_kppBases[instance] == base)
         {
@@ -51,7 +51,7 @@ static uint32_t KPP_GetInstance(KPP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_kppBases));
+    assert(instance < FSL_ARRAY_SIZE(s_kppBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lcdif/fsl_lcdif.c
+++ b/mcux/mcux-sdk/drivers/lcdif/fsl_lcdif.c
@@ -51,7 +51,7 @@ static uint32_t LCDIF_GetInstance(LCDIF_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lcdifBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lcdifBases); instance++)
     {
         if (s_lcdifBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t LCDIF_GetInstance(LCDIF_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lcdifBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lcdifBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lcdifv2/fsl_lcdifv2.c
+++ b/mcux/mcux-sdk/drivers/lcdifv2/fsl_lcdifv2.c
@@ -106,7 +106,7 @@ static uint32_t LCDIFV2_GetInstance(LCDIFV2_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lcdifv2Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lcdifv2Bases); instance++)
     {
         if (s_lcdifv2Bases[instance] == base)
         {
@@ -114,7 +114,7 @@ static uint32_t LCDIFV2_GetInstance(LCDIFV2_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lcdifv2Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_lcdifv2Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/ldb/fsl_ldb.c
+++ b/mcux/mcux-sdk/drivers/ldb/fsl_ldb.c
@@ -92,7 +92,7 @@ static uint32_t LDB_GetInstance(LDB_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_ldbBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_ldbBases); instance++)
     {
         if (s_ldbBases[instance] == base)
         {
@@ -100,7 +100,7 @@ static uint32_t LDB_GetInstance(LDB_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_ldbBases));
+    assert(instance < FSL_ARRAY_SIZE(s_ldbBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/ldb_combo_phy/fsl_ldb.c
+++ b/mcux/mcux-sdk/drivers/ldb_combo_phy/fsl_ldb.c
@@ -87,7 +87,7 @@ static uint32_t LDB_GetInstance(LDB_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_ldbBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_ldbBases); instance++)
     {
         if (s_ldbBases[instance] == base)
         {
@@ -95,7 +95,7 @@ static uint32_t LDB_GetInstance(LDB_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_ldbBases));
+    assert(instance < FSL_ARRAY_SIZE(s_ldbBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpadc/fsl_lpadc.c
+++ b/mcux/mcux-sdk/drivers/lpadc/fsl_lpadc.c
@@ -41,7 +41,7 @@ static uint32_t LPADC_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lpadcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lpadcBases); instance++)
     {
         if (s_lpadcBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t LPADC_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpadcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpadcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_acomp/fsl_acomp.c
+++ b/mcux/mcux-sdk/drivers/lpc_acomp/fsl_acomp.c
@@ -51,7 +51,7 @@ static uint32_t ACOMP_GetInstance(ACOMP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_acompBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_acompBases); instance++)
     {
         if (s_acompBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t ACOMP_GetInstance(ACOMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_acompBases));
+    assert(instance < FSL_ARRAY_SIZE(s_acompBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_adc/fsl_adc.c
+++ b/mcux/mcux-sdk/drivers/lpc_adc/fsl_adc.c
@@ -26,7 +26,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_adcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_adcBases); instance++)
     {
         if (s_adcBases[instance] == base)
         {
@@ -34,7 +34,7 @@ static uint32_t ADC_GetInstance(ADC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_adcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_adcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_dac/fsl_dac.c
+++ b/mcux/mcux-sdk/drivers/lpc_dac/fsl_dac.c
@@ -48,7 +48,7 @@ static uint32_t DAC_GetInstance(DAC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dacBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dacBases); instance++)
     {
         if (s_dacBases[instance] == base)
         {
@@ -56,7 +56,7 @@ static uint32_t DAC_GetInstance(DAC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dacBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dacBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_dma/fsl_dma.c
+++ b/mcux/mcux-sdk/drivers/lpc_dma/fsl_dma.c
@@ -99,14 +99,14 @@ static uint32_t DMA_GetInstance(DMA_Type *base)
 {
     uint32_t instance;
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dmaBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dmaBases); instance++)
     {
         if (s_dmaBases[instance] == base)
         {
             break;
         }
     }
-    assert(instance < ARRAY_SIZE(s_dmaBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dmaBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_freqme/fsl_freqme.c
+++ b/mcux/mcux-sdk/drivers/lpc_freqme/fsl_freqme.c
@@ -39,7 +39,7 @@ static uint32_t FREQME_GetInstance(FREQME_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_freqmeBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_freqmeBases); instance++)
     {
         if (s_freqmeBases[instance] == base)
         {
@@ -47,7 +47,7 @@ static uint32_t FREQME_GetInstance(FREQME_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_freqmeBases));
+    assert(instance < FSL_ARRAY_SIZE(s_freqmeBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_gpio/fsl_gpio.c
+++ b/mcux/mcux-sdk/drivers/lpc_gpio/fsl_gpio.c
@@ -42,7 +42,7 @@ static void GPIO_EnablePortClock(GPIO_Type *base, uint32_t port);
 static void GPIO_EnablePortClock(GPIO_Type *base, uint32_t port)
 {
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
-    assert(port < ARRAY_SIZE(s_gpioClockName));
+    assert(port < FSL_ARRAY_SIZE(s_gpioClockName));
 
     /* Upgate the GPIO clock */
     CLOCK_EnableClock(s_gpioClockName[port]);

--- a/mcux/mcux-sdk/drivers/lpc_i2c/fsl_i2c.c
+++ b/mcux/mcux-sdk/drivers/lpc_i2c/fsl_i2c.c
@@ -103,7 +103,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_i2cBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_i2cBases); instance++)
     {
         if (s_i2cBases[instance] == base)
         {
@@ -111,7 +111,7 @@ uint32_t I2C_GetInstance(I2C_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_i2cBases));
+    assert(instance < FSL_ARRAY_SIZE(s_i2cBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpc_lcdc/fsl_lcdc.c
+++ b/mcux/mcux-sdk/drivers/lpc_lcdc/fsl_lcdc.c
@@ -87,7 +87,7 @@ static uint32_t LCDC_GetInstance(LCD_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lcdBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lcdBases); instance++)
     {
         if (s_lcdBases[instance] == base)
         {
@@ -95,7 +95,7 @@ static uint32_t LCDC_GetInstance(LCD_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lcdBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lcdBases));
 
     return instance;
 }
@@ -355,7 +355,7 @@ void LCDC_SetPanelAddr(LCD_Type *base, lcdc_panel_t panel, uint32_t addr)
  */
 void LCDC_SetPalette(LCD_Type *base, const uint32_t *palette, uint8_t count_words)
 {
-    assert(count_words <= ARRAY_SIZE(base->PAL));
+    assert(count_words <= FSL_ARRAY_SIZE(base->PAL));
 
     uint32_t i;
 

--- a/mcux/mcux-sdk/drivers/lpc_lcdc/fsl_lcdc.h
+++ b/mcux/mcux-sdk/drivers/lpc_lcdc/fsl_lcdc.h
@@ -39,7 +39,7 @@
 #define LCDC_CURSOR_IMG_64X64_WORDS ((uint32_t)(64U * 64U * LCDC_CURSOR_IMG_BPP / (8U * (uint32_t)sizeof(uint32_t))))
 
 /*!@brief LCD palette size in words(32-bit). */
-#define LCDC_PALETTE_SIZE_WORDS (ARRAY_SIZE(((LCD_Type *)0)->PAL))
+#define LCDC_PALETTE_SIZE_WORDS (FSL_ARRAY_SIZE(((LCD_Type *)0)->PAL))
 
 /*!
  * @brief LCD sigal polarity flags.

--- a/mcux/mcux-sdk/drivers/lpc_rit/fsl_rit.c
+++ b/mcux/mcux-sdk/drivers/lpc_rit/fsl_rit.c
@@ -49,7 +49,7 @@ static uint32_t RIT_GetInstance(RIT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_ritBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_ritBases); instance++)
     {
         if (s_ritBases[instance] == base)
         {
@@ -57,7 +57,7 @@ static uint32_t RIT_GetInstance(RIT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_ritBases));
+    assert(instance < FSL_ARRAY_SIZE(s_ritBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpcmp/fsl_lpcmp.c
+++ b/mcux/mcux-sdk/drivers/lpcmp/fsl_lpcmp.c
@@ -48,7 +48,7 @@ static uint32_t LPCMP_GetInstance(LPCMP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lpcmpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lpcmpBases); instance++)
     {
         if (s_lpcmpBases[instance] == base)
         {
@@ -56,7 +56,7 @@ static uint32_t LPCMP_GetInstance(LPCMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpcmpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpcmpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpi2c/fsl_lpi2c.c
+++ b/mcux/mcux-sdk/drivers/lpi2c/fsl_lpi2c.c
@@ -97,13 +97,13 @@ lpi2c_master_isr_t s_lpi2cMasterIsr;
 
 /*! @brief Pointers to master handles for each instance, used internally for LPI2C master interrupt and EDMA
 transactional APIs. */
-void *s_lpi2cMasterHandle[ARRAY_SIZE(kLpi2cBases)];
+void *s_lpi2cMasterHandle[FSL_ARRAY_SIZE(kLpi2cBases)];
 
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static lpi2c_slave_isr_t s_lpi2cSlaveIsr;
 
 /*! @brief Pointers to slave handles for each instance. */
-static lpi2c_slave_handle_t *s_lpi2cSlaveHandle[ARRAY_SIZE(kLpi2cBases)];
+static lpi2c_slave_handle_t *s_lpi2cSlaveHandle[FSL_ARRAY_SIZE(kLpi2cBases)];
 
 /*******************************************************************************
  * Code
@@ -121,7 +121,7 @@ static lpi2c_slave_handle_t *s_lpi2cSlaveHandle[ARRAY_SIZE(kLpi2cBases)];
 uint32_t LPI2C_GetInstance(LPI2C_Type *base)
 {
     uint32_t instance;
-    for (instance = 0U; instance < ARRAY_SIZE(kLpi2cBases); ++instance)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(kLpi2cBases); ++instance)
     {
         if (kLpi2cBases[instance] == base)
         {
@@ -129,7 +129,7 @@ uint32_t LPI2C_GetInstance(LPI2C_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(kLpi2cBases));
+    assert(instance < FSL_ARRAY_SIZE(kLpi2cBases));
     return instance;
 }
 

--- a/mcux/mcux-sdk/drivers/lpit/fsl_lpit.c
+++ b/mcux/mcux-sdk/drivers/lpit/fsl_lpit.c
@@ -51,7 +51,7 @@ uint32_t LPIT_GetInstance(LPIT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_lpitBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_lpitBases); instance++)
     {
         if (s_lpitBases[instance] == base)
         {
@@ -59,7 +59,7 @@ uint32_t LPIT_GetInstance(LPIT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpitBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpitBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpsci/fsl_lpsci.c
+++ b/mcux/mcux-sdk/drivers/lpsci/fsl_lpsci.c
@@ -133,7 +133,7 @@ uint32_t LPSCI_GetInstance(UART0_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lpsciBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lpsciBases); instance++)
     {
         if (s_lpsciBases[instance] == base)
         {
@@ -141,7 +141,7 @@ uint32_t LPSCI_GetInstance(UART0_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpsciBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpsciBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpspi/fsl_lpspi.c
+++ b/mcux/mcux-sdk/drivers/lpspi/fsl_lpspi.c
@@ -131,14 +131,14 @@ static const clock_ip_name_t s_LpspiPeriphClocks[] = LPSPI_PERIPH_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*! @brief Pointers to lpspi handles for each instance. */
-static void *s_lpspiHandle[ARRAY_SIZE(s_lpspiBases)];
+static void *s_lpspiHandle[FSL_ARRAY_SIZE(s_lpspiBases)];
 
 /*! @brief Pointer to master IRQ handler for each instance. */
 static lpspi_master_isr_t s_lpspiMasterIsr;
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static lpspi_slave_isr_t s_lpspiSlaveIsr;
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t g_lpspiDummyData[ARRAY_SIZE(s_lpspiBases)] = {0};
+volatile uint8_t g_lpspiDummyData[FSL_ARRAY_SIZE(s_lpspiBases)] = {0};
 
 /**********************************************************************************************************************
  * Code
@@ -155,7 +155,7 @@ uint32_t LPSPI_GetInstance(LPSPI_Type *base)
     uint8_t instance = 0;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lpspiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lpspiBases); instance++)
     {
         if (s_lpspiBases[instance] == base)
         {
@@ -163,7 +163,7 @@ uint32_t LPSPI_GetInstance(LPSPI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpspiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpspiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpspi/fsl_lpspi_edma.c
+++ b/mcux/mcux-sdk/drivers/lpspi/fsl_lpspi_edma.c
@@ -66,8 +66,8 @@ static void LPSPI_SeparateEdmaReadData(uint8_t *rxData, uint32_t readData, uint3
 static LPSPI_Type *const s_lpspiBases[] = LPSPI_BASE_PTRS;
 
 /*! @brief Pointers to lpspi edma handles for each instance. */
-static lpspi_master_edma_private_handle_t s_lpspiMasterEdmaPrivateHandle[ARRAY_SIZE(s_lpspiBases)];
-static lpspi_slave_edma_private_handle_t s_lpspiSlaveEdmaPrivateHandle[ARRAY_SIZE(s_lpspiBases)];
+static lpspi_master_edma_private_handle_t s_lpspiMasterEdmaPrivateHandle[FSL_ARRAY_SIZE(s_lpspiBases)];
+static lpspi_slave_edma_private_handle_t s_lpspiSlaveEdmaPrivateHandle[FSL_ARRAY_SIZE(s_lpspiBases)];
 
 /***********************************************************************************************************************
  * Code

--- a/mcux/mcux-sdk/drivers/lptmr/fsl_lptmr.c
+++ b/mcux/mcux-sdk/drivers/lptmr/fsl_lptmr.c
@@ -55,7 +55,7 @@ static uint32_t LPTMR_GetInstance(LPTMR_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_lptmrBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_lptmrBases); instance++)
     {
         if (s_lptmrBases[instance] == base)
         {
@@ -63,7 +63,7 @@ static uint32_t LPTMR_GetInstance(LPTMR_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lptmrBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lptmrBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/lpuart/fsl_lpuart.c
+++ b/mcux/mcux-sdk/drivers/lpuart/fsl_lpuart.c
@@ -72,7 +72,7 @@ static void LPUART_ReadNonBlocking(LPUART_Type *base, uint8_t *data, size_t leng
 /* Array of LPUART peripheral base address. */
 static LPUART_Type *const s_lpuartBases[] = LPUART_BASE_PTRS;
 /* Array of LPUART handle. */
-void *s_lpuartHandle[ARRAY_SIZE(s_lpuartBases)];
+void *s_lpuartHandle[FSL_ARRAY_SIZE(s_lpuartBases)];
 /* Array of LPUART IRQ number. */
 #if defined(FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ) && FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ
 static const IRQn_Type s_lpuartRxIRQ[] = LPUART_RX_IRQS;
@@ -112,7 +112,7 @@ uint32_t LPUART_GetInstance(LPUART_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_lpuartBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_lpuartBases); instance++)
     {
         if (s_lpuartBases[instance] == base)
         {
@@ -120,7 +120,7 @@ uint32_t LPUART_GetInstance(LPUART_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_lpuartBases));
+    assert(instance < FSL_ARRAY_SIZE(s_lpuartBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/ltc/fsl_ltc.c
+++ b/mcux/mcux-sdk/drivers/ltc/fsl_ltc.c
@@ -3320,7 +3320,7 @@ static void ltc_hash_move_to_ififo(ltc_hash_ctx_internal_t *ctx,
     ltc_hash_block_t blkZero;
     uint32_t i;
 
-    for (i = 0; i < ARRAY_SIZE(blkZero.w); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(blkZero.w); i++)
     {
         blkZero.w[i] = 0;
     }
@@ -3407,7 +3407,7 @@ static status_t ltc_hash_move_rest_to_context(
     uint32_t i;
 
     /* make blkZero clear */
-    for (i = 0; i < ARRAY_SIZE(blkZero.w); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(blkZero.w); i++)
     {
         blkZero.w[i] = 0;
     }

--- a/mcux/mcux-sdk/drivers/mcan/fsl_mcan.c
+++ b/mcux/mcux-sdk/drivers/mcan/fsl_mcan.c
@@ -176,7 +176,7 @@ static uint32_t MCAN_GetInstance(CAN_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_mcanBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_mcanBases); instance++)
     {
         if (s_mcanBases[instance] == base)
         {
@@ -184,7 +184,7 @@ static uint32_t MCAN_GetInstance(CAN_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_mcanBases));
+    assert(instance < FSL_ARRAY_SIZE(s_mcanBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/mecc/fsl_mecc.c
+++ b/mcux/mcux-sdk/drivers/mecc/fsl_mecc.c
@@ -41,7 +41,7 @@ static uint32_t MECC_GetInstance(MECC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_meccBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_meccBases); instance++)
     {
         if (s_meccBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t MECC_GetInstance(MECC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_meccBases));
+    assert(instance < FSL_ARRAY_SIZE(s_meccBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/mipi_csi2rx/fsl_mipi_csi2rx.c
+++ b/mcux/mcux-sdk/drivers/mipi_csi2rx/fsl_mipi_csi2rx.c
@@ -198,7 +198,7 @@ uint32_t CSI2RX_GetInstance(MIPI_CSI2RX_Type *base)
 {
     uint32_t i;
 
-    for (i = 0U; i < ARRAY_SIZE(s_csi2rxBaseAddrs); i++)
+    for (i = 0U; i < FSL_ARRAY_SIZE(s_csi2rxBaseAddrs); i++)
     {
         if ((uint32_t)base == s_csi2rxBaseAddrs[i])
         {

--- a/mcux/mcux-sdk/drivers/mipi_dsi/fsl_mipi_dsi.c
+++ b/mcux/mcux-sdk/drivers/mipi_dsi/fsl_mipi_dsi.c
@@ -91,7 +91,7 @@ static const IRQn_Type s_dsiIRQ[] = MIPI_DSI_HOST_IRQS;
 /*! @brief Pointers to MIPI DSI bases for each instance. */
 static MIPI_DSI_HOST_Type *const s_dsiBases[] = MIPI_DSI_HOST_BASE_PTRS;
 /*! @brief MIPI DSI internal handle pointer array */
-static dsi_handle_t *s_dsiHandle[ARRAY_SIZE(s_dsiBases)];
+static dsi_handle_t *s_dsiHandle[FSL_ARRAY_SIZE(s_dsiBases)];
 /*! @brief Pointer to IRQ handler. */
 static dsi_isr_t s_dsiIsr;
 
@@ -198,7 +198,7 @@ uint32_t DSI_GetInstance(MIPI_DSI_HOST_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dsiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dsiBases); instance++)
     {
         if (s_dsiBases[instance] == base)
         {
@@ -206,7 +206,7 @@ uint32_t DSI_GetInstance(MIPI_DSI_HOST_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dsiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dsiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/mipi_dsi_split/fsl_mipi_dsi.c
+++ b/mcux/mcux-sdk/drivers/mipi_dsi_split/fsl_mipi_dsi.c
@@ -99,7 +99,7 @@ static const DSI_HOST_IRQn s_dsiIRQ[] = DSI_HOST_IRQS;
 /*! @brief Pointers to MIPI DSI bases for each instance. */
 static DSI_HOST_Type *const s_dsiBases[] = DSI_HOST_BASE_PTRS;
 /*! @brief MIPI DSI internal handle pointer array */
-static dsi_handle_t *s_dsiHandle[ARRAY_SIZE(s_dsiBases)];
+static dsi_handle_t *s_dsiHandle[FSL_ARRAY_SIZE(s_dsiBases)];
 /*! @brief Pointer to IRQ handler. */
 static dsi_isr_t s_dsiIsr;
 
@@ -206,7 +206,7 @@ uint32_t DSI_GetInstance(const MIPI_DSI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_dsiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_dsiBases); instance++)
     {
         if (s_dsiBases[instance] == base->host)
         {
@@ -214,7 +214,7 @@ uint32_t DSI_GetInstance(const MIPI_DSI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_dsiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_dsiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/mscan/fsl_mscan.c
+++ b/mcux/mcux-sdk/drivers/mscan/fsl_mscan.c
@@ -162,7 +162,7 @@ static const IRQn_Type s_mscanWakeUpIRQ[]    = MSCAN_WAKE_UP_IRQS;
 static const IRQn_Type s_mscanErrorIRQ[]     = MSCAN_ERR_IRQS;
 
 /* Array of MsCAN handle. */
-static mscan_handle_t *s_mscanHandle[ARRAY_SIZE(s_mscanBases)];
+static mscan_handle_t *s_mscanHandle[FSL_ARRAY_SIZE(s_mscanBases)];
 
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /* Array of MsCAN clock name. */
@@ -185,7 +185,7 @@ static uint32_t MSCAN_GetInstance(MSCAN_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_mscanBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_mscanBases); instance++)
     {
         if (s_mscanBases[instance] == base)
         {
@@ -193,7 +193,7 @@ static uint32_t MSCAN_GetInstance(MSCAN_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_mscanBases));
+    assert(instance < FSL_ARRAY_SIZE(s_mscanBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/opamp/fsl_opamp.c
+++ b/mcux/mcux-sdk/drivers/opamp/fsl_opamp.c
@@ -40,7 +40,7 @@ static uint32_t OPAMP_GetInstance(OPAMP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0UL; instance < ARRAY_SIZE(s_opampBases); instance++)
+    for (instance = 0UL; instance < FSL_ARRAY_SIZE(s_opampBases); instance++)
     {
         if (s_opampBases[instance] == base)
         {
@@ -48,7 +48,7 @@ static uint32_t OPAMP_GetInstance(OPAMP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_opampBases));
+    assert(instance < FSL_ARRAY_SIZE(s_opampBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/ostimer/fsl_ostimer.c
+++ b/mcux/mcux-sdk/drivers/ostimer/fsl_ostimer.c
@@ -72,7 +72,7 @@ static uint32_t OSTIMER_GetInstance(OSTIMER_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_ostimerBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_ostimerBases); instance++)
     {
         if (s_ostimerBases[instance] == base)
         {
@@ -80,7 +80,7 @@ static uint32_t OSTIMER_GetInstance(OSTIMER_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_ostimerBases));
+    assert(instance < FSL_ARRAY_SIZE(s_ostimerBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pdb/fsl_pdb.c
+++ b/mcux/mcux-sdk/drivers/pdb/fsl_pdb.c
@@ -41,7 +41,7 @@ static uint32_t PDB_GetInstance(PDB_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pdbBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pdbBases); instance++)
     {
         if (s_pdbBases[instance] == base)
         {
@@ -49,7 +49,7 @@ static uint32_t PDB_GetInstance(PDB_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pdbBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pdbBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pdm/fsl_pdm.c
+++ b/mcux/mcux-sdk/drivers/pdm/fsl_pdm.c
@@ -39,7 +39,7 @@ static status_t PDM_ValidateSrcClockRate(uint32_t channelMask,
 /* Base pointer array */
 static PDM_Type *const s_pdmBases[] = PDM_BASE_PTRS;
 /*!@brief PDM handle pointer */
-static pdm_handle_t *s_pdmHandle[ARRAY_SIZE(s_pdmBases)];
+static pdm_handle_t *s_pdmHandle[FSL_ARRAY_SIZE(s_pdmBases)];
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /* Clock name array */
 static const clock_ip_name_t s_pdmClock[] = PDM_CLOCKS;
@@ -55,7 +55,7 @@ static const clock_ip_name_t s_pdmFilterClock[] = PDM_FILTER_CLOCKS;
 /*! @brief Pointer to tx IRQ handler for each instance. */
 static pdm_isr_t s_pdmIsr;
 /*! @brief callback for hwvad. */
-static pdm_hwvad_notification_t s_pdm_hwvad_notification[ARRAY_SIZE(s_pdmBases)];
+static pdm_hwvad_notification_t s_pdm_hwvad_notification[FSL_ARRAY_SIZE(s_pdmBases)];
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -64,7 +64,7 @@ uint32_t PDM_GetInstance(PDM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pdmBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pdmBases); instance++)
     {
         if (s_pdmBases[instance] == base)
         {
@@ -72,7 +72,7 @@ uint32_t PDM_GetInstance(PDM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pdmBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pdmBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pdm/fsl_pdm_edma.c
+++ b/mcux/mcux-sdk/drivers/pdm/fsl_pdm_edma.c
@@ -52,7 +52,7 @@ static void PDM_EDMACallback(edma_handle_t *handle, void *userData, bool done, u
 /*! @brief pdm base address pointer */
 static PDM_Type *const s_pdmBases[] = PDM_BASE_PTRS;
 /*<! Private handle only used for internally. */
-static pdm_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_pdmBases)];
+static pdm_edma_private_handle_t s_edmaPrivateHandle[FSL_ARRAY_SIZE(s_pdmBases)];
 /*******************************************************************************
  * Code
  ******************************************************************************/

--- a/mcux/mcux-sdk/drivers/pdm/fsl_pdm_sdma.c
+++ b/mcux/mcux-sdk/drivers/pdm/fsl_pdm_sdma.c
@@ -27,7 +27,7 @@ typedef struct _pdm_sdma_private_handle
 static PDM_Type *const s_pdmBases[] = PDM_BASE_PTRS;
 
 /*<! Private handle only used for internally. */
-static pdm_sdma_private_handle_t s_sdmaPrivateHandle[ARRAY_SIZE(s_pdmBases)];
+static pdm_sdma_private_handle_t s_sdmaPrivateHandle[FSL_ARRAY_SIZE(s_pdmBases)];
 
 /*******************************************************************************
  * Prototypes

--- a/mcux/mcux-sdk/drivers/pit/fsl_pit.c
+++ b/mcux/mcux-sdk/drivers/pit/fsl_pit.c
@@ -44,7 +44,7 @@ static uint32_t PIT_GetInstance(PIT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pitBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pitBases); instance++)
     {
         if (s_pitBases[instance] == base)
         {
@@ -52,7 +52,7 @@ static uint32_t PIT_GetInstance(PIT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pitBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pitBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pwm/fsl_pwm.c
+++ b/mcux/mcux-sdk/drivers/pwm/fsl_pwm.c
@@ -64,7 +64,7 @@ static uint32_t PWM_GetInstance(PWM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pwmBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pwmBases); instance++)
     {
         if (s_pwmBases[instance] == base)
         {
@@ -72,7 +72,7 @@ static uint32_t PWM_GetInstance(PWM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pwmBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pwmBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pwt/fsl_pwt.c
+++ b/mcux/mcux-sdk/drivers/pwt/fsl_pwt.c
@@ -44,7 +44,7 @@ static uint32_t PWT_GetInstance(PWT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pwtBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pwtBases); instance++)
     {
         if (s_pwtBases[instance] == base)
         {
@@ -52,7 +52,7 @@ static uint32_t PWT_GetInstance(PWT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pwtBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pwtBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pwt_1/fsl_pwt.c
+++ b/mcux/mcux-sdk/drivers/pwt_1/fsl_pwt.c
@@ -43,7 +43,7 @@ static uint32_t PWT_GetInstance(PWT_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pwtBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pwtBases); instance++)
     {
         if (s_pwtBases[instance] == base)
         {
@@ -51,7 +51,7 @@ static uint32_t PWT_GetInstance(PWT_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pwtBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pwtBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/pxp/fsl_pxp.c
+++ b/mcux/mcux-sdk/drivers/pxp/fsl_pxp.c
@@ -175,7 +175,7 @@ static uint32_t PXP_GetInstance(PXP_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_pxpBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_pxpBases); instance++)
     {
         if (s_pxpBases[instance] == base)
         {
@@ -183,7 +183,7 @@ static uint32_t PXP_GetInstance(PXP_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_pxpBases));
+    assert(instance < FSL_ARRAY_SIZE(s_pxpBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/qspi/fsl_qspi.c
+++ b/mcux/mcux-sdk/drivers/qspi/fsl_qspi.c
@@ -84,7 +84,7 @@ uint32_t QSPI_GetInstance(QuadSPI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_qspiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_qspiBases); instance++)
     {
         if (s_qspiBases[instance] == base)
         {
@@ -92,7 +92,7 @@ uint32_t QSPI_GetInstance(QuadSPI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_qspiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_qspiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/qtmr_1/fsl_qtmr.c
+++ b/mcux/mcux-sdk/drivers/qtmr_1/fsl_qtmr.c
@@ -43,7 +43,7 @@ static uint32_t QTMR_GetInstance(TMR_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_qtmrBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_qtmrBases); instance++)
     {
         if (s_qtmrBases[instance] == base)
         {
@@ -51,7 +51,7 @@ static uint32_t QTMR_GetInstance(TMR_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_qtmrBases));
+    assert(instance < FSL_ARRAY_SIZE(s_qtmrBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/qtmr_2/fsl_qtmr.c
+++ b/mcux/mcux-sdk/drivers/qtmr_2/fsl_qtmr.c
@@ -43,7 +43,7 @@ static uint32_t QTMR_GetInstance(TMR_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_qtmrBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_qtmrBases); instance++)
     {
         if (s_qtmrBases[instance] == base)
         {
@@ -51,7 +51,7 @@ static uint32_t QTMR_GetInstance(TMR_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_qtmrBases));
+    assert(instance < FSL_ARRAY_SIZE(s_qtmrBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/rdc/fsl_rdc.c
+++ b/mcux/mcux-sdk/drivers/rdc/fsl_rdc.c
@@ -60,7 +60,7 @@ uint32_t RDC_GetInstance(RDC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_rdcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_rdcBases); instance++)
     {
         if (s_rdcBases[instance] == base)
         {
@@ -68,7 +68,7 @@ uint32_t RDC_GetInstance(RDC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_rdcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_rdcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/rdc_sema42/fsl_rdc_sema42.c
+++ b/mcux/mcux-sdk/drivers/rdc_sema42/fsl_rdc_sema42.c
@@ -63,7 +63,7 @@ uint32_t RDC_SEMA42_GetInstance(RDC_SEMAPHORE_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_sema42Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_sema42Bases); instance++)
     {
         if (s_sema42Bases[instance] == base)
         {
@@ -71,7 +71,7 @@ uint32_t RDC_SEMA42_GetInstance(RDC_SEMAPHORE_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_sema42Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_sema42Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/rgpio/fsl_rgpio.c
+++ b/mcux/mcux-sdk/drivers/rgpio/fsl_rgpio.c
@@ -54,7 +54,7 @@ uint32_t RGPIO_GetInstance(RGPIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_rgpioBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_rgpioBases); instance++)
     {
         if (s_rgpioBases[instance] == base)
         {
@@ -62,7 +62,7 @@ uint32_t RGPIO_GetInstance(RGPIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_rgpioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_rgpioBases));
 
     return instance;
 }
@@ -191,7 +191,7 @@ uint32_t FGPIO_GetInstance(FGPIO_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_fgpioBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_fgpioBases); instance++)
     {
         if (s_fgpioBases[instance] == base)
         {
@@ -199,7 +199,7 @@ uint32_t FGPIO_GetInstance(FGPIO_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_fgpioBases));
+    assert(instance < FSL_ARRAY_SIZE(s_fgpioBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sai/fsl_sai.c
+++ b/mcux/mcux-sdk/drivers/sai/fsl_sai.c
@@ -108,7 +108,7 @@ static void SAI_GetCommonConfig(sai_transceiver_t *config,
 /* Base pointer array */
 static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 /*!@brief SAI handle pointer */
-static sai_handle_t *s_saiHandle[ARRAY_SIZE(s_saiBases)][2];
+static sai_handle_t *s_saiHandle[FSL_ARRAY_SIZE(s_saiBases)][2];
 /* IRQ number array */
 static const IRQn_Type s_saiTxIRQ[] = I2S_TX_IRQS;
 static const IRQn_Type s_saiRxIRQ[] = I2S_RX_IRQS;
@@ -223,7 +223,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_saiBases); instance++)
     {
         if (s_saiBases[instance] == base)
         {
@@ -231,7 +231,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_saiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_saiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sai/fsl_sai_edma.c
+++ b/mcux/mcux-sdk/drivers/sai/fsl_sai_edma.c
@@ -39,7 +39,7 @@ enum
 };
 
 /*<! Private handle only used for internally. */
-static sai_edma_private_handle_t s_edmaPrivateHandle[ARRAY_SIZE(s_saiBases)][2];
+static sai_edma_private_handle_t s_edmaPrivateHandle[FSL_ARRAY_SIZE(s_saiBases)][2];
 
 /*******************************************************************************
  * Prototypes
@@ -79,7 +79,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_saiBases); instance++)
     {
         if (s_saiBases[instance] == base)
         {
@@ -87,7 +87,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_saiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_saiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sai/fsl_sai_sdma.c
+++ b/mcux/mcux-sdk/drivers/sai/fsl_sai_sdma.c
@@ -33,7 +33,7 @@ enum
 static I2S_Type *const s_saiBases[] = I2S_BASE_PTRS;
 
 /*<! Private handle only used for internally. */
-static sai_sdma_private_handle_t s_sdmaPrivateHandle[ARRAY_SIZE(s_saiBases)][2];
+static sai_sdma_private_handle_t s_sdmaPrivateHandle[FSL_ARRAY_SIZE(s_saiBases)][2];
 
 /*******************************************************************************
  * Prototypes
@@ -73,7 +73,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_saiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_saiBases); instance++)
     {
         if (s_saiBases[instance] == base)
         {
@@ -81,7 +81,7 @@ static uint32_t SAI_GetInstance(I2S_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_saiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_saiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sdhc/fsl_sdhc.c
+++ b/mcux/mcux-sdk/drivers/sdhc/fsl_sdhc.c
@@ -220,12 +220,12 @@ static uint32_t SDHC_GetInstance(SDHC_Type *base)
 {
     uint8_t instance = 0;
 
-    while ((instance < ARRAY_SIZE(s_sdhcBase)) && (s_sdhcBase[instance] != base))
+    while ((instance < FSL_ARRAY_SIZE(s_sdhcBase)) && (s_sdhcBase[instance] != base))
     {
         instance++;
     }
 
-    assert(instance < ARRAY_SIZE(s_sdhcBase));
+    assert(instance < FSL_ARRAY_SIZE(s_sdhcBase));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sdif/fsl_sdif.c
+++ b/mcux/mcux-sdk/drivers/sdif/fsl_sdif.c
@@ -218,12 +218,12 @@ static uint32_t SDIF_GetInstance(SDIF_Type *base)
 {
     uint8_t instance = 0U;
 
-    while ((instance < ARRAY_SIZE(s_sdifBase)) && (s_sdifBase[instance] != base))
+    while ((instance < FSL_ARRAY_SIZE(s_sdifBase)) && (s_sdifBase[instance] != base))
     {
         instance++;
     }
 
-    assert(instance < ARRAY_SIZE(s_sdifBase));
+    assert(instance < FSL_ARRAY_SIZE(s_sdifBase));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sdma/fsl_sdma.c
+++ b/mcux/mcux-sdk/drivers/sdma/fsl_sdma.c
@@ -114,7 +114,7 @@ static uint32_t SDMA_GetInstance(SDMAARM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_sdmaBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_sdmaBases); instance++)
     {
         if (s_sdmaBases[instance] == base)
         {
@@ -122,7 +122,7 @@ static uint32_t SDMA_GetInstance(SDMAARM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_sdmaBases));
+    assert(instance < FSL_ARRAY_SIZE(s_sdmaBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sdramc/fsl_sdramc.c
+++ b/mcux/mcux-sdk/drivers/sdramc/fsl_sdramc.c
@@ -51,7 +51,7 @@ static uint32_t SDRAMC_GetInstance(SDRAM_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_sdramcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_sdramcBases); instance++)
     {
         if (s_sdramcBases[instance] == base)
         {
@@ -59,7 +59,7 @@ static uint32_t SDRAMC_GetInstance(SDRAM_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_sdramcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_sdramcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sema4/fsl_sema4.c
+++ b/mcux/mcux-sdk/drivers/sema4/fsl_sema4.c
@@ -69,7 +69,7 @@ uint32_t SEMA4_GetInstance(SEMA4_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_sema4Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_sema4Bases); instance++)
     {
         if (s_sema4Bases[instance] == base)
         {
@@ -77,7 +77,7 @@ uint32_t SEMA4_GetInstance(SEMA4_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_sema4Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_sema4Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sema42/fsl_sema42.c
+++ b/mcux/mcux-sdk/drivers/sema42/fsl_sema42.c
@@ -54,7 +54,7 @@ uint32_t SEMA42_GetInstance(SEMA42_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_sema42Bases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_sema42Bases); instance++)
     {
         if (s_sema42Bases[instance] == base)
         {
@@ -62,7 +62,7 @@ uint32_t SEMA42_GetInstance(SEMA42_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_sema42Bases));
+    assert(instance < FSL_ARRAY_SIZE(s_sema42Bases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/semc/fsl_semc.c
+++ b/mcux/mcux-sdk/drivers/semc/fsl_semc.c
@@ -121,7 +121,7 @@ static uint32_t SEMC_GetInstance(SEMC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_semcBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_semcBases); instance++)
     {
         if (s_semcBases[instance] == base)
         {
@@ -129,7 +129,7 @@ static uint32_t SEMC_GetInstance(SEMC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_semcBases));
+    assert(instance < FSL_ARRAY_SIZE(s_semcBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/slcd/fsl_slcd.c
+++ b/mcux/mcux-sdk/drivers/slcd/fsl_slcd.c
@@ -52,7 +52,7 @@ static uint32_t SLCD_GetInstance(LCD_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_slcdBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_slcdBases); instance++)
     {
         if (s_slcdBases[instance] == base)
         {
@@ -60,7 +60,7 @@ static uint32_t SLCD_GetInstance(LCD_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_slcdBases));
+    assert(instance < FSL_ARRAY_SIZE(s_slcdBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/spdif/fsl_spdif.c
+++ b/mcux/mcux-sdk/drivers/spdif/fsl_spdif.c
@@ -36,7 +36,7 @@ typedef void (*spdif_isr_t)(SPDIF_Type *base, spdif_handle_t *handle);
 /* Base pointer array */
 static SPDIF_Type *const s_spdifBases[] = SPDIF_BASE_PTRS;
 /*! @brief SPDIF handle pointer */
-static spdif_handle_t *s_spdifHandle[ARRAY_SIZE(s_spdifBases)][2];
+static spdif_handle_t *s_spdifHandle[FSL_ARRAY_SIZE(s_spdifBases)][2];
 /* IRQ number array */
 static const IRQn_Type s_spdifIRQ[] = SPDIF_IRQS;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -60,7 +60,7 @@ uint32_t SPDIF_GetInstance(SPDIF_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_spdifBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_spdifBases); instance++)
     {
         if (s_spdifBases[instance] == base)
         {
@@ -68,7 +68,7 @@ uint32_t SPDIF_GetInstance(SPDIF_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_spdifBases));
+    assert(instance < FSL_ARRAY_SIZE(s_spdifBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/spi/fsl_spi.c
+++ b/mcux/mcux-sdk/drivers/spi/fsl_spi.c
@@ -107,7 +107,7 @@ static spi_isr_t s_spiMasterIsr;
 static spi_isr_t s_spiSlaveIsr;
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t g_spiDummyData[ARRAY_SIZE(s_spiBases)] = {0};
+volatile uint8_t g_spiDummyData[FSL_ARRAY_SIZE(s_spiBases)] = {0};
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -121,7 +121,7 @@ uint32_t SPI_GetInstance(SPI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_spiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_spiBases); instance++)
     {
         if (s_spiBases[instance] == base)
         {
@@ -129,7 +129,7 @@ uint32_t SPI_GetInstance(SPI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_spiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_spiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/spifi/fsl_spifi.c
+++ b/mcux/mcux-sdk/drivers/spifi/fsl_spifi.c
@@ -51,7 +51,7 @@ uint32_t SPIFI_GetInstance(SPIFI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_spifiBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_spifiBases); instance++)
     {
         if (s_spifiBases[instance] == base)
         {
@@ -59,7 +59,7 @@ uint32_t SPIFI_GetInstance(SPIFI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_spifiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_spifiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/sysctl/fsl_sysctl.c
+++ b/mcux/mcux-sdk/drivers/sysctl/fsl_sysctl.c
@@ -61,12 +61,12 @@ static uint32_t SYSCTL_GetInstance(SYSCTL_Type *base)
 {
     uint8_t instance = 0;
 
-    while ((instance < ARRAY_SIZE(s_sysctlBase)) && (s_sysctlBase[instance] != base))
+    while ((instance < FSL_ARRAY_SIZE(s_sysctlBase)) && (s_sysctlBase[instance] != base))
     {
         instance++;
     }
 
-    assert(instance < ARRAY_SIZE(s_sysctlBase));
+    assert(instance < FSL_ARRAY_SIZE(s_sysctlBase));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/tmu/fsl_tmu.c
+++ b/mcux/mcux-sdk/drivers/tmu/fsl_tmu.c
@@ -47,7 +47,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_tmuBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_tmuBases); instance++)
     {
         if (s_tmuBases[instance] == base)
         {
@@ -55,7 +55,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_tmuBases));
+    assert(instance < FSL_ARRAY_SIZE(s_tmuBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/tmu_1/fsl_tmu.c
+++ b/mcux/mcux-sdk/drivers/tmu_1/fsl_tmu.c
@@ -47,7 +47,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_tmuBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_tmuBases); instance++)
     {
         if (s_tmuBases[instance] == base)
         {
@@ -55,7 +55,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_tmuBases));
+    assert(instance < FSL_ARRAY_SIZE(s_tmuBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/tmu_2/fsl_tmu.c
+++ b/mcux/mcux-sdk/drivers/tmu_2/fsl_tmu.c
@@ -65,7 +65,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_tmuBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_tmuBases); instance++)
     {
         if (s_tmuBases[instance] == base)
         {
@@ -73,7 +73,7 @@ static uint32_t TMU_GetInstance(TMU_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_tmuBases));
+    assert(instance < FSL_ARRAY_SIZE(s_tmuBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/trng/fsl_trng.c
+++ b/mcux/mcux-sdk/drivers/trng/fsl_trng.c
@@ -1233,7 +1233,7 @@ static uint32_t trng_GetInstance(TRNG_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_trngBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_trngBases); instance++)
     {
         if (s_trngBases[instance] == base)
         {
@@ -1241,7 +1241,7 @@ static uint32_t trng_GetInstance(TRNG_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_trngBases));
+    assert(instance < FSL_ARRAY_SIZE(s_trngBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/tsc/fsl_tsc.c
+++ b/mcux/mcux-sdk/drivers/tsc/fsl_tsc.c
@@ -42,7 +42,7 @@ static uint32_t TSC_GetInstance(TSC_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_tscBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_tscBases); instance++)
     {
         if (s_tscBases[instance] == base)
         {
@@ -50,7 +50,7 @@ static uint32_t TSC_GetInstance(TSC_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_tscBases));
+    assert(instance < FSL_ARRAY_SIZE(s_tscBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/tsi/fsl_tsi_v5.c
+++ b/mcux/mcux-sdk/drivers/tsi/fsl_tsi_v5.c
@@ -39,7 +39,7 @@ uint32_t TSI_GetInstance(TSI_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0U; instance < ARRAY_SIZE(s_tsiBases); instance++)
+    for (instance = 0U; instance < FSL_ARRAY_SIZE(s_tsiBases); instance++)
     {
         if (s_tsiBases[instance] == base)
         {
@@ -47,7 +47,7 @@ uint32_t TSI_GetInstance(TSI_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_tsiBases));
+    assert(instance < FSL_ARRAY_SIZE(s_tsiBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/usdhc/fsl_usdhc.c
+++ b/mcux/mcux-sdk/drivers/usdhc/fsl_usdhc.c
@@ -206,7 +206,7 @@ static void USDHC_TransferHandleReTuning(USDHC_Type *base, usdhc_handle_t *handl
 static USDHC_Type *const s_usdhcBase[] = USDHC_BASE_PTRS;
 
 /*! @brief USDHC internal handle pointer array */
-static usdhc_handle_t *s_usdhcHandle[ARRAY_SIZE(s_usdhcBase)] = {0};
+static usdhc_handle_t *s_usdhcHandle[FSL_ARRAY_SIZE(s_usdhcBase)] = {0};
 
 /*! @brief USDHC IRQ name array */
 static const IRQn_Type s_usdhcIRQ[] = USDHC_IRQS;
@@ -237,12 +237,12 @@ static uint32_t USDHC_GetInstance(USDHC_Type *base)
 {
     uint8_t instance = 0;
 
-    while ((instance < ARRAY_SIZE(s_usdhcBase)) && (s_usdhcBase[instance] != base))
+    while ((instance < FSL_ARRAY_SIZE(s_usdhcBase)) && (s_usdhcBase[instance] != base))
     {
         instance++;
     }
 
-    assert(instance < ARRAY_SIZE(s_usdhcBase));
+    assert(instance < FSL_ARRAY_SIZE(s_usdhcBase));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/utick/fsl_utick.c
+++ b/mcux/mcux-sdk/drivers/utick/fsl_utick.c
@@ -68,7 +68,7 @@ static uint32_t UTICK_GetInstance(UTICK_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_utickBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_utickBases); instance++)
     {
         if (s_utickBases[instance] == base)
         {
@@ -76,7 +76,7 @@ static uint32_t UTICK_GetInstance(UTICK_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_utickBases));
+    assert(instance < FSL_ARRAY_SIZE(s_utickBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/vref/fsl_vref.c
+++ b/mcux/mcux-sdk/drivers/vref/fsl_vref.c
@@ -47,7 +47,7 @@ static uint32_t VREF_GetInstance(VREF_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_vrefBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_vrefBases); instance++)
     {
         if (s_vrefBases[instance] == base)
         {
@@ -55,7 +55,7 @@ static uint32_t VREF_GetInstance(VREF_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_vrefBases));
+    assert(instance < FSL_ARRAY_SIZE(s_vrefBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/vref_1/fsl_vref.c
+++ b/mcux/mcux-sdk/drivers/vref_1/fsl_vref.c
@@ -46,7 +46,7 @@ static uint32_t VREF_GetInstance(VREF_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_vrefBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_vrefBases); instance++)
     {
         if (s_vrefBases[instance] == base)
         {
@@ -54,7 +54,7 @@ static uint32_t VREF_GetInstance(VREF_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_vrefBases));
+    assert(instance < FSL_ARRAY_SIZE(s_vrefBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/wdog01/fsl_wdog.c
+++ b/mcux/mcux-sdk/drivers/wdog01/fsl_wdog.c
@@ -32,7 +32,7 @@ static uint32_t WDOG_GetInstance(WDOG_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_wdogBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_wdogBases); instance++)
     {
         if (s_wdogBases[instance] == base)
         {
@@ -40,7 +40,7 @@ static uint32_t WDOG_GetInstance(WDOG_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_wdogBases));
+    assert(instance < FSL_ARRAY_SIZE(s_wdogBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/xbar/fsl_xbar.c
+++ b/mcux/mcux-sdk/drivers/xbar/fsl_xbar.c
@@ -59,7 +59,7 @@ static const clock_ip_name_t s_xbarClock[] = XBAR_CLOCKS;
 static uint32_t XBAR_GetInstance(XBAR_Type *base)
 {
     uint32_t instance;
-    uint32_t xbarInstanceCount = ARRAY_SIZE(s_xbarBases);
+    uint32_t xbarInstanceCount = FSL_ARRAY_SIZE(s_xbarBases);
 
     /* Find the instance index from base address mappings. */
     for (instance = 0; instance < xbarInstanceCount; instance++)

--- a/mcux/mcux-sdk/drivers/xbara/fsl_xbara.c
+++ b/mcux/mcux-sdk/drivers/xbara/fsl_xbara.c
@@ -59,7 +59,7 @@ static uint32_t XBARA_GetInstance(XBARA_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_xbaraBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_xbaraBases); instance++)
     {
         if (s_xbaraBases[instance] == base)
         {
@@ -67,7 +67,7 @@ static uint32_t XBARA_GetInstance(XBARA_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_xbaraBases));
+    assert(instance < FSL_ARRAY_SIZE(s_xbaraBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/xbarb/fsl_xbarb.c
+++ b/mcux/mcux-sdk/drivers/xbarb/fsl_xbarb.c
@@ -56,7 +56,7 @@ static uint32_t XBARB_GetInstance(XBARB_Type *base)
     uint32_t instance;
 
     /* Find the instance index from base address mappings. */
-    for (instance = 0; instance < ARRAY_SIZE(s_xbarbBases); instance++)
+    for (instance = 0; instance < FSL_ARRAY_SIZE(s_xbarbBases); instance++)
     {
         if (s_xbarbBases[instance] == base)
         {
@@ -64,7 +64,7 @@ static uint32_t XBARB_GetInstance(XBARB_Type *base)
         }
     }
 
-    assert(instance < ARRAY_SIZE(s_xbarbBases));
+    assert(instance < FSL_ARRAY_SIZE(s_xbarbBases));
 
     return instance;
 }

--- a/mcux/mcux-sdk/drivers/xrdc/fsl_xrdc.c
+++ b/mcux/mcux-sdk/drivers/xrdc/fsl_xrdc.c
@@ -104,7 +104,7 @@ void XRDC_Init(XRDC_Type *base)
 #else
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_xrdcClock); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_xrdcClock); i++)
     {
         CLOCK_EnableClock(s_xrdcClock[i]);
     }
@@ -131,7 +131,7 @@ void XRDC_Deinit(XRDC_Type *base)
 #else
     uint8_t i;
 
-    for (i = 0; i < ARRAY_SIZE(s_xrdcClock); i++)
+    for (i = 0; i < FSL_ARRAY_SIZE(s_xrdcClock); i++)
     {
         CLOCK_DisableClock(s_xrdcClock[i]);
     }

--- a/mcux/middleware/mcux-sdk-middleware-usb/output/source/device/class/usb_device_class.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/output/source/device/class/usb_device_class.c
@@ -340,7 +340,7 @@ usb_status_t USB_DeviceClassEvent(usb_device_handle handle, usb_device_class_eve
 
     for (classIndex = 0U; classIndex < classHandle->configList->count; classIndex++)
     {
-        for (mapIndex = 0U; mapIndex < (ARRAY_SIZE(s_UsbDeviceClassInterfaceMap) - 1U); mapIndex++)
+        for (mapIndex = 0U; mapIndex < (FSL_ARRAY_SIZE(s_UsbDeviceClassInterfaceMap) - 1U); mapIndex++)
         {
             if (s_UsbDeviceClassInterfaceMap[mapIndex].type ==
                 classHandle->configList->config[classIndex].classInfomation->type)


### PR DESCRIPTION
ARRAY_SIZE is already defined by Zephyr, so it can't be re-used in public headers such as fsl_common.h (used by some Zephyr code). Rename the macro to FSL_ARRAY_SIZE instead.

Automated using:

```
perl -i -pe 's/([^_])ARRAY_SIZE\((.*)\)/\1FSL_ARRAY_SIZE(\2)/g' **/*.c/h
```

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>