### PR TITLE
cmake: remove board definitions and flash configuration includes

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -211,68 +211,6 @@ if(${MCUX_DEVICE} MATCHES "MIMXRT(5|6)")
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/lpc_iopctl)
 endif()
 
-#include macro definition
-zephyr_compile_definitions_ifdef(CONFIG_NXP_IMX_RT_BOOT_HEADER XIP_BOOT_HEADER_ENABLE=1)
-zephyr_compile_definitions_ifdef(CONFIG_NXP_IMX_RT6XX_BOOT_HEADER BOOT_HEADER_ENABLE=1)
-zephyr_compile_definitions_ifdef(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER BOOT_HEADER_ENABLE=1)
-zephyr_compile_definitions_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA XIP_BOOT_HEADER_DCD_ENABLE=1)
-zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-
-if(CONFIG_BOARD_MIMXRT1010_EVK)
-  set(MCUX_BOARD evkmimxrt1010)
-elseif(CONFIG_BOARD_MIMXRT1015_EVK)
-  set(MCUX_BOARD evkmimxrt1015)
-elseif(CONFIG_BOARD_MIMXRT1020_EVK)
-  set(MCUX_BOARD evkmimxrt1020)
-elseif(CONFIG_BOARD_MIMXRT1024_EVK)
-  set(MCUX_BOARD evkmimxrt1024)
-elseif(CONFIG_BOARD_MIMXRT1050_EVK OR CONFIG_BOARD_MIMXRT1050_EVK_QSPI)
-  set(MCUX_BOARD evkbimxrt1050)
-if (CONFIG_BOARD_MIMXRT1050_EVK_QSPI)
-  set(MCUX_BOARD_MOD _qspi)
-endif()
-elseif(CONFIG_BOARD_MIMXRT1060_EVK OR CONFIG_BOARD_MIMXRT1060_EVK_HYPERFLASH)
-  set(MCUX_BOARD evkmimxrt1060)
-elseif(CONFIG_BOARD_MIMXRT1060_EVKB)
-  set(MCUX_BOARD evkbmimxrt1060)
-elseif(CONFIG_BOARD_MIMXRT1064_EVK)
-  set(MCUX_BOARD evkmimxrt1064)
-elseif(CONFIG_BOARD_MIMXRT595_EVK)
-  set(MCUX_BOARD evkmimxrt595)
-elseif(CONFIG_BOARD_MIMXRT685_EVK)
-  set(MCUX_BOARD evkmimxrt685)
-elseif(CONFIG_BOARD_MIMXRT1170_EVK_CM7 OR CONFIG_BOARD_MIMXRT1170_EVK_CM4)
-  set(MCUX_BOARD evkmimxrt1170)
-elseif(CONFIG_BOARD_MIMXRT1160_EVK_CM7 OR CONFIG_BOARD_MIMXRT1160_EVK_CM4)
-  set(MCUX_BOARD evkmimxrt1160)
-endif()
-
-if (${MCUX_BOARD} MATCHES "evk[b]?[bm]imxrt1[0-9][0-9][0-9]")
-  list(APPEND CMAKE_MODULE_PATH
-    ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD}/xip
-  )
-  include_ifdef(CONFIG_BOOT_FLEXSPI_NOR driver_xip_board_${MCUX_BOARD}${MCUX_BOARD_MOD})
-  zephyr_library_sources_ifdef(CONFIG_DEVICE_CONFIGURATION_DATA mcux-sdk/boards/${MCUX_BOARD}/dcd.c)
-  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD})
-
-elseif (${MCUX_BOARD} MATCHES "evkmimxrt6[0-9][0-9]")
-
-  list(APPEND CMAKE_MODULE_PATH
-    ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD}/flash_config
-  )
-  include_ifdef(CONFIG_NXP_IMX_RT6XX_BOOT_HEADER    driver_flash_config)
-  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD})
-
-elseif (${MCUX_BOARD} MATCHES "evkmimxrt5[0-9][0-9]")
-
-  list(APPEND CMAKE_MODULE_PATH
-    ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD}/flash_config
-  )
-  include_ifdef(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER    driver_flash_config)
-  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/boards/${MCUX_BOARD})
-
-endif()
-
 if(CONFIG_ETH_MCUX)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/phy)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/phy/device/phyksz8081)


### PR DESCRIPTION
Remove board related definitions, as well as flash configuration includes from NXP HAL cmake. Although the board configuration files are still present, they are now included from board directories in tree, so that customers porting Zephyr to a custom board face less challenges locating the relevant file.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>