### PR TITLE
mcux: add CMSIS SystemInit cmake files where required

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -44,7 +44,7 @@ zephyr_library_compile_definitions_ifdef(
 
 include(driver_common)
 
-#Include system_xxx file for MXRT platforms
+#Include system_xxx file
 #This can be extended to other SoC series if needed
 if (CONFIG_SOC_MIMXRT1166_CM4)
 include(device_system_MIMXRT1166_cm4)
@@ -54,7 +54,15 @@ elseif (CONFIG_SOC_MIMXRT1176_CM4)
 include(device_system_MIMXRT1176_cm4)
 elseif (CONFIG_SOC_MIMXRT1176_CM7)
 include(device_system_MIMXRT1176_cm7)
-elseif (CONFIG_SOC_SERIES_IMX_RT OR CONFIG_SOC_SERIES_IMX_RT6XX OR CONFIG_SOC_SERIES_IMX_RT5XX)
+elseif (CONFIG_SOC_LPC55S69_CPU0)
+include(device_system_LPC55S69_cm33_core0)
+elseif (CONFIG_SOC_LPC55S69_CPU1)
+include(device_system_LPC55S69_cm33_core1)
+elseif (CONFIG_SOC_LPC54114_M4)
+include(device_system_LPC54114_cm4)
+elseif (CONFIG_SOC_LPC54114_M0)
+include(device_system_LPC54114_cm0plus)
+elseif (CONFIG_PLATFORM_SPECIFIC_INIT)
 include(device_system)
 endif()
 

--- a/mcux/mcux-sdk/devices/MK82F25615/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MK82F25615/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MK82F25615.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)

--- a/mcux/mcux-sdk/devices/MKL25Z4/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MKL25Z4/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MKL25Z4.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)

--- a/mcux/mcux-sdk/devices/MKW24D5/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MKW24D5/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MKW24D5.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)

--- a/mcux/mcux-sdk/devices/MKW40Z4/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MKW40Z4/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MKW40Z4.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)

--- a/mcux/mcux-sdk/devices/MKW41Z4/device_system.cmake
+++ b/mcux/mcux-sdk/devices/MKW41Z4/device_system.cmake
@@ -1,0 +1,14 @@
+#Description: device_system; user_visible: False
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MKW41Z4.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(device_CMSIS)


### PR DESCRIPTION
Add CMSIS SystemInit cmake files where required, and include device_system cmake for all SOCs, as this is where the CMSIS SystemInit function is defined.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>