### PR TITLE
mcux: hal_nxp: only relocate flexSPI driver when CONFIG_FLASH=y

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -25,7 +25,7 @@ endfunction()
 message("Load components for ${MCUX_DEVICE}:")
 
 #specific operation to shared drivers
-if(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+if((DEFINED CONFIG_FLASH_MCUX_FLEXSPI_XIP) AND (DEFINED CONFIG_FLASH))
   zephyr_code_relocate(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/flexspi/fsl_flexspi.c ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
 endif()
 


### PR DESCRIPTION
Only relocate flexSPI driver when CONFIG_FLASH=y.
CONFIG_FLASH_MCUX_FLEXSPI_XIP previously was dependent on CONFIG_FLASH, but the scope of this Kconfig has changed. Due to this, the flexSPI driver now must have two checks, as it should not relocated when the driver is being used for a memory controller that does not expose the flash driver interface

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>