### PR TITLE
mcux: mcux-sdk: driver: flexcan: propagate kStatus_FLEXCAN_RxOverflow

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -66,3 +66,4 @@ Patch List:
      write side, the EDL bit is now utilized for selection of can frame type and on the receiver side, the EDL and BRS status are read from the message
      buffer.
   4. Add device_system cmake definitions for the following SOCs: MKL25Z4, MK82F25615, MKW24D5, MKW40Z4, MKW41Z4
+  5. Fixed the FlexCAN driver to propagate kStatus_FLEXCAN_RxOverflow mailbox status when using the FlexCAN driver transactional APIs.

--- a/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c
+++ b/mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c
@@ -4261,22 +4261,28 @@ static status_t FLEXCAN_SubHandlerForDataTransfered(CAN_Type *base, flexcan_hand
                     if (0U != (base->MCR & CAN_MCR_FDEN_MASK))
                     {
                         status = FLEXCAN_ReadFDRxMb(base, (uint8_t)result, handle->mbFDFrameBuf[result]);
-                        if (kStatus_Success == status)
+                        if (kStatus_Success == status || kStatus_FLEXCAN_RxOverflow == status)
                         {
                             /* Align the current index of RX MB timestamp to the timestamp array by handle. */
                             handle->timestamp[result] = handle->mbFDFrameBuf[result]->timestamp;
-                            status                    = kStatus_FLEXCAN_RxIdle;
+                            if (kStatus_Success == status)
+                            {
+                                status = kStatus_FLEXCAN_RxIdle;
+                            }
                         }
                     }
                     else
 #endif
                     {
                         status = FLEXCAN_ReadRxMb(base, (uint8_t)result, handle->mbFrameBuf[result]);
-                        if (kStatus_Success == status)
+                        if (kStatus_Success == status || kStatus_FLEXCAN_RxOverflow == status)
                         {
                             /* Align the current index of RX MB timestamp to the timestamp array by handle. */
                             handle->timestamp[result] = handle->mbFrameBuf[result]->timestamp;
-                            status                    = kStatus_FLEXCAN_RxIdle;
+                            if (kStatus_Success == status)
+                            {
+                                status = kStatus_FLEXCAN_RxIdle;
+                            }
                         }
                     }
 #if (defined(FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE) && FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE)


### PR DESCRIPTION
Propagate kStatus_FLEXCAN_RxOverflow status when using the FlexCAN transactional APIs.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>