### PR TITLE
mcux: include device_system unconditionally

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -65,3 +65,4 @@ Patch List:
   3. Fixed flexcan_fd_frame being written into/written from the message buffer in the flexcan driver (mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c). On the
      write side, the EDL bit is now utilized for selection of can frame type and on the receiver side, the EDL and BRS status are read from the message
      buffer.
+  4. Add device_system cmake definitions for the following SOCs: MKL25Z4, MK82F25615, MKW24D5, MKW40Z4, MKW41Z4

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -62,7 +62,7 @@ elseif (CONFIG_SOC_LPC54114_M4)
 include(device_system_LPC54114_cm4)
 elseif (CONFIG_SOC_LPC54114_M0)
 include(device_system_LPC54114_cm0plus)
-elseif (CONFIG_PLATFORM_SPECIFIC_INIT)
+else()
 include(device_system)
 endif()
 


### PR DESCRIPTION
Include device_system cmake file unconditionally for NXP SOCs. The files sourced by device_system implement CMSIS SystemInit, and also define core clock variables used by some RT series SOCs.

Add notes to the README patch list specifying SOCs which have had device_system files added.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>