### PR TITLE
drivers: flexio: fixes SPI Master SHIFTBUF Overrun

### DIFF
--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio_spi.c
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio_spi.c
@@ -1307,8 +1307,14 @@ void FLEXIO_SPI_MasterTransferHandleIRQ(void *spiType, void *spiHandle)
     base   = (FLEXIO_SPI_Type *)spiType;
     status = FLEXIO_SPI_GetStatusFlags(base);
 
+    /* Receive interrupt. */
+    if ((status & (uint32_t)kFLEXIO_SPI_RxBufferFullFlag) == 0)
+    {
+        return;
+    }
+
     /* Handle rx. */
-    if (((status & (uint32_t)kFLEXIO_SPI_RxBufferFullFlag) != 0U) && (handle->rxRemainingBytes != 0U))
+    if (handle->rxRemainingBytes != 0U)
     {
         FLEXIO_SPI_TransferReceiveTransaction(base, handle);
     }


### PR DESCRIPTION
When implementing multiple FLEXIO SPIs, the parent interrupt handler calls all child interrupt handlers in turn, for example FLEXIO_SPI_MasterTransferHandleIRQ().
The problem appears when the interrupt is generated by one interface, and in another interface the send buffer is empty
(kFLEXIO_SPI_TxBufferEmptyFlag is set), and there is no data in the receive buffer yet (kFLEXIO_SPI_RxBufferFullFlag is not set), then without waiting for data in the receive buffer, the handler will send new data, which will result in to data loss (SHIFTBUF Overrun). Since in SPI MASTER mode an interrupt is generated only when the receive buffer is full, the child interrupt handler should only be executed when the receive buffer is full.

Signed-off-by: Mikhail Siomin <victorovich.01@mail.ru>