### PR TITLE
mcux: changed FlexIO SPI dummy transfer data

### DIFF
--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio_spi.h
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio_spi.h
@@ -29,7 +29,7 @@
 
 #ifndef FLEXIO_SPI_DUMMYDATA
 /*! @brief FlexIO SPI dummy transfer data, the data is sent while txData is NULL. */
-#define FLEXIO_SPI_DUMMYDATA (0xFFFFFFFFU)
+#define FLEXIO_SPI_DUMMYDATA (0x00U)
 #endif
 
 /*! @brief Retry times for waiting flag. */


### PR DESCRIPTION
Other SPI drivers use dummy transfer data equal to 0x00. Tests also expect 0x00 after dummy data transfer.

Signed-off-by: Mikhail Siomin <victorovich.01@mail.ru>