### PR TITLE
mcux: fsl_caam: Fix forced reseed on each RNG request

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -67,3 +67,4 @@ Patch List:
      buffer.
   4. Add device_system cmake definitions for the following SOCs: MKL25Z4, MK82F25615, MKW24D5, MKW40Z4, MKW41Z4
   5. Fixed the FlexCAN driver to propagate kStatus_FLEXCAN_RxOverflow mailbox status when using the FlexCAN driver transactional APIs.
+  6. Fixed fsl_caam.c: CAAM_RNG_GetRandomDataNonBlocking() to not force a reseed with each request. Internal bug submitted [MCUX-57074]

--- a/mcux/mcux-sdk/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk/drivers/caam/fsl_caam.c
@@ -3653,7 +3653,7 @@ static const uint32_t templateRng[] = {
     /* 02 */ 0x00000000u, /* place: additional input address */
     /* 03 */ 0x12820004u, /* LOAD Class 1 Data Size Register by IMM data */
     /* 04 */ 0x00000000u, /* place: data size to generate */
-    /* 05 */ 0x82500002u, /* RNG generate */
+    /* 05 */ 0x82500000u, /* RNG generate */
     /* 06 */ 0x60700000u, /* FIFO STORE message */
     /* 07 */ 0x00000000u, /* place: destination address */
     /* 08 */ 0x00000000u, /* place: destination size */
@@ -3696,6 +3696,7 @@ status_t CAAM_RNG_GetRandomDataNonBlocking(CAAM_Type *base,
     if (additionalEntropy != NULL)
     {
         descriptor[2] = ADD_OFFSET((uint32_t)additionalEntropy);
+        descriptor[5] |= (uint32_t)1U << 1;  /* set PR bit in ALG OPERATION (entropy seed) */
         descriptor[5] |= (uint32_t)1U << 11; /* set AI bit in ALG OPERATION */
     }
     else


### PR DESCRIPTION
The templateRng descriptor used by CAAM_RNG_GetRandomDataNonBlocking() sets the PR (predictive ressitance) bit for each RNG request. This forces the hardware to regenerate entropy and reseed the DRBG on each request.

Cost on a 4000 byte rng request:

- with reseed: 130+ ms
- without reseed: 39 us

on a 4 byte request it is 130 ms versus 3us

Signed-off-by: David Leach <david.leach@nxp.com>