### PR TITLE
mcux: use Zephyr BIT() if building for Zephyr

### DIFF
--- a/mcux/mcux-sdk/CMSIS/Core_A/Include/core_ca53.h
+++ b/mcux/mcux-sdk/CMSIS/Core_A/Include/core_ca53.h
@@ -95,8 +95,10 @@
  *                 Register Definitions
  ******************************************************************************/
 
-#ifndef BIT
+#if !defined(BIT) && !defined(__ZEPHYR__)
 #define BIT(n) (1 << (n))
+#else
+#include <zephyr/sys/util.h>
 #endif
 
 /* DAIF Register */

--- a/mcux/mcux-sdk/CMSIS/Core_A/Include/core_ca55.h
+++ b/mcux/mcux-sdk/CMSIS/Core_A/Include/core_ca55.h
@@ -95,8 +95,10 @@
  *                 Register Definitions
  ******************************************************************************/
 
-#ifndef BIT
+#if !defined(BIT) && !defined(__ZEPHYR__)
 #define BIT(n) (1 << (n))
+#else
+#include <zephyr/sys/util.h>
 #endif
 
 /* DAIF Register */


### PR DESCRIPTION
BIT() definition in a public header conflicts with Zephyr's own definition. Even though it is guarded with an ifndef, in some occasions we can't control the order of includes, leading to build errors.