### PR TITLE
NXP HAL fixups for 2.13

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -68,3 +68,4 @@ Patch List:
   4. Add device_system cmake definitions for the following SOCs: MKL25Z4, MK82F25615, MKW24D5, MKW40Z4, MKW41Z4
   5. Fixed the FlexCAN driver to propagate kStatus_FLEXCAN_RxOverflow mailbox status when using the FlexCAN driver transactional APIs.
   6. Fixed fsl_caam.c: CAAM_RNG_GetRandomDataNonBlocking() to not force a reseed with each request. Internal bug submitted [MCUX-57074]
+  7. fsl_common.h: add #ifdef ZEPHYR #endif to include Zephyr's sys utils

--- a/mcux/mcux-sdk/drivers/common/fsl_common.h
+++ b/mcux/mcux-sdk/drivers/common/fsl_common.h
@@ -220,6 +220,9 @@ enum
 /*! @brief Type used for all status and error return values. */
 typedef int32_t status_t;
 
+#ifdef __ZEPHYR__
+#include <zephyr/sys/util.h>
+#else
 /*!
  * @name Min/max macros
  * @{
@@ -237,6 +240,7 @@ typedef int32_t status_t;
 #if !defined(ARRAY_SIZE)
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
+#endif /* __ZEPHYR__ */
 
 /*! @name UINT16_MAX/UINT32_MAX value */
 /* @{ */


### PR DESCRIPTION
Added 'zephyrisms' back to fsl_common.h
Updated readme