### PR TITLE
mcux: mcux-sdk: fix calculation of Flexcomm USART BRG value in 32K mode

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -69,3 +69,4 @@ Patch List:
   5. Fixed the FlexCAN driver to propagate kStatus_FLEXCAN_RxOverflow mailbox status when using the FlexCAN driver transactional APIs.
   6. Fixed fsl_caam.c: CAAM_RNG_GetRandomDataNonBlocking() to not force a reseed with each request. Internal bug submitted [MCUX-57074]
   7. fsl_common.h: add #ifdef ZEPHYR #endif to include Zephyr's sys utils
+  8. fsl_usart.c: Fixed calculation of BRG value for baud rate in 32KHz clock mode, in USART_Init()

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_usart.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_usart.c
@@ -244,7 +244,7 @@ status_t USART_Init(USART_Type *base, const usart_config_t *config, uint32_t src
     {
         if ((9600U % config->baudRate_Bps) == 0U)
         {
-            base->BRG = 9600U / config->baudRate_Bps;
+            base->BRG = 9600U / config->baudRate_Bps - 1U;
         }
         else
         {


### PR DESCRIPTION
Fix calculation of the USART BRG value when using the flexcomm in 32KHz clock mode. This value should be one less, or the resulting baud rate will be half what the user requests. This issue is already fixed in the USART_Enable32kMode() function, but still existed in the USART_Init() function.