### PR TITLE
mcux: flexcom: i2c: Fix slave report

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -60,12 +60,13 @@ License Link:
 Patch List:
   1. Delete the .a binary archive files after an SDK update before committing the changes. These files are still present in the SDK github repo but have been
      deleted from the Zephyr HAL
-  2. Move used job descriptors in the CAAM driver (mcux-sdk/drivers/caam/fsl_caam.c) from the stack to noncacheable section. At time of writing, there should
+  2. mcux-sdk/drivers/caam/fsl_caam.c: Move used job descriptors in the CAAM driver from the stack to noncacheable section. At time of writing, there should
      be four being used for entropy in zephyr.
-  3. Fixed flexcan_fd_frame being written into/written from the message buffer in the flexcan driver (mcux/mcux-sdk/drivers/flexcan/fsl_flexcan.c). On the
+  3. mcux-sdk/drivers/flexcan/fsl_flexcan.c: Fixed flexcan_fd_frame being written into/written from the message buffer in the flexcan driver. On the
      write side, the EDL bit is now utilized for selection of can frame type and on the receiver side, the EDL and BRS status are read from the message
      buffer.
   4. Add device_system cmake definitions for the following SOCs: MKL25Z4, MK82F25615, MKW24D5, MKW40Z4, MKW41Z4
   5. Fixed the FlexCAN driver to propagate kStatus_FLEXCAN_RxOverflow mailbox status when using the FlexCAN driver transactional APIs.
   6. Fixed fsl_caam.c: CAAM_RNG_GetRandomDataNonBlocking() to not force a reseed with each request. Internal bug submitted [MCUX-57074]
   7. fsl_common.h: add #ifdef ZEPHYR #endif to include Zephyr's sys utils
+  8. mcux-sdk/drivers/flexcomm/fsl_i2c.c & fsl_i2c.h: patch to fix Zephyr bug #57858. The changes will be part of the next official NXP SDK release.

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c.c
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2022 NXP
+ * Copyright 2016-2023 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -242,6 +242,14 @@ void I2C_MasterInit(I2C_Type *base, const i2c_master_config_t *masterConfig, uin
     (void)FLEXCOMM_Init(base, FLEXCOMM_PERIPH_I2C);
     I2C_MasterEnable(base, masterConfig->enableMaster);
     I2C_MasterSetBaudRate(base, masterConfig->baudRate_Bps, srcClock_Hz);
+    if (masterConfig->enableTimeout)
+	{
+		base->CFG |= I2C_CFG_TIMEOUTEN_MASK;
+	}
+	else
+	{
+		base->CFG &= ~I2C_CFG_TIMEOUTEN_MASK;
+	}
     I2C_MasterSetTimeoutValue(base, masterConfig->timeout_Ms, srcClock_Hz);
 }
 
@@ -402,7 +410,9 @@ void I2C_MasterSetTimeoutValue(I2C_Type *base, uint8_t timeout_Ms, uint32_t srcC
 
     /* The low 4 bits of the timout reister TIMEOUT is hard-wired to be 1, so the the time out value is always 16 times
        the I2C functional clock, we only need to calculate the high bits. */
-    uint32_t timeoutValue = ((uint32_t)timeout_Ms * srcClock_Hz / 16UL / 100UL + 5UL) / 10UL;
+    uint32_t clkDivider = (base->CLKDIV & I2C_CLKDIV_DIVVAL_MASK) >> I2C_CLKDIV_DIVVAL_SHIFT;
+    uint32_t timeoutValue = ((uint32_t)timeout_Ms * (srcClock_Hz / (clkDivider + 1UL)) / 16UL / 100UL + 5UL) / 10UL;
+
     if (timeoutValue > 0x1000UL)
     {
         timeoutValue = 0x1000UL;
@@ -887,7 +897,7 @@ status_t I2C_MasterTransferNonBlocking(I2C_Type *base, i2c_master_handle_t *hand
     result = I2C_InitTransferStateMachine(base, handle, xfer);
 
     /* Clear error flags. */
-    I2C_ClearStatusFlags(base, I2C_STAT_MSTARBLOSS_MASK | I2C_STAT_MSTSTSTPERR_MASK);
+    I2C_ClearStatusFlags(base, (uint32_t)((uint32_t)kI2C_MasterAllClearFlags | (uint32_t)kI2C_CommonAllClearFlags));
 
     /* Enable I2C internal IRQ sources. */
     I2C_EnableInterrupts(base, (uint32_t)kI2C_MasterIrqFlags);
@@ -1076,7 +1086,12 @@ static status_t I2C_RunTransferStateMachine(I2C_Type *base, i2c_master_handle_t 
        before, the timeout status can be used to avoid the transfer hangs indefinitely. */
     if ((status & (uint32_t)kI2C_EventTimeoutFlag) != 0U)
     {
+#if defined(FSL_FEATURE_I2C_TIMEOUT_RECOVERY) && FSL_FEATURE_I2C_TIMEOUT_RECOVERY
+        I2C_MasterEnable(base, false);
+        I2C_MasterEnable(base, true);
+#endif
         I2C_ClearStatusFlags(base, (uint32_t)kI2C_EventTimeoutFlag);
+
         return kStatus_I2C_EventTimeout;
     }
 
@@ -1084,7 +1099,12 @@ static status_t I2C_RunTransferStateMachine(I2C_Type *base, i2c_master_handle_t 
        specified by TIMEOUT register. */
     if ((status & (uint32_t)kI2C_SclTimeoutFlag) != 0U)
     {
+#if defined(FSL_FEATURE_I2C_TIMEOUT_RECOVERY) && FSL_FEATURE_I2C_TIMEOUT_RECOVERY
+        I2C_MasterEnable(base, false);
+        I2C_MasterEnable(base, true);
+#endif
         I2C_ClearStatusFlags(base, (uint32_t)kI2C_SclTimeoutFlag);
+
         return kStatus_I2C_SclLowTimeout;
     }
 
@@ -1095,9 +1115,8 @@ static status_t I2C_RunTransferStateMachine(I2C_Type *base, i2c_master_handle_t 
 
     /* Get the hardware state of the I2C module */
     master_state = (base->STAT & I2C_STAT_MSTSTATE_MASK) >> I2C_STAT_MSTSTATE_SHIFT;
-    if (((master_state == (uint32_t)I2C_STAT_MSTCODE_NACKADR) ||
-         (master_state == (uint32_t)I2C_STAT_MSTCODE_NACKDAT)) &&
-        (ignoreNak != true))
+    if ((master_state == (uint32_t)I2C_STAT_MSTCODE_NACKADR) ||
+        ((master_state == (uint32_t)I2C_STAT_MSTCODE_NACKDAT) && (ignoreNak != true)))
     {
         /* Slave NACKed last byte, issue stop and return error */
         base->MSTCTL  = I2C_MSTCTL_MSTSTOP_MASK;

--- a/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c.h
+++ b/mcux/mcux-sdk/drivers/flexcomm/fsl_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2022 NXP
+ * Copyright 2016-2023 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -28,7 +28,7 @@
 /*! @name Driver version */
 /*@{*/
 /*! @brief I2C driver version. */
-#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 3, 1))
+#define FSL_I2C_DRIVER_VERSION (MAKE_VERSION(2, 3, 3))
 /*@}*/
 
 /*! @brief Retry times for waiting flag. */


### PR DESCRIPTION
Patch to address driver not properly reporting if slave node is present on bus.

Fixes #57858