### PR TITLE
mcux: cmake: include Data Co-Processor (DCP)

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -108,3 +108,6 @@ zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
   NOCACHE_SECTION
   nocache.ld
 )
+zephyr_library_compile_definitions_ifdef(CONFIG_NOCACHE_MEMORY
+  __STARTUP_INITIALIZE_NONCACHEDATA
+)

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -1,6 +1,7 @@
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}/drivers
+    ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/cache/armv7-m7
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/common
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/dmamux
     ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/CMSIS/Core/Include
@@ -161,6 +162,7 @@ include_driver_ifdef(CONFIG_MCUX_SDIF			sdif		driver_sdif)
 include_driver_ifdef(CONFIG_ADC_MCUX_ETC		adc_etc		driver_adc_etc)
 include_driver_ifdef(CONFIG_MCUX_XBARA			xbara		driver_xbara)
 include_driver_ifdef(CONFIG_QDEC_MCUX			enc		driver_enc)
+include_driver_ifdef(CONFIG_CRYPTO_MCUX_DCP			dcp		driver_dcp)
 
 if ((${MCUX_DEVICE} MATCHES "MIMXRT1[0-9][0-9][0-9]") AND (NOT (CONFIG_SOC_MIMXRT1166_CM4 OR CONFIG_SOC_MIMXRT1176_CM4)))
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/armv7-m7	driver_cache_armv7_m7)

--- a/mcux/nocache.ld
+++ b/mcux/nocache.ld
@@ -6,3 +6,4 @@
 
 . = ALIGN(4);
 KEEP(*(NonCacheable))
+KEEP(*(NonCacheable.init))


### PR DESCRIPTION
Enable DCP support for mcux platform.

~One remaining issue is that I get a linker warning:~
```
warning: orphan section `NonCacheable.init' from `modules/hal_nxp/hal_nxp/lib..__modules__hal__nxp.a(fsl_dcp.c.obj)' being placed in section `NonCacheable.init'
```