### PR TITLE
Add support for newly introduced CCM Rev3 on i.MX93

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -76,3 +76,4 @@ Patch List:
   12. devices: MIMX8QM6: Add missing LPUART interrupt macro.
   13. mcux-sdk/drivers/lpspi/fsl_lpspi.h: add workaround for errata ERR050456 on S32K3x4 SoC
   according to S32K3X4-0P55A-1P55A-ERRATA.
+  14. devices: MIMX9352: Allow clock driver to work w/o identity mapping

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -44,6 +44,10 @@ zephyr_library_compile_definitions_ifdef(
   CONFIG_HAS_MCUX_CACHE FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
 )
 
+zephyr_library_compile_definitions_ifdef(
+  CONFIG_NXP_HAL_DISABLE_IMPLICIT_CLOCKING
+  FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL=1
+)
 
 # Required by all SCFW-based SoCs
 if (CONFIG_SOC_MIMX8QM_A53)

--- a/mcux/mcux-sdk/devices/MIMX9352/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MIMX9352/drivers/fsl_clock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2023 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -13,6 +13,8 @@
 #ifndef FSL_COMPONENT_ID
 #define FSL_COMPONENT_ID "platform.drivers.clock"
 #endif
+
+static CCM_Type *ccm_base = CCM_CTRL;
 
 volatile uint32_t g_clockSourceFreq[kCLOCK_Ext + 1];
 
@@ -29,4 +31,76 @@ uint32_t CLOCK_GetIpFreq(clock_root_t name)
     assert(clock <= kCLOCK_Ext);
 
     return g_clockSourceFreq[clock] / div;
+}
+
+void CLOCK_Init(CCM_Type *regBase)
+{
+	ccm_base = regBase;
+}
+
+void CLOCK_SetRootClockMux(clock_root_t root, uint8_t src)
+{
+    assert(src < 8U);
+    ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW =
+        (ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & ~(CCM_CLOCK_ROOT_MUX_MASK)) | CCM_CLOCK_ROOT_MUX(src);
+    __DSB();
+    __ISB();
+}
+
+uint32_t CLOCK_GetRootClockMux(clock_root_t root)
+{
+	return (ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_MUX_MASK) >> CCM_CLOCK_ROOT_MUX_SHIFT;
+}
+
+void CLOCK_SetRootClockDiv(clock_root_t root, uint8_t div)
+{
+    assert(div);
+    ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW =
+        (ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & ~CCM_CLOCK_ROOT_DIV_MASK) |
+	CCM_CLOCK_ROOT_DIV((uint32_t)div - 1UL);
+    __DSB();
+    __ISB();
+}
+
+uint32_t CLOCK_GetRootClockDiv(clock_root_t root)
+{
+    return ((ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_DIV_MASK) >> CCM_CLOCK_ROOT_DIV_SHIFT) +
+    1UL;
+}
+
+void CLOCK_PowerOffRootClock(clock_root_t root)
+{
+    if (0UL == (ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_OFF_MASK))
+    {
+        ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.SET = CCM_CLOCK_ROOT_OFF_MASK;
+        __DSB();
+        __ISB();
+    }
+}
+
+void CLOCK_PowerOnRootClock(clock_root_t root)
+{
+    ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.CLR = CCM_CLOCK_ROOT_OFF_MASK;
+    __DSB();
+    __ISB();
+}
+
+void CLOCK_SetRootClock(clock_root_t root, const clock_root_config_t *config)
+{
+    assert(config);
+    ccm_base->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW = CCM_CLOCK_ROOT_MUX(config->mux) |
+                                                       CCM_CLOCK_ROOT_DIV((uint32_t)config->div - 1UL) |
+						       (config->clockOff ? CCM_CLOCK_ROOT_OFF(config->clockOff) : 0UL);
+    __DSB();
+    __ISB();
+}
+
+void CLOCK_ControlGate(clock_ip_name_t name, clock_gate_value_t value)
+{
+    if (((uint32_t)value & CCM_LPCG_DIRECT_ON_MASK) != (ccm_base->LPCG[name].DIRECT & CCM_LPCG_DIRECT_ON_MASK))
+    {
+        ccm_base->LPCG[name].DIRECT = ((uint32_t)value & CCM_LPCG_DIRECT_ON_MASK);
+	__DSB();
+	__ISB();
+    }
 }


### PR DESCRIPTION
This series of changes will make sure that the CCM Rev3 driver from Zephyr is supported on i.MX93