### PR TITLE
devices: MIMX8QM6: Add support for MIMX8QM6's CA53 cores

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -70,3 +70,7 @@ Patch List:
   6. Fixed fsl_caam.c: CAAM_RNG_GetRandomDataNonBlocking() to not force a reseed with each request. Internal bug submitted [MCUX-57074]
   7. fsl_common.h: add #ifdef ZEPHYR #endif to include Zephyr's sys utils
   8. mcux-sdk/drivers/flexcomm/fsl_i2c.c & fsl_i2c.h: patch to fix Zephyr bug #57858. The changes will be part of the next official NXP SDK release.
+  9. mcux: Add support for MIMX8QM6's CA53.
+  10. devices: MIMX8QM6: Add mapped versions of clock functions.
+  11. devices: MIMX8QM6: Don't allow drivers to perform clock-related operations on Zephyr.
+  12. devices: MIMX8QM6: Add missing LPUART interrupt macro.

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -43,6 +43,16 @@ zephyr_library_compile_definitions_ifdef(
   CONFIG_HAS_MCUX_CACHE FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
 )
 
+
+# Required by all SCFW-based SoCs
+if (CONFIG_SOC_MIMX8QM_A53)
+    list(APPEND CMAKE_MODULE_PATH
+        ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}/scfw_api
+    )
+    zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}/scfw_api)
+    include(driver_scfw_api)
+endif()
+
 include(driver_common)
 
 #Include system_xxx file

--- a/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_ca53_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_ca53_features.h
@@ -557,5 +557,9 @@
 /* @brief Offset between MIPI CSI controller and CSR in the MIPI CSI subsystem. */
 #define FSL_FEATURE_CSI2RX_CSR_OFFSET (0x6100)
 
+#ifdef __ZEPHYR__
+#define FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL 1
+#endif /* __ZEPHYR__ */
+
 #endif /* _MIMX8QM6_ca53_FEATURES_H_ */
 

--- a/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_ca53_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_ca53_features.h
@@ -1,0 +1,561 @@
+/*
+** ###################################################################
+**     Version:             rev. 2.0, 2017-05-04
+**     Build:               b200603
+**
+**     Abstract:
+**         Chip specific module features.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2018 NXP
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2016-06-02)
+**         Initial version.
+**     - rev. 2.0 (2017-05-04)
+**         RevA Header ER
+**     - rev. 3.0 (2018-08-30)
+**         RevC Header EAR
+**
+** ###################################################################
+*/
+
+/* !DISCLAIMER!: This file is merely a copy of MIMX8QM6_cm4_core0_feature.h
+ *
+ * Use it cautiously.
+ */
+
+#ifndef _MIMX8QM6_ca53_FEATURES_H_
+#define _MIMX8QM6_ca53_FEATURES_H_
+
+/* SOC module features */
+
+/* @brief APBH availability on the SoC. */
+#define FSL_FEATURE_SOC_APBH_COUNT (1)
+/* @brief ASRC availability on the SoC. */
+#define FSL_FEATURE_SOC_ASRC_COUNT (2)
+/* @brief ADC availability on the SoC. */
+#define FSL_FEATURE_SOC_ADC_COUNT (2)
+/* @brief BBS_SIM availability on the SoC. */
+#define FSL_FEATURE_SOC_ASMC_COUNT (1)
+/* @brief BCH availability on the SoC. */
+#define FSL_FEATURE_SOC_BCH_COUNT (1)
+/* @brief ENET availability on the SoC. */
+#define FSL_FEATURE_SOC_ENET_COUNT (2)
+/* @brief EDMA availability on the SoC. */
+#define FSL_FEATURE_SOC_EDMA_COUNT (5)
+/* @brief EMVSIM availability on the SoC. */
+#define FSL_FEATURE_SOC_EMVSIM_COUNT (2)
+/* @brief ESAI availability on the SoC. */
+#define FSL_FEATURE_SOC_ESAI_COUNT (2)
+/* @brief FLEXCAN availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXCAN_COUNT (3)
+/* @brief FLEXSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXSPI_COUNT (2)
+/* @brief FTM availability on the SoC. */
+#define FSL_FEATURE_SOC_FTM_COUNT (2)
+/* @brief RGPIO availability on the SoC. */
+#define FSL_FEATURE_SOC_RGPIO_COUNT (3)
+/* @brief GPIO availability on the SoC. */
+#define FSL_FEATURE_SOC_GPIO_COUNT (17)
+/* @brief I2S availability on the SoC. */
+#define FSL_FEATURE_SOC_I2S_COUNT (8)
+/* @brief INTMUX availability on the SoC. */
+#define FSL_FEATURE_SOC_INTMUX_COUNT (3)
+/* @brief IRQSTEER availability on the SoC. */
+#define FSL_FEATURE_SOC_IRQSTEER_COUNT (1)
+/* @brief LMEM availability on the SoC. */
+#define FSL_FEATURE_SOC_LMEM_COUNT (1)
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (20)
+/* @brief LPIT availability on the SoC. */
+#define FSL_FEATURE_SOC_LPIT_COUNT (3)
+/* @brief LPSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_LPSPI_COUNT (4)
+/* @brief LPUART availability on the SoC. */
+#define FSL_FEATURE_SOC_LPUART_COUNT (8)
+/* @brief PWM availability on the SoC. */
+#define FSL_FEATURE_SOC_PWM_COUNT (16)
+/* @brief GPT availability on the SoC. */
+#define FSL_FEATURE_SOC_GPT_COUNT (11)
+/* @brief GPMI availability on the SoC. */
+#define FSL_FEATURE_SOC_GPMI_COUNT (1)
+/* @brief MMCAU availability on the SoC. */
+#define FSL_FEATURE_SOC_MMCAU_COUNT (1)
+/* @brief MIPI_CSI2RX availability on the SoC. */
+#define FSL_FEATURE_SOC_MIPI_CSI2RX_COUNT (2)
+/* @brief MIPI_DSI_HOST availability on the SoC. */
+#define FSL_FEATURE_SOC_MIPI_DSI_HOST_COUNT (2)
+/* @brief MU availability on the SoC. */
+#define FSL_FEATURE_SOC_MU_COUNT (15)
+/* @brief ROMCP availability on the SoC. */
+#define FSL_FEATURE_SOC_ROMC_COUNT (2)
+/* @brief SEMA42 availability on the SoC. */
+#define FSL_FEATURE_SOC_SEMA42_COUNT (3)
+/* @brief TPM availability on the SoC. */
+#define FSL_FEATURE_SOC_TPM_COUNT (3)
+/* @brief TSTMR availability on the SoC. */
+#define FSL_FEATURE_SOC_TSTMR_COUNT (2)
+/* @brief WDOG availability on the SoC. */
+#define FSL_FEATURE_SOC_WDOG_COUNT (3)
+/* @brief USBDCD availability on the SoC. */
+#define FSL_FEATURE_SOC_USBDCD_COUNT (1)
+/* @brief USDHC availability on the SoC. */
+#define FSL_FEATURE_SOC_USDHC_COUNT (3)
+
+/* ASMC module features */
+
+/* @brief Has high speed run mode. */
+#define FSL_FEATURE_ASMC_HAS_HIGH_SPEED_RUN_MODE (0)
+
+/* LDB module features */
+
+/* @brief Use Mixel combo PHY. */
+#define FSL_FEATURE_LDB_COMBO_PHY (0)
+
+/* LPADC module features */
+
+/* @brief Has differential mode (bitfield CMDLn[DIFF]). */
+#define FSL_FEATURE_LPADC_HAS_CMDL_DIFF (1)
+/* @brief Has channel scale (bitfield CMDLn[CSCALE]). */
+#define FSL_FEATURE_LPADC_HAS_CMDL_CSCALE (1)
+/* @brief Has internal clock (bitfield CFG[ADCKEN]). */
+#define FSL_FEATURE_LPADC_HAS_CFG_ADCKEN (0)
+/* @brief Enable support for low voltage reference on option 1 reference (bitfield CFG[VREF1RNG]). */
+#define FSL_FEATURE_LPADC_HAS_CFG_VREF1RNG (0)
+/* @brief Has calibration (bitfield CFG[CALOFS]). */
+#define FSL_FEATURE_LPADC_HAS_CFG_CALOFS (0)
+/* @brief Has offset trim (register OFSTRIM). */
+#define FSL_FEATURE_LPADC_HAS_OFSTRIM (0)
+
+/* ENET module features */
+
+/* @brief Support Interrupt Coalesce */
+#define FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE (1)
+/* @brief Queue Size. */
+#define FSL_FEATURE_ENET_QUEUE (3)
+/* @brief Has AVB Support. */
+#define FSL_FEATURE_ENET_HAS_AVB (1)
+/* @brief Has Timer Pulse Width control. */
+#define FSL_FEATURE_ENET_HAS_TIMER_PWCONTROL (0)
+/* @brief Has Extend MDIO Support. */
+#define FSL_FEATURE_ENET_HAS_EXTEND_MDIO (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt. */
+#define FSL_FEATURE_ENET_HAS_ADD_1588_TIMER_CHN_INT (0)
+/* @brief Support Interrupt Coalesce for each instance */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_INTERRUPT_COALESCEn(x) (0)
+/* @brief Queue Size for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) (3)
+/* @brief Has AVB Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_AVBn(x) (1)
+/* @brief Has Timer Pulse Width control for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_TIMER_PWCONTROLn(x) (0)
+/* @brief Has Extend MDIO Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_EXTEND_MDIOn(x) (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_ADD_1588_TIMER_CHN_INTn(x) (0)
+/* @brief Has threshold for the number of frames in the receive FIFO (register bit field RSEM[STAT_SECTION_EMPTY]). */
+#define FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD (1)
+
+/* FLEXCAN module features */
+
+/* @brief Message buffer size */
+#define FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(x) (64)
+/* @brief Has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT (1)
+/* @brief Insatnce has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_DOZE_MODE_SUPPORTn(x) (1)
+/* @brief Has a glitch filter on the receive pin (register bit field MCR[WAKSRC]). */
+#define FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER (1)
+/* @brief Has extended interrupt mask and flag register (register IMASK2, IFLAG2). */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER (1)
+/* @brief Instance has extended bit timing register (register CBT). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_EXTENDED_TIMING_REGISTERn(x) (1)
+/* @brief Has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA (1)
+/* @brief Instance has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_RX_FIFO_DMAn(x) (1)
+/* @brief Remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_SUPPORT_ENGINE_CLK_SEL_REMOVE (1)
+/* @brief Instance remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_SUPPORT_ENGINE_CLK_SEL_REMOVEn(x) (1)
+/* @brief Is affected by errata with ID 5641 (Module does not transmit a message that is enabled to be transmitted at a specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641 (1)
+/* @brief Has CAN with Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE (1)
+/* @brief CAN instance support Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_FLEXIBLE_DATA_RATEn(x) (1)
+/* @brief Has extra MB interrupt or common one. */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTRA_MB_INT (0)
+/* @brief Has memory error control (register MECR). */
+#define FSL_FEATURE_FLEXCAN_HAS_MEMORY_ERROR_CONTROL (0)
+/* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
+#define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (1)
+
+/* FLEXSPI module features */
+
+/* @brief FlexSPI AHB buffer count */
+#define FSL_FEATURE_FLEXSPI_AHB_BUFFER_COUNTn(x) (8)
+
+/* FTM module features */
+
+/* @brief Number of channels. */
+#define FSL_FEATURE_FTM_CHANNEL_COUNTn(x) \
+    ((x) == DMA__FTM0 ? (8) : \
+    ((x) == DMA__FTM1 ? (8) : (-1)))
+/* @brief MU Has register CCR */
+#define FSL_FEATURE_FTM_HAS_COUNTER_RESET_BY_CAPTURE_EVENT (1)
+/* @brief Has extended deadtime value. */
+#define FSL_FEATURE_FTM_HAS_EXTENDED_DEADTIME_VALUE (0)
+/* @brief Enable pwm output for the module. */
+#define FSL_FEATURE_FTM_HAS_ENABLE_PWM_OUTPUT (1)
+/* @brief Has half-cycle reload for the module. */
+#define FSL_FEATURE_FTM_HAS_HALFCYCLE_RELOAD (1)
+/* @brief Has reload interrupt. */
+#define FSL_FEATURE_FTM_HAS_RELOAD_INTERRUPT (1)
+/* @brief Has reload initialization trigger. */
+#define FSL_FEATURE_FTM_HAS_RELOAD_INITIALIZATION_TRIGGER (1)
+/* @brief Has DMA support, bitfield CnSC[DMA]. */
+#define FSL_FEATURE_FTM_HAS_DMA_SUPPORT (1)
+/* @brief If channel 6 is used to generate channel trigger, bitfield EXTTRIG[CH6TRIG]. */
+#define FSL_FEATURE_FTM_HAS_CHANNEL6_TRIGGER (1)
+/* @brief If channel 7 is used to generate channel trigger, bitfield EXTTRIG[CH7TRIG]. */
+#define FSL_FEATURE_FTM_HAS_CHANNEL7_TRIGGER (1)
+
+/* RGPIO module features */
+
+/* @brief Has GPIO attribute checker register  (GACR). */
+#define FSL_FEATURE_RGPIO_HAS_ATTRIBUTE_CHECKER (0)
+
+/* EDMA module features */
+
+/* @brief Number of DMA channels (related to number of registers TCD, DCHPRI, bit fields ERQ[ERQn], EEI[EEIn], INT[INTn], ERR[ERRn], HRS[HRSn] and bit field widths ES[ERRCHN], CEEI[CEEI], SEEI[SEEI], CERQ[CERQ], SERQ[SERQ], CDNE[CDNE], SSRT[SSRT], CERR[CERR], CINT[CINT], TCDn_CITER_ELINKYES[LINKCH], TCDn_CSR[MAJORLINKCH], TCDn_BITER_ELINKYES[LINKCH]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL (32)
+/* @brief Total number of DMA channels on all modules. */
+#define FSL_FEATURE_EDMA_DMAMUX_CHANNELS (32)
+/* @brief Number of DMA channel groups (register bit fields CR[ERGA], CR[GRPnPRI], ES[GPE], DCHPRIn[GRPPRI]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT (1)
+/* @brief Has DMA_Error interrupt vector. */
+#define FSL_FEATURE_EDMA_HAS_ERROR_IRQ (1)
+/* @brief Number of DMA channels with asynchronous request capability (register EARS). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT (32)
+/* @brief If channel clock controlled independently */
+#define FSL_FEATURE_EDMA_CHANNEL_HAS_OWN_CLOCK_GATE (1)
+/* @brief Number of channel for each EDMA instance, (only defined for soc with different channel numbers for difference instance) */
+#define FSL_FEATURE_EDMA_INSTANCE_CHANNELn(x) \
+    ((x) == AUDIO__EDMA0 ? (32) : \
+    ((x) == AUDIO__EDMA1 ? (32) : \
+    ((x) == CONNECTIVITY__EDMA ? (5) : \
+    ((x) == DMA__EDMA0 ? (32) : \
+    ((x) == DMA__EDMA1 ? (32) : (-1))))))
+/* @brief Has no register bit fields MP_CSR[EBW]. */
+#define FSL_FEATURE_EDMA_HAS_NO_MP_CSR_EBW (0)
+
+/* ESAI module features */
+
+/* @brief ESAI FIFO Size. */
+#define FSL_FEATURE_ESAI_FIFO_SIZEn(x) (128)
+
+/* INTMUX module features */
+
+/* @brief Number of INTMUX channels (related to number of register CHn_CSR). */
+#define FSL_FEATURE_INTMUX_CHANNEL_COUNT (8)
+/* @brief Number of INTMUX IRQ source. */
+#define FSL_FEATURE_INTMUX_IRQ_COUNT (32)
+/* @brief The start IRQ index of first INTMUX source IRQ. */
+#define FSL_FEATURE_INTMUX_IRQ_START_INDEX (563)
+/* @brief The direction of INTMUX. OUT, route the CM4 subsystem IRQ to System. */
+#define FSL_FEATURE_INTMUX_DIRECTION_OUT (1)
+/* @brief The total number of level1 interrupt vectors. */
+#define FSL_FEATURE_NUMBER_OF_LEVEL1_INT_VECTORS (51)
+
+/* IRQSTEER module features */
+
+/* @brief Number of IRQSTEER CHn_MASK register. */
+#define FSL_FEATURE_IRQSTEER_CHn_MASK_COUNT (16)
+/* @brief The start IRQ index of first IRQSTEER source IRQ. */
+#define FSL_FEATURE_IRQSTEER_IRQ_START_INDEX (51)
+/* @brief Number of IRQSTEER master. */
+#define FSL_FEATURE_IRQSTEER_MASTER_COUNT (8)
+
+/* LMEM module features */
+
+/* @brief Has process identifier support. */
+#define FSL_FEATURE_LMEM_HAS_SYSTEMBUS_CACHE (1)
+/* @brief Support instruction cache demote. */
+#define FSL_FEATURE_LMEM_SUPPORT_ICACHE_DEMOTE_REMOVE (1)
+/* @brief Has no NONCACHEABLE section. */
+#define FSL_FEATURE_HAS_NO_NONCACHEABLE_SECTION (0)
+/* @brief L1 ICACHE line size in byte. */
+#define FSL_FEATURE_L1ICACHE_LINESIZE_BYTE (32)
+/* @brief L1 DCACHE line size in byte. */
+#define FSL_FEATURE_L1DCACHE_LINESIZE_BYTE (32)
+
+/* LPI2C module features */
+
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) \
+    ((x) == CM4_0__LPI2C ? (4) : \
+    ((x) == CM4_1__LPI2C ? (4) : \
+    ((x) == DI_HDMI__LPI2C ? (16) : \
+    ((x) == DI_LVDS_0__LPI2C0 ? (16) : \
+    ((x) == DI_LVDS_0__LPI2C1 ? (16) : \
+    ((x) == DI_LVDS_1__LPI2C0 ? (16) : \
+    ((x) == DI_LVDS_1__LPI2C1 ? (16) : \
+    ((x) == DI_MIPI_0__LPI2C0 ? (16) : \
+    ((x) == DI_MIPI_0__LPI2C1 ? (16) : \
+    ((x) == DI_MIPI_1__LPI2C0 ? (16) : \
+    ((x) == DI_MIPI_1__LPI2C1 ? (16) : \
+    ((x) == DMA__LPI2C0 ? (16) : \
+    ((x) == DMA__LPI2C1 ? (16) : \
+    ((x) == DMA__LPI2C2 ? (16) : \
+    ((x) == DMA__LPI2C3 ? (16) : \
+    ((x) == DMA__LPI2C4 ? (16) : \
+    ((x) == MIPI_CSI_0__LPI2C ? (16) : \
+    ((x) == MIPI_CSI_1__LPI2C ? (16) : \
+    ((x) == RX_HDMI__LPI2C ? (16) : \
+    ((x) == SCU__LPI2C ? (4) : (-1)))))))))))))))))))))
+	
+/* LPIT module features */
+
+/* @brief Number of channels (related to number of registers LDVALn, CVALn, TCTRLn, TFLGn). */
+#define FSL_FEATURE_LPIT_TIMER_COUNT (4)
+/* @brief Has lifetime timer (related to existence of registers LTMR64L and LTMR64H). */
+#define FSL_FEATURE_LPIT_HAS_LIFETIME_TIMER (0)
+
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_LPIT_HAS_SHARED_IRQ_HANDLER (1)
+
+/* LPSPI module features */
+
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPSPI_FIFO_SIZEn(x) (64)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+
+/* LPUART module features */
+
+/* @brief Has receive FIFO overflow detection (bit field CFIFO[RXOFE]). */
+#define FSL_FEATURE_LPUART_HAS_IRQ_EXTENDED_FUNCTIONS (0)
+/* @brief Has low power features (can be enabled in wait mode via register bit C1[DOZEEN] or CTRL[DOZEEN] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_LOW_POWER_UART_SUPPORT (1)
+/* @brief Has extended data register ED (or extra flags in the DATA register if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_EXTENDED_DATA_REGISTER_FLAGS (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_HAS_FIFO (1)
+/* @brief Has 32-bit register MODIR */
+#define FSL_FEATURE_LPUART_HAS_MODIR (1)
+/* @brief Hardware flow control (RTS, CTS) is supported. */
+#define FSL_FEATURE_LPUART_HAS_MODEM_SUPPORT (1)
+/* @brief Infrared (modulation) is supported. */
+#define FSL_FEATURE_LPUART_HAS_IR_SUPPORT (1)
+/* @brief 2 bits long stop bit is available. */
+#define FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT (1)
+/* @brief If 10-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_10BIT_DATA_SUPPORT (1)
+/* @brief If 7-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT (1)
+/* @brief Baud rate fine adjustment is available. */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT (0)
+/* @brief Baud rate oversampling is available (has bit fields C4[OSR], C5[BOTHEDGE], C5[RESYNCDIS] or BAUD[OSR], BAUD[BOTHEDGE], BAUD[RESYNCDIS] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_OVER_SAMPLING_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_RX_RESYNC_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_BOTH_EDGE_SAMPLING_SUPPORT (1)
+/* @brief Peripheral type. */
+#define FSL_FEATURE_LPUART_IS_SCI (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_FIFO_SIZEn(x) \
+    ((x) == CM4_0__LPUART ? (32) : \
+    ((x) == CM4_1__LPUART ? (32) : \
+    ((x) == DMA__LPUART0 ? (64) : \
+    ((x) == DMA__LPUART1 ? (64) : \
+    ((x) == DMA__LPUART2 ? (64) : \
+    ((x) == DMA__LPUART3 ? (64) : \
+    ((x) == DMA__LPUART4 ? (64) : \
+    ((x) == SCU__LPUART ? (32) : (-1)))))))))
+/* @brief Maximal data width without parity bit. */
+#define FSL_FEATURE_LPUART_MAX_DATA_WIDTH_WITH_NO_PARITY (10)
+/* @brief Maximal data width with parity bit. */
+#define FSL_FEATURE_LPUART_MAX_DATA_WIDTH_WITH_PARITY (9)
+/* @brief Supports two match addresses to filter incoming frames. */
+#define FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING (1)
+/* @brief Has transmitter/receiver DMA enable bits C5[TDMAE]/C5[RDMAE] (or BAUD[TDMAE]/BAUD[RDMAE] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_DMA_ENABLE (1)
+/* @brief Has transmitter/receiver DMA select bits C4[TDMAS]/C4[RDMAS], resp. C5[TDMAS]/C5[RDMAS] if IS_SCI = 0. */
+#define FSL_FEATURE_LPUART_HAS_DMA_SELECT (0)
+/* @brief Data character bit order selection is supported (bit field S2[MSBF] or STAT[MSBF] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_BIT_ORDER_SELECT (1)
+/* @brief Has smart card (ISO7816 protocol) support and no improved smart card support. */
+#define FSL_FEATURE_LPUART_HAS_SMART_CARD_SUPPORT (0)
+/* @brief Has improved smart card (ISO7816 protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_IMPROVED_SMART_CARD_SUPPORT (0)
+/* @brief Has local operation network (CEA709.1-B protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_LOCAL_OPERATION_NETWORK_SUPPORT (0)
+/* @brief Has 32-bit registers (BAUD, STAT, CTRL, DATA, MATCH, MODIR) instead of 8-bit (BDH, BDL, C1, S1, D, etc.). */
+#define FSL_FEATURE_LPUART_HAS_32BIT_REGISTERS (1)
+/* @brief Lin break detect available (has bit BAUD[LBKDIE]). */
+#define FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT (1)
+/* @brief UART stops in Wait mode available (has bit C1[UARTSWAI]). */
+#define FSL_FEATURE_LPUART_HAS_WAIT_MODE_OPERATION (0)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_DMA_RX_TX_REQn(x) (0)
+/* @brief Has separate RX and TX interrupts. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ (0)
+/* @brief Has LPAURT_PARAM. */
+#define FSL_FEATURE_LPUART_HAS_PARAM (1)
+/* @brief Has LPUART_VERID. */
+#define FSL_FEATURE_LPUART_HAS_VERID (1)
+/* @brief Has LPUART_GLOBAL. */
+#define FSL_FEATURE_LPUART_HAS_GLOBAL (1)
+/* @brief Has LPUART_PINCFG. */
+#define FSL_FEATURE_LPUART_HAS_PINCFG (1)
+
+/* MU module features */
+
+/* @brief MU Has register CCR */
+#define FSL_FEATURE_MU_HAS_CCR (0)
+/* @brief MU Has register SR[RS] */
+#define FSL_FEATURE_MU_HAS_SR_RS (0)
+/* @brief MU Has register CR[BRDIE], CR[BRAIE], SR[BRDIP], SR[BRAIP] */
+#define FSL_FEATURE_MU_HAS_RESET_INT (0)
+/* @brief MU Has register SR[MURIP] */
+#define FSL_FEATURE_MU_HAS_SR_MURIP (0)
+/* @brief brief MU Has register SR[HRIP] */
+#define FSL_FEATURE_MU_HAS_SR_HRIP (0)
+
+/* SAI module features */
+
+/* @brief Receive/transmit FIFO size in item count (register bit fields TCSR[FRDE], TCSR[FRIE], TCSR[FRF], TCR1[TFW], RCSR[FRDE], RCSR[FRIE], RCSR[FRF], RCR1[RFW], registers TFRn, RFRn). */
+#define FSL_FEATURE_SAI_FIFO_COUNT (64)
+/* @brief Receive/transmit channel number (register bit fields TCR3[TCE], RCR3[RCE], registers TDRn and RDRn). */
+#define FSL_FEATURE_SAI_CHANNEL_COUNTn(x) \
+    (((x) == AUDIO__SAI0) ? (1) : \
+    (((x) == AUDIO__SAI1) ? (1) : \
+    (((x) == AUDIO__SAI2) ? (1) : \
+    (((x) == AUDIO__SAI3) ? (1) : \
+    (((x) == AUDIO__SAI6) ? (1) : \
+    (((x) == AUDIO__SAI7) ? (1) : \
+    (((x) == AUDIO__SAI_HDMIRX0) ? (4) : \
+    (((x) == AUDIO__SAI_HDMITX0) ? (4) : (-1)))))))))
+/* @brief Maximum words per frame (register bit fields TCR3[WDFL], TCR4[FRSZ], TMR[TWM], RCR3[WDFL], RCR4[FRSZ], RMR[RWM]). */
+#define FSL_FEATURE_SAI_MAX_WORDS_PER_FRAME (32)
+/* @brief Has support of combining multiple data channel FIFOs into single channel FIFO (register bit fields TCR3[CFR], TCR4[FCOMB], TFR0[WCP], TFR1[WCP], RCR3[CFR], RCR4[FCOMB], RFR0[RCP], RFR1[RCP]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE (0)
+/* @brief Has packing of 8-bit and 16-bit data into each 32-bit FIFO word (register bit fields TCR4[FPACK], RCR4[FPACK]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_PACKING (1)
+/* @brief Configures when the SAI will continue transmitting after a FIFO error has been detected (register bit fields TCR4[FCONT], RCR4[FCONT]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR (1)
+/* @brief Configures if the frame sync is generated internally, a frame sync is only generated when the FIFO warning flag is clear or continuously (register bit fields TCR4[ONDEM], RCR4[ONDEM]). */
+#define FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE (1)
+/* @brief Simplified bit clock source and asynchronous/synchronous mode selection (register bit fields TCR2[CLKMODE], RCR2[CLKMODE]), in comparison with the exclusively implemented TCR2[SYNC,BCS,BCI,MSEL], RCR2[SYNC,BCS,BCI,MSEL]. */
+#define FSL_FEATURE_SAI_HAS_CLOCKING_MODE (0)
+/* @brief Has register for configuration of the MCLK divide ratio (register bit fields MDR[FRACT], MDR[DIVIDE]). */
+#define FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER (0)
+/* @brief Interrupt source number */
+#define FSL_FEATURE_SAI_INT_SOURCE_NUM (1)
+/* @brief Has register of MCR. */
+#define FSL_FEATURE_SAI_HAS_MCR (0)
+/* @brief Has bit field MICS of the MCR register. */
+#define FSL_FEATURE_SAI_HAS_NO_MCR_MICS (1)
+/* @brief Has register of MDR */
+#define FSL_FEATURE_SAI_HAS_MDR (0)
+/* @brief Has support the BCLK bypass mode when BCLK = MCLK. */
+#define FSL_FEATURE_SAI_HAS_BCLK_BYPASS (0)
+
+/* SEMA42 module features */
+
+/* @brief Gate counts */
+#define FSL_FEATURE_SEMA42_GATE_COUNT (16)
+
+/* TPM module features */
+
+/* @brief Number of channels. */
+#define FSL_FEATURE_TPM_CHANNEL_COUNTn(x) (6)
+/* @brief Has counter reset by the selected input capture event (register bits C0SC[ICRST], C1SC[ICRST], ...). */
+#define FSL_FEATURE_TPM_HAS_COUNTER_RESET_BY_CAPTURE_EVENT (0)
+/* @brief Has TPM_PARAM. */
+#define FSL_FEATURE_TPM_HAS_PARAM (1)
+/* @brief Has TPM_VERID. */
+#define FSL_FEATURE_TPM_HAS_VERID (1)
+/* @brief Has TPM_GLOBAL. */
+#define FSL_FEATURE_TPM_HAS_GLOBAL (1)
+/* @brief Has TPM_TRIG. */
+#define FSL_FEATURE_TPM_HAS_TRIG (1)
+/* @brief Whether TRIG register has effect. */
+#define FSL_FEATURE_TPM_TRIG_HAS_EFFECTn(x) (1)
+/* @brief Has counter pause on trigger. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_COUNTER_ON_TRIGGER (1)
+/* @brief Has external trigger selection. */
+#define FSL_FEATURE_TPM_HAS_EXTERNAL_TRIGGER_SELECTION (1)
+/* @brief Has TPM_COMBINE. */
+#define FSL_FEATURE_TPM_HAS_COMBINE (1)
+/* @brief Has TPM_POL. */
+#define FSL_FEATURE_TPM_HAS_POL (1)
+/* @brief Whether POL register has effect. */
+#define FSL_FEATURE_TPM_POL_HAS_EFFECTn(x) (1)
+/* @brief Has TPM_FILTER. */
+#define FSL_FEATURE_TPM_HAS_FILTER (1)
+/* @brief Has TPM_QDCTRL. */
+#define FSL_FEATURE_TPM_HAS_QDCTRL (1)
+/* @brief TPM COMBINE HAS EFFECT. */
+#define FSL_FEATURE_TPM_COMBINE_HAS_EFFECTn(x) (1)
+/* @brief TPM FILTER HAS EFFECT. */
+#define FSL_FEATURE_TPM_FILTER_HAS_EFFECTn(x) (1)
+/* @brief TPM QDCTRL HAS EFFECT. */
+#define FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(x) (1)
+/* @brief Has pause level select. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_LEVEL_SELECT (0)
+/* @brief Whether 32 bits counter has effect. */
+#define FSL_FEATURE_TPM_HAS_32BIT_COUNTERn(x) (1)
+
+/* WDOG module features */
+
+/* @brief Watchdog is available. */
+#define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
+/* @brief WDOG_CNT can be 32-bit written. */
+#define FSL_FEATURE_WDOG_HAS_32BIT_ACCESS (1)
+
+/* USDHC module features */
+
+/* @brief Has external DMA support (VEND_SPEC[EXT_DMA_EN]) */
+#define FSL_FEATURE_USDHC_HAS_EXT_DMA (0)
+/* @brief Has HS400 mode (MIX_CTRL[HS400_MODE]) */
+#define FSL_FEATURE_USDHC_HAS_HS400_MODE (1)
+/* @brief Has SDR50 support (HOST_CTRL_CAP[SDR50_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR50_MODE (0)
+/* @brief Has SDR104 support (HOST_CTRL_CAP[SDR104_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR104_MODE (0)
+/* @brief USDHC has reset control */
+#define FSL_FEATURE_USDHC_HAS_RESET (0)
+/* @brief USDHC has no bitfield WTMK_LVL[WR_BRST_LEN] and WTMK_LVL[RD_BRST_LEN] */
+#define FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN (1)
+
+/* TSTMR module features */
+
+/* @brief TSTMR clock frequency is 8MHZ. */
+#define FSL_FEATURE_TSTMR_CLOCK_FREQUENCY_8MHZ (1)
+/* @brief TSTMR clock frequency is 1MHZ. */
+#define FSL_FEATURE_TSTMR_CLOCK_FREQUENCY_1MHZ (0)
+
+/* @brief Memory map has offset between subsystems */
+#define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)
+
+/* MIPI DSI module features */
+/* @brief Offset between MIPI DSI controller and CSR in the MIPI DSI subsystem. */
+#define FSL_FEATURE_DSI_CSR_OFFSET (0x7000)
+
+/* MIPI CSI module features */
+/* @brief Offset between MIPI CSI controller and CSR in the MIPI CSI subsystem. */
+#define FSL_FEATURE_CSI2RX_CSR_OFFSET (0x6100)
+
+#endif /* _MIMX8QM6_ca53_FEATURES_H_ */
+

--- a/mcux/mcux-sdk/devices/MIMX8QM6/device_CMSIS.cmake
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/device_CMSIS.cmake
@@ -9,5 +9,10 @@ target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/.
 )
 
+if(${MCUX_DEVICE} STREQUAL "MIMX8QM6")
+    include(CMSIS_Include_core_cm)
+endif()
 
-include(CMSIS_Include_core_cm4)
+if(${MCUX_DEVICE} STREQUAL "MIMX8QM6_ca53")
+    include(CMSIS_Include_core_ca)
+endif()

--- a/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.c
@@ -162,6 +162,8 @@ uint32_t CLOCK_GetCoreSysClkFreq(void)
     err = sc_pm_get_clock_rate(ipcHandle, SC_R_M4_0_PID0, SC_PM_CLK_PER, &freq);
 #elif defined(MIMX8QM_CM4_CORE1)
     err = sc_pm_get_clock_rate(ipcHandle, SC_R_M4_1_PID0, SC_PM_CLK_PER, &freq);
+#elif defined(CONFIG_SOC_MIMX8QM_A53)
+    err = sc_pm_get_clock_rate(ipcHandle, SC_R_A53, SC_PM_CLK_PER, &freq);
 #else
 #error "Clock driver not support the core!"
 #endif

--- a/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.c
@@ -58,12 +58,26 @@ void CLOCK_Deinit(void)
  */
 bool CLOCK_EnableClockExt(clock_ip_name_t name, uint32_t gate)
 {
+	return CLOCK_EnableClockExtMapped((uint32_t *)LPCG_TUPLE_REG_BASE(name), name, gate);
+}
+
+
+/*!
+ * brief Enable the clock for specific IP, with gate setting (mapped version).
+ *
+ * param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * param name  Which clock to enable, see \ref clock_ip_name_t.
+ * param gate  0: clock always on, 1: HW auto clock gating.
+ * return true if success, false if failure.
+ */
+bool CLOCK_EnableClockExtMapped(uint32_t *lpcgBase, clock_ip_name_t name, uint32_t gate)
+{
     sc_err_t err;
 
     err = sc_pm_clock_enable(ipcHandle, LPCG_TUPLE_RSRC(name), SC_PM_CLK_PER, true, (bool)gate);
 
     /* Enable the Clock Gate control in LPCG */
-    CLOCK_ConfigLPCG(name, true, (bool)gate);
+    CLOCK_ConfigLPCGMapped(lpcgBase, name, true, (bool)gate);
 
     if (err != SC_ERR_NONE)
     {
@@ -83,10 +97,22 @@ bool CLOCK_EnableClockExt(clock_ip_name_t name, uint32_t gate)
  */
 bool CLOCK_DisableClock(clock_ip_name_t name)
 {
+	return CLOCK_DisableClockMapped((uint32_t *)LPCG_TUPLE_REG_BASE(name), name);
+}
+
+/*!
+ * brief Disable the clock for specific IP (mapped version).
+ *
+ * param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * param name  Which clock to disable, see \ref clock_ip_name_t.
+ * return true for success, false for failure.
+ */
+bool CLOCK_DisableClockMapped(uint32_t *lpcgBase, clock_ip_name_t name)
+{
     sc_err_t err;
 
     /* Disable the Clock Gate control in LPCG */
-    CLOCK_ConfigLPCG(name, false, false);
+    CLOCK_ConfigLPCGMapped(lpcgBase, name, false, false);
 
     err = sc_pm_clock_enable(ipcHandle, LPCG_TUPLE_RSRC(name), SC_PM_CLK_PER, false, false);
 
@@ -245,9 +271,22 @@ void CLOCK_SetLpcgGate(volatile uint32_t *regBase, bool swGate, bool hwGate, uin
  */
 void CLOCK_ConfigLPCG(clock_ip_name_t name, bool swGate, bool hwGate)
 {
+    CLOCK_ConfigLPCGMapped((uint32_t *)LPCG_TUPLE_REG_BASE(name), name, swGate, hwGate);
+}
+
+/*!
+ * brief Config the LPCG cell for specific IP (mapped version).
+ *
+ * param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * param name  Which clock to enable, see \ref clock_ip_name_t.
+ * param swGate Software clock gating. 0: clock is gated;  1: clock is enabled
+ * param swGate Hardware auto gating. 0: disable the HW clock gate control;  1: HW clock gating is enabled
+ */
+void CLOCK_ConfigLPCGMapped(uint32_t *lpcgBase, clock_ip_name_t name, bool swGate, bool hwGate)
+{
     volatile uint32_t *regBase;
 
-    regBase = LPCG_TUPLE_REG_BASE(name);
+    regBase = lpcgBase;
 
     /* Return if LPCG Cell is not available. */
     if (regBase == NULL)

--- a/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.h
@@ -432,6 +432,16 @@ void CLOCK_Deinit(void);
 bool CLOCK_EnableClockExt(clock_ip_name_t name, uint32_t gate);
 
 /*!
+ * @brief Enable the clock for specific IP, with gate setting (mapped version).
+ *
+ * @param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * @param name  Which clock to enable, see \ref clock_ip_name_t.
+ * @param gate  0: clock always on, 1: HW auto clock gating.
+ * @return true if success, false if failure.
+ */
+bool CLOCK_EnableClockExtMapped(uint32_t *lpcgBase, clock_ip_name_t name, uint32_t gate);
+
+/*!
  * @brief Enable the clock for specific IP.
  *
  * @param name  Which clock to enable, see \ref clock_ip_name_t.
@@ -443,12 +453,33 @@ static inline bool CLOCK_EnableClock(clock_ip_name_t name)
 }
 
 /*!
+ * @brief Enable the clock for specific IP (mapped version).
+ *
+ * @param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * @param name  Which clock to enable, see \ref clock_ip_name_t.
+ * @return true for success, false for failure.
+ */
+static inline bool CLOCK_EnableClockMapped(uint32_t *lpcgBase, clock_ip_name_t name)
+{
+    return CLOCK_EnableClockExtMapped(lpcgBase, name, 0);
+}
+
+/*!
  * @brief Disable the clock for specific IP.
  *
  * @param name  Which clock to disable, see \ref clock_ip_name_t.
  * @return true for success, false for failure.
  */
 bool CLOCK_DisableClock(clock_ip_name_t name);
+
+/*!
+ * @brief Disable the clock for specific IP (mapped version).
+ *
+ * @param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * @param name  Which clock to disable, see \ref clock_ip_name_t.
+ * @return true for success, false for failure.
+ */
+bool CLOCK_DisableClockMapped(uint32_t *lpcgBase, clock_ip_name_t name);
 
 /*!
  * @brief Set the clock frequency for specific IP module.
@@ -497,6 +528,16 @@ uint32_t CLOCK_GetCoreSysClkFreq(void);
  * @param hwGate Hardware auto gating. false: disable the HW clock gate control;  true: HW clock gating is enabled
  */
 void CLOCK_ConfigLPCG(clock_ip_name_t name, bool swGate, bool hwGate);
+
+/*!
+ * @brief Config the LPCG cell for specific IP (mapped version).
+ *
+ * @param lpcgBase Virtual/physical base address of the LPCG region associated with IP.
+ * @param name  Which clock to enable, see \ref clock_ip_name_t.
+ * @param swGate Software clock gating. false: clock is gated;  true: clock is enabled
+ * @param hwGate Hardware auto gating. false: disable the HW clock gate control;  true: HW clock gating is enabled
+ */
+void CLOCK_ConfigLPCGMapped(uint32_t *lpcgBase, clock_ip_name_t name, bool swGate, bool hwGate);
 
 /*!
  * @brief Set LPCG gate for specific LPCG.

--- a/mcux/mcux-sdk/devices/MIMX8QM6/fsl_device_registers.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/fsl_device_registers.h
@@ -32,6 +32,16 @@
 /* CPU specific feature definitions */
 #include "MIMX8QM6_cm4_core1_features.h"
 
+#elif(defined(CPU_MIMX8QM6AVUFF_ca53))
+
+#define MIMX8QM6_ca53_SERIES
+
+/* CMSIS-style register definitions */
+#include "MIMX8QM6_ca53.h"
+
+/* CPU specific feature definitions */
+#include "MIMX8QM6_ca53_features.h"
+
 #else
 #error "No valid CPU defined!"
 #endif

--- a/mcux/mcux-sdk/devices/MIMX8QM6/system_MIMX8QM6_ca53.c
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/system_MIMX8QM6_ca53.c
@@ -1,0 +1,86 @@
+/*
+** ###################################################################
+**     Processor:           MIMX8QM6AVUFF
+**     Compilers:           GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**                          Keil ARM C/C++ Compiler
+**
+**     Reference manual:    IMX8QMRM, Rev. E, Jun. 2018
+**     Version:             rev. 4.0, 2018-08-30
+**     Build:               b230621
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2023 NXP
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2016-06-02)
+**         Initial version.
+**     - rev. 2.0 (2017-05-04)
+**         RevA Header ER
+**     - rev. 3.0 (2018-01-29)
+**         RevB Header ER
+**     - rev. 4.0 (2018-08-30)
+**         RevC Header EAR
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MIMX8QM6_ca53
+ * @version 4.0
+ * @date 2018-08-30
+ * @brief Device specific configuration file for MIMX8QM6_ca53 (implementation
+ *        file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#include <stdint.h>
+#include "fsl_device_registers.h"
+
+
+
+/* ----------------------------------------------------------------------------
+   -- Core clock
+   ---------------------------------------------------------------------------- */
+
+uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
+
+/* ----------------------------------------------------------------------------
+   -- SystemInit()
+   ---------------------------------------------------------------------------- */
+
+void SystemInit (void) {
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  SCB->CPACR |= ((3UL << 10*2) | (3UL << 11*2));    /* set CP10, CP11 Full Access */
+#endif /* ((__FPU_PRESENT == 1) && (__FPU_USED == 1)) */
+/* i.MX8QM systemInit */
+  SystemInitHook();
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemCoreClockUpdate()
+   ---------------------------------------------------------------------------- */
+
+void SystemCoreClockUpdate (void) {
+/* i.MX8QM systemCoreClockUpdate */
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemInitHook()
+   ---------------------------------------------------------------------------- */
+
+__attribute__ ((weak)) void SystemInitHook (void) {
+  /* Void implementation of the weak function. */
+}

--- a/mcux/mcux-sdk/devices/MIMX8QM6/system_MIMX8QM6_ca53.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/system_MIMX8QM6_ca53.h
@@ -1,0 +1,104 @@
+/*
+** ###################################################################
+**     Processor:           MIMX8QM6AVUFF
+**     Compilers:           GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**                          Keil ARM C/C++ Compiler
+**
+**     Reference manual:    IMX8QMRM, Rev. E, Jun. 2018
+**     Version:             rev. 4.0, 2018-08-30
+**     Build:               b230621
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2023 NXP
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2016-06-02)
+**         Initial version.
+**     - rev. 2.0 (2017-05-04)
+**         RevA Header ER
+**     - rev. 3.0 (2018-01-29)
+**         RevB Header ER
+**     - rev. 4.0 (2018-08-30)
+**         RevC Header EAR
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MIMX8QM6_ca53
+ * @version 4.0
+ * @date 2018-08-30
+ * @brief Device specific configuration file for MIMX8QM6_ca53 (header file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#ifndef _SYSTEM_MIMX8QM6_ca53_H_
+#define _SYSTEM_MIMX8QM6_ca53_H_                 /**< Symbol preventing repeated inclusion */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#define DEFAULT_SYSTEM_CLOCK           1200000000u            /* Default System clock value */
+
+/**
+ * @brief System clock frequency (core clock)
+ *
+ * The system clock frequency supplied to the SysTick timer and the processor
+ * core clock. This variable can be used by the user application to setup the
+ * SysTick timer or configure other parameters. It may also be used by debugger to
+ * query the frequency of the debug timer or configure the trace clock speed
+ * SystemCoreClock is initialized with a correct predefined value.
+ */
+extern uint32_t SystemCoreClock;
+
+/**
+ * @brief Setup the microcontroller system.
+ *
+ * Typically this function configures the oscillator (PLL) that is part of the
+ * microcontroller device. For systems with variable clock speed it also updates
+ * the variable SystemCoreClock. SystemInit is called from startup_device file.
+ */
+void SystemInit (void);
+
+/**
+ * @brief Updates the SystemCoreClock variable.
+ *
+ * It must be called whenever the core clock is changed during program
+ * execution. SystemCoreClockUpdate() evaluates the clock register settings and calculates
+ * the current core clock.
+ */
+void SystemCoreClockUpdate (void);
+
+/**
+ * @brief SystemInit function hook.
+ *
+ * This weak function allows to call specific initialization code during the
+ * SystemInit() execution.This can be used when an application specific code needs
+ * to be called as close to the reset entry as possible (for example the Multicore
+ * Manager MCMGR_EarlyInit() function call).
+ * NOTE: No global r/w variables can be used in this hook function because the
+ * initialization of these variables happens after this function.
+ */
+void SystemInitHook (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _SYSTEM_MIMX8QM6_ca53_H_ */


### PR DESCRIPTION
This PR introduces the necessary changes for supporting MIMX8QM6's CA53 cores with Zephyr.