### PR TITLE
Add support for LPSPI on S32K344

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -74,3 +74,5 @@ Patch List:
   10. devices: MIMX8QM6: Add mapped versions of clock functions.
   11. devices: MIMX8QM6: Don't allow drivers to perform clock-related operations on Zephyr.
   12. devices: MIMX8QM6: Add missing LPUART interrupt macro.
+  13. mcux-sdk/drivers/lpspi/fsl_lpspi.h: add workaround for errata ERR050456 on S32K3x4 SoC
+  according to S32K3X4-0P55A-1P55A-ERRATA.

--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -17,6 +17,8 @@
 #define FSL_FEATURE_SOC_FLEXCAN_COUNT (6)
 /* @brief LPI2C availability on the SoC. */
 #define FSL_FEATURE_SOC_LPI2C_COUNT (2)
+/* @brief LPSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_LPSPI_COUNT (6)
 
 /* LPUART module features */
 
@@ -155,5 +157,16 @@
 #define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (0)
 /* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
 #define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (4)
+
+/* LPSPI module features */
+
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPSPI_FIFO_SIZEn(x) (4)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has CCR1 (related to existence of registers CCR1). */
+#define FSL_FEATURE_LPSPI_HAS_CCR1 (1)
+/* @brief Is affected by errata S32K3X4-0P55A-1P55A-ERRATA / ERR050456 (LPSPI: Reset to fifo does not work as expected). */
+#define FSL_FEATURE_LPSPI_HAS_ERRATA_050456 (1)
 
 #endif /* _S32K344_FEATURES_H_ */

--- a/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
+++ b/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
@@ -137,4 +137,36 @@
 /** Interrupt vectors for the LPI2C peripheral type */
 #define LPI2C_IRQS                               { LPI2C0_IRQn, LPI2C1_IRQn }
 
+/* LPSPI - Peripheral instance base addresses */
+/** Peripheral LPSPI0 base address */
+#define LPSPI0_BASE                              IP_LPSPI_0_BASE
+/** Peripheral LPSPI0 base pointer */
+#define LPSPI0                                   IP_LPSPI_0
+/** Peripheral LPSPI1 base address */
+#define LPSPI1_BASE                              IP_LPSPI_1_BASE
+/** Peripheral LPSPI1 base pointer */
+#define LPSPI1                                   IP_LPSPI_1
+/** Peripheral LPSPI2 base address */
+#define LPSPI2_BASE                              IP_LPSPI_2_BASE
+/** Peripheral LPSPI2 base pointer */
+#define LPSPI2                                   IP_LPSPI_2
+/** Peripheral LPSPI3 base address */
+#define LPSPI3_BASE                              IP_LPSPI_3_BASE
+/** Peripheral LPSPI3 base pointer */
+#define LPSPI3                                   IP_LPSPI_3
+/** Peripheral LPSPI4 base address */
+#define LPSPI4_BASE                              IP_LPSPI_4_BASE
+/** Peripheral LPSPI4 base pointer */
+#define LPSPI4                                   IP_LPSPI_4
+/** Peripheral LPSPI5 base address */
+#define LPSPI5_BASE                              IP_LPSPI_5_BASE
+/** Peripheral LPSPI5 base pointer */
+#define LPSPI5                                   IP_LPSPI_5
+/** Array initializer of LPSPI peripheral base addresses */
+#define LPSPI_BASE_ADDRS                         IP_LPSPI_BASE_ADDRS
+/** Array initializer of LPSPI peripheral base pointers */
+#define LPSPI_BASE_PTRS                          IP_LPSPI_BASE_PTRS
+/** Interrupt vectors for the LPSPI peripheral type */
+#define LPSPI_IRQS                               { LPSPI0_IRQn, LPSPI1_IRQn, LPSPI2_IRQn, LPSPI3_IRQn, LPSPI4_IRQn, LPSPI5_IRQn }
+
 #endif  /* _S32K344_GLUE_MCUX_H_ */


### PR DESCRIPTION
Configure LPSPI features and allow to build this driver for S32K344.

LPSPI is affected by errata ERR050456 on this device, as described in S32K3X4-0P55A-1P55A-ERRATA.
The user can reset the transmit FIFO using LPSPIn_CR[RTF] bit and can reset the receive FIFO using LPSPIn_CR[RRF]. However, resetting the FIFO using CR[RTF] and CR[RRF] does not clear the FIFO pointers completely. Workaround this by resetting resetting the entire module using LPSPIn_CR[RST] bit.