### PR TITLE
Add support for LPI2C on S32K344

### DIFF
--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -15,6 +15,8 @@
 #define FSL_FEATURE_SOC_LPUART_COUNT (16)
 /* @brief FLEXCAN availability on the SoC. */
 #define FSL_FEATURE_SOC_FLEXCAN_COUNT (6)
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (2)
 
 /* LPUART module features */
 
@@ -146,5 +148,12 @@
 #define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO (0)
 /* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
 #define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (0)
+
+/* LPI2C module features */
+
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (0)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (4)
 
 #endif /* _S32K344_FEATURES_H_ */

--- a/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
+++ b/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
@@ -121,4 +121,20 @@
 #define CAN_ORed_Message_buffer_64_95_IRQS       { FlexCAN0_1_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn}
 #define CAN_ORed_Message_buffer_IRQS             CAN_ORed_Message_buffer_0_31_IRQS
 
+/* LPI2C - Peripheral instance base addresses */
+/** Peripheral LPI2C0 base address */
+#define LPI2C0_BASE                              IP_LPI2C_0_BASE
+/** Peripheral LPI2C0 base pointer */
+#define LPI2C0                                   IP_LPI2C_0
+/** Peripheral LPI2C1 base address */
+#define LPI2C1_BASE                              IP_LPI2C_1_BASE
+/** Peripheral LPI2C1 base pointer */
+#define LPI2C1                                   IP_LPI2C_1
+/** Array initializer of LPI2C peripheral base addresses */
+#define LPI2C_BASE_ADDRS                         IP_LPI2C_BASE_ADDRS
+/** Array initializer of LPI2C peripheral base pointers */
+#define LPI2C_BASE_PTRS                          IP_LPI2C_BASE_PTRS
+/** Interrupt vectors for the LPI2C peripheral type */
+#define LPI2C_IRQS                               { LPI2C0_IRQn, LPI2C1_IRQn }
+
 #endif  /* _S32K344_GLUE_MCUX_H_ */


### PR DESCRIPTION
Add LPI2C instance base addresses and module features to support using LPI2C MCUX driver.