### PR TITLE
modules: rename S32 to NXP_S32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_S32_HAL)
+if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL)
   zephyr_library()
 endif()
 
-if(CONFIG_HAS_S32_HAL)
+if(CONFIG_HAS_NXP_S32_HAL)
   add_subdirectory(s32)
 else()
   add_subdirectory_ifdef(


### PR DESCRIPTION
Rename module from `S32` to `NXP_S32` to avoid ambiguity. All other files and symbols have been already renamed but this was missing to update.