### PR TITLE
mcux: add tempmon driver to cmake

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -174,6 +174,7 @@ include_driver_ifdef(CONFIG_MCUX_XBARA			xbara		driver_xbara)
 include_driver_ifdef(CONFIG_QDEC_MCUX			enc		driver_enc)
 include_driver_ifdef(CONFIG_CRYPTO_MCUX_DCP			dcp		driver_dcp)
 include_driver_ifdef(CONFIG_DMA_MCUX_SMARTDMA		smartdma	driver_lpc_smartdma)
+include_driver_ifdef(CONFIG_MCUX_TEMPMON		tempmon		driver_tempmon)
 
 if ((${MCUX_DEVICE} MATCHES "MIMXRT1[0-9][0-9][0-9]") AND (NOT (CONFIG_SOC_MIMXRT1166_CM4 OR CONFIG_SOC_MIMXRT1176_CM4)))
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/armv7-m7	driver_cache_armv7_m7)


### PR DESCRIPTION
Add tempmon driver to MCUX cmake directive, to enable inclusion of MCUX TEMPMON HAL driver.