### PR TITLE
module: define CMake and Kconfig root within NXP module

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Linaro, Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# file is empty and kept as a place holder if/when Kconfig is needed

--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -111,3 +111,6 @@ zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
 zephyr_library_compile_definitions_ifdef(CONFIG_NOCACHE_MEMORY
   __STARTUP_INITIALIZE_NONCACHEDATA
 )
+
+# Add Zephyr-specific glue code
+add_subdirectory(zephyr)

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -86,6 +86,7 @@ zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/common)
 #include shared drivers
 include_driver_ifdef(CONFIG_ADC_MCUX_LPADC		lpadc		driver_lpadc)
 include_driver_ifdef(CONFIG_COUNTER_MCUX_CTIMER		ctimer		driver_ctimer)
+include_driver_ifdef(CONFIG_PWM_MCUX_CTIMER		ctimer		driver_ctimer)
 include_driver_ifdef(CONFIG_COUNTER_MCUX_LPC_RTC	lpc_rtc		driver_lpc_rtc)
 include_driver_ifdef(CONFIG_DMA_MCUX_LPC		lpc_dma		driver_lpc_dma)
 include_driver_ifdef(CONFIG_GPIO_MCUX_LPC		lpc_gpio        driver_lpc_gpio)

--- a/mcux/zephyr/CMakeLists.txt
+++ b/mcux/zephyr/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright 2023 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+add_subdirectory_ifdef(CONFIG_USB_DEVICE_DRIVER usb)
+zephyr_include_directories(.)

--- a/mcux/zephyr/fsl_os_abstraction.h
+++ b/mcux/zephyr/fsl_os_abstraction.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __FSL_OS_ABSTRACTION__
+#define __FSL_OS_ABSTRACTION__
+
+#include <zephyr/irq.h>
+
+/* enter critical macros */
+#define OSA_SR_ALLOC() int osa_current_sr
+#define OSA_ENTER_CRITICAL() osa_current_sr = irq_lock()
+#define OSA_EXIT_CRITICAL() irq_unlock(osa_current_sr)
+
+#endif /* __FSL_OS_ABSTRACTION__ */

--- a/mcux/zephyr/usb/CMakeLists.txt
+++ b/mcux/zephyr/usb/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2021, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+zephyr_include_directories(.)

--- a/mcux/zephyr/usb/usb_device_config.h
+++ b/mcux/zephyr/usb/usb_device_config.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 - 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __USB_DEVICE_CONFIG_H__
+#define __USB_DEVICE_CONFIG_H__
+
+#include <zephyr/devicetree.h>
+#include "usb.h"
+
+/******************************************************************************
+ * Definitions
+ *****************************************************************************/
+/* EHCI instance count */
+#ifdef CONFIG_USB_DC_NXP_EHCI
+#define USB_DEVICE_CONFIG_EHCI (1U)
+/* How many the DTD are supported. */
+#define USB_DEVICE_CONFIG_EHCI_MAX_DTD (16U)
+#endif /* CONFIG_USB_DC_NXP_EHCI */
+
+#ifdef CONFIG_USB_DC_NXP_LPCIP3511
+
+#ifdef USBHSD_BASE_ADDRS
+#define USB_DEVICE_CONFIG_LPCIP3511HS (1U)
+#else
+#define USB_DEVICE_CONFIG_LPCIP3511HS (0U)
+#endif
+
+#ifdef USB_BASE_ADDRS
+#define USB_DEVICE_CONFIG_LPCIP3511FS (1U)
+#else
+#define USB_DEVICE_CONFIG_LPCIP3511FS (0U)
+#endif
+
+#endif /* CONFIG_USB_DC_NXP_LPCIP3511 */
+
+/* Whether device is self power. 1U supported, 0U not supported */
+#define USB_DEVICE_CONFIG_SELF_POWER (1U)
+
+#define DT_DRV_COMPAT nxp_mcux_usbd
+
+/* Number of endpoints supported */
+#define USB_DEVICE_CONFIG_ENDPOINTS (DT_INST_PROP(0, num_bidir_endpoints))
+
+#endif /* __USB_DEVICE_CONFIG_H__ */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,6 +1,6 @@
 name: hal_nxp
 build:
-  cmake-ext: True
-  kconfig-ext: True
+  cmake: .
+  kconfig: Kconfig
   settings:
     dts_root: .


### PR DESCRIPTION
Define CMake and Kconfig root within NXP module, rather than within $ZEPHYR_BASE/modules directory. This will enable additional flexibility if the NXP HAL needs to define Kconfig symbols outside of Zephyr proper.

As part of this cleanup, the fsl_os_abstraction and usb middleware glue code for MCUX SDK now are stored in $MODULE_ROOT/mcux/zephyr