### PR TITLE
s32: use zephyr/toolchain.h

### DIFF
--- a/s32/drivers/s32k3/BaseNXP/include/Compiler.h
+++ b/s32/drivers/s32k3/BaseNXP/include/Compiler.h
@@ -485,7 +485,7 @@ extern "C"{
  */
 #ifdef CONFIG_NOCACHE_MEMORY
 #ifdef __ZEPHYR__
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #else
 #ifndef STRINGIFY
 #define STRINGIFY(x) #x

--- a/s32/drivers/s32ze/BaseNXP/include/Compiler.h
+++ b/s32/drivers/s32ze/BaseNXP/include/Compiler.h
@@ -524,7 +524,7 @@ extern "C"{
  */
 #ifdef CONFIG_NOCACHE_MEMORY
 #ifdef __ZEPHYR__
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #else
 #ifndef STRINGIFY
 #define STRINGIFY(x) #x


### PR DESCRIPTION
It is wrong to use toolchain-specific headers.