### PR TITLE
Add bare-metal driver for eMIOS ICU for S32K344

### DIFF
--- a/s32/drivers/s32k3/Icu/CMakeLists.txt
+++ b/s32/drivers/s32k3/Icu/CMakeLists.txt
@@ -12,3 +12,10 @@ zephyr_library_sources_ifdef(CONFIG_NXP_S32_WKPU
     src/Wkpu_Ip.c
     src/Wkpu_Ip_Irq.c
 )
+
+if (CONFIG_PWM_NXP_S32_EMIOS AND CONFIG_PWM_CAPTURE)
+    zephyr_library_sources(
+        src/Emios_Icu_Ip.c
+        src/Emios_Icu_Ip_Irq.c
+    )
+endif()

--- a/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip.h
+++ b/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip.h
@@ -1,0 +1,694 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_H
+#define EMIOS_ICU_IP_H
+
+/**
+*   @file Emios_Icu_Ip.h
+*
+*   @addtogroup emios_icu_ip EMIOS IPL
+*   @{
+*/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*==================================================================================================
+                                         INCLUDE FILES
+ 1) system and project includes
+ 2) needed interfaces from external units
+ 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "Emios_Icu_Ip_Types.h"
+#include "Emios_Icu_Ip_Cfg.h"
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if (STD_ON == EMIOS_ICU_USES_MCL_DRIVER)
+    /* Include common functions of EMIOS. */
+        #include "Emios_Mcl_Ip.h"
+    #endif
+#endif  /* EMIOS_ICU_IP_USED */
+
+/*==================================================================================================
+                               SOURCE FILE VERSION INFORMATION
+==================================================================================================*/
+#define EMIOS_ICU_IP_VENDOR_ID                           43
+#define EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION            4
+#define EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION            7
+#define EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION         0
+#define EMIOS_ICU_IP_SW_MAJOR_VERSION                    3
+#define EMIOS_ICU_IP_SW_MINOR_VERSION                    0
+#define EMIOS_ICU_IP_SW_PATCH_VERSION                    0
+
+/*==================================================================================================
+                                      FILE VERSION CHECKS
+==================================================================================================*/
+/* Check Emios_Icu_Ip.h against Emios_Icu_Ip_Types.h file versions */
+#if (EMIOS_ICU_IP_VENDOR_ID != EMIOS_ICU_IP_TYPES_VENDOR_ID)
+    #error "Emios_Icu_Ip.h and Emios_Icu_Ip_Types.h have different vendor IDs"
+#endif
+
+#if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_REVISION_VERSION))
+  #error "AutoSar Version Numbers of Emios_Icu_Ip.h and Emios_Icu_Ip_Types.h are different"
+#endif
+
+#if ((EMIOS_ICU_IP_SW_MAJOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_SW_MINOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_SW_PATCH_VERSION != EMIOS_ICU_IP_TYPES_SW_PATCH_VERSION))
+       #error "Software Version Numbers of Emios_Icu_Ip.h  and Emios_Icu_Ip_Types.h are different"
+#endif
+
+#if (EMIOS_ICU_IP_VENDOR_ID != EMIOS_ICU_IP_CFG_VENDOR_ID)
+    #error "Emios_Icu_Ip.h and Emios_Icu_Ip_Cfg.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_Cfg.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip.h and Emios_Icu_Ip_Cfg.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_Cfg.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_SW_MAJOR_VERSION != EMIOS_ICU_IP_CFG_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_SW_MINOR_VERSION != EMIOS_ICU_IP_CFG_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_SW_PATCH_VERSION != EMIOS_ICU_IP_CFG_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip.h and Emios_Icu_Ip_Cfg.h are different"
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if (STD_ON == EMIOS_ICU_USES_MCL_DRIVER)
+        /* Check if  header file and Emios_Mcl_Ip.h file are of the same Autosar version */
+        #if (EMIOS_ICU_IP_VENDOR_ID != EMIOS_MCL_IP_VENDOR_ID)
+            #error "Emios_Icu_Ip.h and Emios_Mcl_Ip.h have different vendor ids"
+        #endif
+        
+        /* Check if  header file and Emios_Mcl_Ip.h file are of the same Autosar version */
+        #if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION    != EMIOS_MCL_IP_AR_RELEASE_MAJOR_VERSION) || \
+             (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION    != EMIOS_MCL_IP_AR_RELEASE_MINOR_VERSION) || \
+             (EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION != EMIOS_MCL_IP_AR_RELEASE_REVISION_VERSION))
+            #error "AutoSar Version Numbers of Emios_Icu_Ip.h and Emios_Mcl_Ip.h are different"
+        #endif
+        
+        /* Check if header file and Emios_Mcl_Ip.h file are of the same Software version */
+        #if ((EMIOS_ICU_IP_SW_MAJOR_VERSION != EMIOS_MCL_IP_SW_MAJOR_VERSION) || \
+             (EMIOS_ICU_IP_SW_MINOR_VERSION != EMIOS_MCL_IP_SW_MINOR_VERSION) || \
+             (EMIOS_ICU_IP_SW_PATCH_VERSION != EMIOS_MCL_IP_SW_PATCH_VERSION))
+            #error "Software Version Numbers of Emios_Icu_Ip.h and Emios_Mcl_Ip.h are different"
+        #endif
+    #endif
+#endif  /* EMIOS_ICU_IP_USED */
+/*==================================================================================================
+                                           CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+                                       DEFINES AND MACROS
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+#if (defined EMIOS_ICU_CONFIG_EXT)
+#define ICU_START_SEC_CONFIG_DATA_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+/* Macro used to import SIUL2 PB generated configurations. */
+EMIOS_ICU_CONFIG_EXT
+
+#define ICU_STOP_SEC_CONFIG_DATA_UNSPECIFIED
+#include "Icu_MemMap.h"
+#endif
+/*==================================================================================================
+*                                        GLOBAL VARIABLES
+==================================================================================================*/
+
+/*==================================================================================================
+                                             ENUMS
+==================================================================================================*/
+
+/*==================================================================================================
+                                 STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+
+
+/*==================================================================================================
+                                 GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+                                     FUNCTION PROTOTYPES
+==================================================================================================*/
+#define ICU_START_SEC_CODE
+#include "Icu_MemMap.h"
+
+/**
+ * @brief      Emios_Icu_Ip_Init
+ * @details    This function is called separately for each EMIOS hw channel corresponding to
+ *             the configured Icu channels, and:
+ *             - Disables the interrupt corresponding to eMIOS channel
+ *             - Initializes prescaler value, channel filter, freeze enable, and bus select fields
+ *             - Defines on which edge the period starts
+ *             - Clears the (pending) interrupt flag corresponding to eMIOS channel
+ *             - Resets the UC A register.
+ *             - Enables the SAIC mode for eMIOS channels.
+ * @param[in]  instance - EMIOS instance used.
+ * @param[in]  userConfig - pointer to eMios configuration structure
+ */
+eMios_Icu_Ip_StatusType Emios_Icu_Ip_Init(uint8 instance, const eMios_Icu_Ip_ConfigType *userConfig);
+
+#if (EMIOS_ICU_IP_DEINIT_API == STD_ON)
+/**
+* @brief      Emios_Icu_Ip_Deinit
+* @details    This function is called separately for each EMIOS hw channel corresponding to the
+*             configured Icu channels, and:
+*             - Resets the eMIOS channel control register
+*             - Resets the UC A register.
+*             - Clears the (pending) interrupt flag corresponding to eMIOS channel
+* @param[in]  peMiosIpConfig   - pointer to eMios configuration structure
+*/
+eMios_Icu_Ip_StatusType Emios_Icu_Ip_Deinit(uint8 instance);
+#endif
+
+#if (EMIOS_ICU_IP_SET_MODE_API == STD_ON)
+/**
+* @brief      Emios_Icu_Ip_SetSleepMode
+* @details    This function is called separately for each EMIOS hw channel corresponding to the
+*             configured Icu channels, and:
+*             - Enables the interrupt for the eMIOS channel,
+*                 if the wake up functionality is enabled
+*             - Disables the interrupt for the eMIOS channel,
+*                 if the wake up functionality is disabled
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+* @api
+*/
+void Emios_Icu_Ip_SetSleepMode(uint8 instance, uint8 hwChannel);
+
+/**
+* @brief      Emios_Icu_Ip_SetNormalMode
+* @details    This function: Set normal mode
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+* @api
+*/
+void Emios_Icu_Ip_SetNormalMode(uint8 instance, uint8 hwChannel);
+#endif  /* ICU_SET_MODE_API */
+
+/**
+* @brief      Icu driver function that sets activation condition of eMIOS channel
+* @details    This function enables the requested activation condition(rising, falling or both
+*             edges) for corresponding eMIOS channels.
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS channel index
+* @param[in]  edge        - type of edge to be used
+* @api
+*/
+void Emios_Icu_Ip_SetActivation(uint8 instance, uint8 hwChannel, eMios_Icu_Ip_EdgeType edge);
+
+#if (EMIOS_ICU_IP_EDGE_DETECT_API == STD_ON)
+/**
+* @brief      Emios_Icu_Ip_EnableEdgeDetection
+* @details    eMIOS IP function that starts the edge detection service for an eMIOS channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*
+* @return void
+*/
+void Emios_Icu_Ip_EnableEdgeDetection(uint8 instance, uint8 hwChannel);
+
+/**
+* @brief      Emios_Icu_Ip_DisableEdgeDetection
+* @details    eMIOS IP function that stops the edge detection service for an eMIOS channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*
+* @return void
+*/
+void Emios_Icu_Ip_DisableEdgeDetection(uint8 instance, uint8 hwChannel);
+#endif /* ICU_EDGE_DETECT_API */
+
+/**
+ * @brief      Driver function Enable Notification.
+ *
+ * @param[in]  instance  Hardware instance used. 
+ * @param[in]  hwChannel Hardware channel used.
+ * @return     void
+ */
+void Emios_Icu_Ip_EnableNotification(uint8 instance, uint8 hwChannel);
+
+/**
+ * @brief      Driver function Disable Notification.
+ *
+ * @param[in]  instance  Hardware instance used. 
+ * @param[in]  hwChannel Hardware channel used.
+ * @return     void
+ */
+void Emios_Icu_Ip_DisableNotification(uint8 instance, uint8 hwChannel);
+
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+/**
+* @brief      Icu driver function that starts time stamp measurement of eMIOS channel.
+* @details    This function:
+*             - Puts the eMIOS channel into GPIO mode
+*             - Clears the pending interrupts
+*             - Enables SAIC mode for the channel
+*             - Enbales the interrupt for the channel
+*
+* @param[in]  instance         - eMIOS module index
+* @param[in]  hwChannel        - eMIOS encoded hardware channel
+* @param[in]  bufferPtr        - buffer pointer for results
+* @param[in]  bufferSize       - size of buffer results
+* @param[in]  notifyInterval   - interval for calling notification
+* @api
+*/
+void Emios_Icu_Ip_StartTimestamp
+(
+    uint8 instance,
+    uint8 hwChannel,
+    eMios_Icu_ValueType * bufferPtr,
+    uint16 bufferSize,
+    uint16 notifyInterval
+);
+
+/**
+* @brief   This function reads the timestamp index of the given channel.
+* @details This function reentrant and reads the timestamp index of the given channel,
+*          which is next to be written.
+*
+* @param[in]  instance      - eMIOS module index
+* @param[in]  hwChannel     - Logical number of the ICU channel
+*
+* @return     uint16 - Timestamp index of the given channel
+* @pre        Emios_Icu_Ip_Init must be called before. Icu_StartTimestamp must be called before.
+*/
+uint16 Emios_Icu_Ip_GetTimestampIndex
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief      Icu driver function that stops time stamp measurement of eMIOS channel.
+* @details    This function:
+*             - Puts the eMIOS channel into GPIO mode
+*             - Disables the interrupt for the channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+* @api
+*/
+void Emios_Icu_Ip_StopTimestamp(uint8 instance, uint8 hwChannel);
+#endif  /* EMIOS_ICU_IP_TIMESTAMP_API */
+
+#if ((EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_USES_DMA == STD_ON))
+/**
+* @brief      Emios_Icu_Ip_GetStartAddress
+* @details    eMIOS IP function that stops the edge detection service for an eMIOS channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*
+* @return void
+*
+**/
+uint32 Emios_Icu_Ip_GetStartAddress
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif
+
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+/**
+* @brief      Icu driver function that resets the edge counter measurement of eMIOS channel.
+* @details    The function:
+*             - Puts the eMIOS channel into GPIO mode
+*             - Resets the counter to initial value
+*             - Loads the initial value to the RegisterA
+*             - Clears the pending interrupts
+*             - Restores the previous mode
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*
+* @api
+*/
+void Emios_Icu_Ip_ResetEdgeCount
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief      Icu driver function that enables the edge counter measurement of eMIOS channel.
+* @details    The function:
+*             - Puts the eMIOS channel into GPIO mode
+*             - Counter register is loaded with startValue
+*             - Loads initial value to RegisterA
+*             - Clears the pending interrupts
+*             - Sets the mode to Modulus counter mode
+*             - Enables the interrupt for eMIOS channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*/
+void Emios_Icu_Ip_EnableEdgeCount(uint8 instance, uint8 hwChannel);
+
+/**
+* @brief      Icu driver function that disables the edge counter measurement of eMIOS channel.
+* @details    The function:
+*             - Disables the eMIOS channel interrupt
+*             - Clears the pending interrupts
+*             - Save the current counter value before entering into GPIO mode
+*             - Puts the channel into GPIO mode
+*             - Disables MCB mode for the channel
+*
+* @param[in]  instance     - eMIOS module index
+* @param[in]  hwChannel    - eMIOS encoded hardware channel
+*
+* @api
+*/
+void Emios_Icu_Ip_DisableEdgeCount
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief      Icu driver function that gets edge counter measurement of eMIOS channel.
+* @details    This function returns counter value (the number of counter edges) of eMIOS channel
+*
+* @param[in]  instance    - eMIOS module index
+* @param[in]  hwChannel   - eMIOS encoded hardware channel
+*
+* @return     uint32 - Counted edges number
+*
+* @api
+*/
+eMios_Icu_ValueType Emios_Icu_Ip_GetEdgeNumbers
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+#if (STD_ON == EMIOS_ICU_IP_SET_INITIAL_COUNTER)
+/**
+* @brief      Icu driver function that Set Initial setting of eMIOS Counter.
+* @details    This function Set Initial setting of eMIOS Counter
+*
+* @param[in]  instance        - eMIOS module index
+* @param[in]  hwChannel       - eMIOS encoded hardware channel
+* @param[in]  offsetCounter   - eMios Initial counter
+*
+* @pre        This function is not required because the counter value is 
+*             set automatically. But to arbitrarily change the Initial value 
+*             of the counter value, it is necessary to call this function 
+*             before the Emios_Icu_Ip_EnableEdgeCount.
+*             After call Emios_Icu_Ip_ResetEdgeCount function to reset counter value 
+*             to 0, the previously set Initial value will no longer be valid.
+*/
+void Emios_Icu_Ip_SetInitialCounterValue
+(
+    uint8 instance,
+    uint8 hwChannel,
+    uint32 initialCounter
+);
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_INITIAL_COUNTER */
+
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+/**
+* @brief      Icu driver function that Set Max setting of eMIOS Counter.
+* @details    This function Set Max setting of eMIOS Counter
+*
+* @param[in]  instance        - eMIOS module index
+* @param[in]  hwChannel       - eMIOS encoded hardware channel
+* @param[in]  defaultCounter  - eMios Max counter
+*
+* @pre        This function is not required because the counter value is 
+*             set automatically. But to arbitrarily change the Max value 
+*             of the counter value, it is necessary to call this function  
+*             before the Emios_Icu_Ip_EnableEdgeCount function.
+*/
+void Emios_Icu_Ip_SetMaxCounterValue
+(
+    uint8 instance,
+    uint8 hwChannel,
+    uint32 maxCounter
+);
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+#endif  /* EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/**
+* @brief      Icu driver function that starts the signal measurement of eMIOS channel.
+* @details    This function:
+*             - Disables the interrupt of eMIOS channel
+*             - Puts the eMIOS channel into GPIO mode
+*             - Sets activation condition (Rising, Falling or Both edges)
+*             - Puts the eMIOS channel into requested mode (IPWM, IPM or SAIC)
+*             - Clears pending interrupts
+*             - Enables the interrupt for eMIOS channel
+*
+* @param[in]  instance   - eMIOS module index
+* @param[in]  hwChannel  - eMIOS encoded hardware channel
+*
+* @api
+*/
+void Emios_Icu_Ip_StartSignalMeasurement
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief      Icu driver function that stops the signal measurement of eMIOS channel.
+* @details    This function:
+*             - Puts the eMIOS channel into GPIO mode
+*             - Disables the interrupt for requsted eMIOS channel
+*             - Clears pending interrupts
+*
+* @param[in]  instance   - eMIOS module index
+* @param[in]  hwChannel  - eMIOS encoded hardware channel
+*
+* @api
+*/
+void Emios_Icu_Ip_StopSignalMeasurement
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief   This function reads the elapsed Signal Low, High or Period Time for the given channel.
+* @details This service is reentrant and reads the elapsed Signal Low Time for the given channel
+*          that is configured  in Measurement Mode Signal Measurement, Signal Low Time.
+*          The elapsed time is measured between a falling edge and the consecutive rising edge of
+*          the channel.
+*          This service reads the elapsed Signal High Time for the given channel that is configured
+*          in Measurement Mode Signal Measurement,Signal High Time.The elapsed time is measured
+*          between a rising edge and the consecutive falling edge of the channel.
+*          This service reads the elapsed Signal Period Time for the given channel that is
+*          configured in Measurement Mode Signal Measurement,  Signal Period Time.The elapsed time
+*          is measured between consecutive  rising (or falling) edges  of the  channel. The  period
+*          start edge is
+*
+*          configurable.
+*
+* @param[in]  instance     - eMIOS module index
+* @param[in]  hwChannel    - Logical number of the ICU channel
+*
+* @return     uint16 -  the elapsed Signal Low Time for the given channel that is configured in
+*             Measurement Mode Signal Measurement, Signal Low Time
+* @pre        Emios_Icu_Ip_Init must be called before. The channel must be configured in Measurement Mode Signal
+*             Measurement.
+*/
+eMios_Icu_ValueType Emios_Icu_Ip_GetTimeElapsed
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+/**
+* @brief   This function reads the coherent active time and period time for the given ICU Channel.
+* @details The function is reentrant and reads the coherent active time and period time for
+*          the given ICU Channel, if it is configured in Measurement Mode Signal Measurement, Duty
+*          Cycle Values.
+*
+* @param[in]     instance         - eMIOS module index
+* @param[in]     hwChannel        - Logical number of the ICU channel
+* @param[out]    dutyCycleValues  - Pointer to a buffer where the results (active time and period time)
+*                                   shall be placed.
+*
+* @return     void
+* @pre        Emios_Icu_Ip_Init must be called before. The given channel must be configured in Measurement Mode
+*             Signal Measurement, Duty Cycle Values.
+*/
+void Emios_Icu_Ip_GetDutyCycleValues
+(
+    uint8 instance,
+    uint8 hwChannel,
+    eMios_Icu_Ip_DutyCycleType*  dutyCycleValues
+);
+
+/**
+ * @brief Emios_Icu_Ip_SetPWandPeriod
+ * 
+ * @param instance 
+ * @param hwChannel 
+ * @param activePulseWidth 
+ * @param period 
+ */
+void Emios_Icu_Ip_SetPWandPeriod(uint8 instance,
+                                 uint8 hwChannel,
+                                 eMios_Icu_ValueType activePulseWidth,
+                                 eMios_Icu_ValueType period);
+
+#endif  /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API */
+
+#if (EMIOS_ICU_IP_GET_INPUT_STATE_API == STD_ON)
+/**
+* @brief      Icu driver function that gets the input state of eMIOS channel.
+* @details    This function:
+*             - Checks if interrupt flags for corresponding eMIOS channel is set then
+*             it clears the interrupt flag and returns the value as true.
+*
+* @param[in]  instance   - eMIOS module index
+* @param[in]  hwChannel  - eMIOS encoded hardware channel
+*
+* @return       boolean
+* @retval       true  - if channel is active
+* @retval       false - if channel is idle
+*
+* @api
+*/
+boolean Emios_Icu_Ip_GetInputState
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif  /* EMIOS_ICU_IP_GET_INPUT_STATE_API */
+
+#if (EMIOS_ICU_IP_GET_INPUT_LEVEL_API == STD_ON)
+/**
+* @brief      This function returns the actual status of PIN.
+* @details    This function returns the actual status o PIN
+*
+* @param[in]     instance   - eMIOS module index
+* @param[in]     hwChannel  - eMIOS encoded hardware channel
+*
+* @return  void
+*
+* @api
+*/
+eMios_Icu_Ip_LevelType Emios_Icu_Ip_GetInputLevel
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif /* EMIOS_ICU_IP_GET_INPUT_LEVEL_API == STD_ON */
+
+/**
+* @brief      Emios_Icu_Ip_GetOverflow
+* @details    eMIOS IP function that get the state of the overflow flag
+*
+* @param[in]   instance    - eMIOS module index
+* @param[in]   hwChannel   - eMIOS  encoded hardware channel
+*
+* @return      boolean      the state of the overflow flag
+* @retval      true         the overflow flag is set
+* @retval      false        the overflow flag is not set
+*
+* @return void
+*/
+boolean Emios_Icu_Ip_GetOverflow
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+
+#if (EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON)
+void Emios_Icu_Ip_SetClockMode
+(
+    uint8 instance,
+    const eMios_Icu_Ip_ConfigType * peMiosIpConfig,
+    const eMios_Icu_Ip_ClockModeType Prescaler
+);
+#endif  /* EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_CAPTURERGISTER_API == STD_ON) && ((EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)))
+uint32 Emios_Icu_Ip_GetCaptureRegValue
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif  /* EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+/**
+* @brief      This function returns the signals High time, Low time and Period without using the
+*             channel interrupt
+* @details    This function returns the signals High time, Low time and Period without using the
+*             channel interrupt
+*
+* @param[in]  instance   - eMIOS module index
+* @param[in]  hwChannel  - eMIOS hardware channel
+*/
+void Emios_Icu_Ip_GetPulseWidth
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif /* ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) &&  (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))*/
+
+#if ((EMIOS_ICU_IP_VALIDATE_GLOBAL_CALL == STD_ON) && ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)))
+Std_ReturnType Emios_Icu_Ip_ValidateSignalMeasureWithoutInterrupt
+(
+    uint8 instance,
+    uint8 hwChannel
+);
+#endif /* ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) &&  (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))*/
+
+/**
+* @brief      Emios_Icu_Ip_EnableInterrupt
+* @details    This function Clears the pending interrupts of eMIOS channels and
+*             enables eMIOS Channel interrupt
+*
+* @param[in]  instance  - eMIOS module index
+* @param[in]  hwChannel - eMIOS Channel index
+* @api
+*/
+void Emios_Icu_Ip_EnableInterrupt(uint8 instance, uint8 hwChannel);
+
+/**
+* @brief      Emios_Icu_Ip_DisableInterrupt
+* @details    This function disables eMIOS Channel interrupt
+*
+* @param[in]  instance  - eMIOS module index
+* @param[in]  hwChannel - eMIOS Channel index
+* @api
+*/
+void Emios_Icu_Ip_DisableInterrupt(uint8 instance, uint8 hwChannel);
+
+
+#define ICU_STOP_SEC_CODE
+#include "Icu_MemMap.h"
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/** @} */
+
+#endif  /* EMIOS_ICU_IP_H */

--- a/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_Irq.h
+++ b/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_Irq.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IRQ_H
+#define EMIOS_ICU_IRQ_H
+
+/**
+ *   @file Emios_Icu_Ip_Irq.h
+ *
+ *   @addtogroup emios_icu_ip EMIOS IPL
+ *   @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/*==================================================================================================
+*                                          INCLUDE FILES
+*  1) system and project includes
+*  2) needed interfaces from external units
+*  3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "OsIf.h"
+#include "Emios_Icu_Ip_Cfg.h"
+#include "Emios_Icu_Ip_Types.h"
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+        #include "Dma_Ip.h"
+    #endif
+#endif
+/*==================================================================================================
+*                                SOURCE FILE VERSION INFORMATION
+==================================================================================================*/
+#define EMIOS_ICU_IP_IRQ_VENDOR_ID                       43
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION        4
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION        7
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION     0
+#define EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION                3
+#define EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION                0
+#define EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION                0
+
+/*==================================================================================================
+*                                       FILE VERSION CHECKS
+==================================================================================================*/
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    #if (STD_ON == EMIOS_ICU_IP_USED)
+        #if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+            /* Check if header file and Dma_Ip.h file are of the same Autosar version */
+            #if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION != DMA_IP_AR_RELEASE_MAJOR_VERSION) || \
+                 (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION != DMA_IP_AR_RELEASE_MINOR_VERSION))
+                #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.h and Dma_Ip.h are different"
+            #endif
+        #endif
+    #endif
+#endif
+
+#if (EMIOS_ICU_IP_IRQ_VENDOR_ID != EMIOS_ICU_IP_TYPES_VENDOR_ID)
+    #error "Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Types.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_Types.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Types.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_Types.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION != EMIOS_ICU_IP_TYPES_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Types.h are different"
+#endif
+
+#if (EMIOS_ICU_IP_IRQ_VENDOR_ID != EMIOS_ICU_IP_CFG_VENDOR_ID)
+    #error "Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Cfg.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_Cfg.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Cfg.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_Cfg.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION != EMIOS_ICU_IP_CFG_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION != EMIOS_ICU_IP_CFG_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION != EMIOS_ICU_IP_CFG_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Irq.h and Emios_Icu_Ip_Cfg.h are different"
+#endif
+
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    /* Check if this header file and OsIf.h file are of the same Autosar version */
+    #if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION != OSIF_AR_RELEASE_MAJOR_VERSION) || \
+        (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION != OSIF_AR_RELEASE_MINOR_VERSION))
+        #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.h and OsIf.h are different"
+    #endif
+#endif
+
+/*==================================================================================================
+*                                            CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                        DEFINES AND MACROS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                        GLOBAL VARIABLES
+==================================================================================================*/
+
+/*==================================================================================================
+*                                              ENUMS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                  STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                  GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                      FUNCTION PROTOTYPES
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    
+#define ICU_START_SEC_CODE
+#include "Icu_MemMap.h"
+
+/**
+* @brief      Icu driver function that handles the interrupt of eMIOS channel.
+* @details    This function:
+*              - Reads the status register
+*              - Clears the pending interrupt
+*              - Processes interrupt for corresponding eMIOS channel
+*
+* @param[in]  channel - eMIOS hardware channel
+*
+*
+*/
+void Emios_Icu_Ip_IrqHandler(uint8 instance, uint8 channel);
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/**
+* @brief      Icu driver function that handles the signal measurement type interrupt.
+* @details    This service is  called when an  interrupt is recognized  as a Signal  Measurement
+*             type. There are two branch depending on  the sub-function selected: Duty Cycle or
+*             OTHER. Duty Cycle requires  an extra  variable, because  three values  are required:
+*             two flanks for active signal time and another flank for the end of the pulse. For
+*             calculating high, low and period is enough with the HW registers.
+*
+* @param[in]  instance  - eMIOS module index
+* @param[in]  hwChannel - eMIOS Channel index
+* @param[in]  bOverflow        Parameter that indicates the source of report is an overflow
+*/
+void Emios_Icu_Ip_SignalMeasurementHandler(const uint8 instance, const uint8 hwChannel, boolean bOverflow);
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+/**
+* @brief      This function saves the value of timestamps in the internal buffer
+* @details    This function saves the value of timestamps in the internal buffer
+*
+* @param[in]  Channel   Logical number of the ICU channel
+*
+* @return     void
+* @pre        Emios_Icu_Ip_Init must be called before.
+* implements  Emios_Icu_Ip_TimestampDmaProcessing
+**/
+void Emios_Icu_Ip_TimestampDmaProcessing(uint8 instance, uint8 hwChannel);
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+/**
+* @brief      This function saves the value of signal measurement  in the internal buffer
+* @details    This function saves the value of signal measurement in the internal buffer
+*
+* @param[in]  Channel   Logical number of the ICU channel
+* @return     void
+* @pre        Emios_Icu_Ip_Init must be called before.
+*
+* implements Emios_Icu_Ip_SignalMeasurementDmaProcessing
+**/
+void Emios_Icu_Ip_SignalMeasurementDmaProcessing(uint8 instance, uint8 hwChannel);
+#endif
+
+#define ICU_STOP_SEC_CODE
+#include "Icu_MemMap.h"
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif  /* EMIOS_ICU_IP_IRQ_H */

--- a/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_TrustedFunctions.h
+++ b/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_TrustedFunctions.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_TRUSTEDFUNCTIONS_H
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_H
+
+/**
+*   @file EMIOS_ICU_IP_TRUSTEDFUNCTIONS_H.h
+*
+*   @addtogroup emios_icu_ip EMIOS IPL
+*   @{
+*/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*==================================================================================================
+                                         INCLUDE FILES
+ 1) system and project includes
+ 2) needed interfaces from external units
+ 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "Emios_Icu_Ip_Defines.h"
+
+/*==================================================================================================
+                               SOURCE FILE VERSION INFORMATION
+==================================================================================================*/
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_VENDOR_ID                           43
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_MAJOR_VERSION            4
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_MINOR_VERSION            7
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_REVISION_VERSION         0
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_MAJOR_VERSION                    3
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_MINOR_VERSION                    0
+#define EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_PATCH_VERSION                    0
+
+/*==================================================================================================
+                                      FILE VERSION CHECKS
+==================================================================================================*/
+/* Check if this header file and Define header file are of the same vendor */
+#if (EMIOS_ICU_IP_TRUSTEDFUNCTIONS_VENDOR_ID != EMIOS_ICU_IP_DEFINES_VENDOR_ID)
+    #error "Emios_Icu_Ip_TrustedFunctions.h and Emios_Icu_Ip_Defines.h have different vendor IDs"
+#endif
+/* Check if this header  file and Define header file are of the same AutoSar version */
+#if ((EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_MAJOR_VERSION  != EMIOS_ICU_IP_DEFINES_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_MINOR_VERSION  != EMIOS_ICU_IP_DEFINES_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_TRUSTEDFUNCTIONS_AR_RELEASE_REVISION_VERSION   != EMIOS_ICU_IP_DEFINES_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_TrustedFunctions.h and Emios_Icu_Ip_Defines.h are different"
+#endif
+/* Check if source file and Define header file are of the same Software version */
+#if ((EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_MAJOR_VERSION  != EMIOS_ICU_IP_DEFINES_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_MINOR_VERSION  != EMIOS_ICU_IP_DEFINES_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_TRUSTEDFUNCTIONS_SW_PATCH_VERSION  != EMIOS_ICU_IP_DEFINES_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_TrustedFunctions.h and Emios_Icu_Ip_Defines.h are different"
+#endif
+/*==================================================================================================
+                                           CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+                                       DEFINES AND MACROS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                        GLOBAL VARIABLES
+==================================================================================================*/
+
+/*==================================================================================================
+                                             ENUMS
+==================================================================================================*/
+
+/*==================================================================================================
+                                 STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+
+
+/*==================================================================================================
+                                 GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+                                     FUNCTION PROTOTYPES
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+#define ICU_START_SEC_CODE
+#include "Icu_MemMap.h
+
+/**
+ * @brief      Emios_Icu_Ip_SetUserAccessAllowed
+ * @details    This function is called externally by OS Application
+ * @param[in]  EmiosBaseAddr - The base address of Emios.
+ */
+#if (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)
+    extern void Emios_Icu_Ip_SetUserAccessAllowed(uint32 EmiosBaseAddr);
+#endif 
+
+
+#define ICU_STOP_SEC_CODE
+#include "Icu_MemMap.h"
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/** @} */
+
+#endif  /* EMIOS_IP_TRUSTEDFUNCTIONS_H */

--- a/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_Types.h
+++ b/s32/drivers/s32k3/Icu/include/Emios_Icu_Ip_Types.h
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_TYPES_H
+#define EMIOS_ICU_IP_TYPES_H
+
+/**
+ *   @file       Emios_Icu_Ip_[!IF "var:defined('postBuildVariant')"!][!"$postBuildVariant"!]_[!ENDIF!]PBcfg.c
+ *   @version    3.0.0
+ *
+ *   @brief      AUTOSAR Icu - contains the data exported by the Icu module
+ *   @details    Contains the information that will be exported by the module, as requested by AUTOSAR.
+ *
+ *   @addtogroup emios_icu_ip EMIOS IPL
+ *   @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/*==================================================================================================
+                                         INCLUDE FILES
+ 1) system and project includes
+ 2) needed interfaces from external units
+ 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "Emios_Icu_Ip_Defines.h"
+
+/*==================================================================================================
+                               SOURCE FILE VERSION INFORMATION
+==================================================================================================*/
+#define EMIOS_ICU_IP_TYPES_VENDOR_ID                     43
+#define EMIOS_ICU_IP_TYPES_AR_RELEASE_MAJOR_VERSION      4
+#define EMIOS_ICU_IP_TYPES_AR_RELEASE_MINOR_VERSION      7
+#define EMIOS_ICU_IP_TYPES_AR_RELEASE_REVISION_VERSION   0
+#define EMIOS_ICU_IP_TYPES_SW_MAJOR_VERSION              3
+#define EMIOS_ICU_IP_TYPES_SW_MINOR_VERSION              0
+#define EMIOS_ICU_IP_TYPES_SW_PATCH_VERSION              0
+
+/*==================================================================================================
+                                      FILE VERSION CHECKS
+==================================================================================================*/
+#if (EMIOS_ICU_IP_TYPES_VENDOR_ID != EMIOS_ICU_IP_DEFINES_VENDOR_ID)
+    #error "Emios_Icu_Ip_Types.h and Emios_Icu_Ip_Defines.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_Defines.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_TYPES_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_DEFINES_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_TYPES_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_DEFINES_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_TYPES_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_DEFINES_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Types.h and Emios_Icu_Ip_Defines.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_Defines.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_TYPES_SW_MAJOR_VERSION != EMIOS_ICU_IP_DEFINES_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_TYPES_SW_MINOR_VERSION != EMIOS_ICU_IP_DEFINES_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_TYPES_SW_PATCH_VERSION != EMIOS_ICU_IP_DEFINES_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Types.h and Emios_Icu_Ip_Defines.h are different"
+#endif
+
+/*==================================================================================================
+                                           CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+                                       DEFINES AND MACROS
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+/**
+* @brief EMIOS Channels defines
+*/
+#define EMIOS_ICU_IP_CB_NONE       ((uint8)0xFF)
+#define EMIOS_ICU_IP_CB_DIVERSE    ((uint8)0x07)
+#define EMIOS_ICU_IP_CHANNEL_0     ((uint8)0x00)
+#define EMIOS_ICU_IP_CHANNEL_7     ((uint8)0x07)
+#define EMIOS_ICU_IP_CHANNEL_8     ((uint8)0x08)
+#define EMIOS_ICU_IP_CHANNEL_15    ((uint8)0x0F)
+#define EMIOS_ICU_IP_CHANNEL_16    ((uint8)0x10)
+#define EMIOS_ICU_IP_CHANNEL_22    ((uint8)0x16)
+#define EMIOS_ICU_IP_CHANNEL_23    ((uint8)0x17)
+#define EMIOS_ICU_IP_CHANNEL_24    ((uint8)0x18)
+
+#if (STD_ON == EMIOS_ICU_IP_CHANNEL_24_USED)
+#define EMIOS_ICU_IP_CHANNEL_31    ((uint8)0x1F)
+#endif
+
+#define EMIOS_ICU_IP_MCB_INT_CLOCK_U32         ((uint32)(0x50U))
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+#define EMIOS_ICU_IP_MCB_EXT_CLOCK_U32         ((uint32)(0x51U))
+#endif
+
+#define EMIOS_ICU_IP_CCR_CLEAR_U32             ((uint32)(0x0U))
+#define EMIOS_ICU_IP_CSR_CLEAR_U32             ((uint32)(0xFFFFFFFFU))
+
+#if ((EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON) || (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON))
+#define EMIOS_ICU_IP_INIT_CCNTR_U32            (0x00000000U)
+#define EMIOS_ICU_IP_INIT_CADR_U32             ((uint32)EMIOS_ICU_IP_COUNTER_MASK)
+#endif
+
+#define EMIOS_ICU_IP_CCR_MODE_GPI_U32          ((uint32)(0x00))
+#define EMIOS_ICU_IP_CCR_MODE_SAIC_U32         ((uint32)(0x02))
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+#define EMIOS_ICU_IP_CCR_MODE_IPWM_U32         ((uint32)(0x04))
+#define EMIOS_ICU_IP_CCR_MODE_IPM_U32          ((uint32)(0x05))
+#endif
+
+/*==================================================================================================
+                                             ENUMS
+==================================================================================================*/
+
+/**
+* @brief    eMIOS_Activation EDGE
+* @details  Indicates the channel activation type(Rising, Falling, Both Edges or Opposite Edges).
+*/
+typedef enum
+{
+    /** @brief No trigger. */
+    EMIOS_ICU_NO_PIN_CONTROL    = 0x0U,
+    /** @brief Rising edge trigger. */
+    EMIOS_ICU_RISING_EDGE       = 0x1U,
+    /** @brief Rising edge trigger. */
+    EMIOS_ICU_FALLING_EDGE      = 0x2U,
+    /** @brief Rising and falling edge trigger */
+    EMIOS_ICU_BOTH_EDGES        = 0x3U
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+    /** @brief EMIOS_OPPOSITE_EDGES = An appropriate action shall be executed when either a falling or rising edge occur on the ICU input signal. */
+    ,EMIOS_OPPOSITE_EDGES       = 0x4U
+#endif   /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+} eMios_Icu_Ip_EdgeType;
+
+/** @brief Operation mode for ICU driver. */
+typedef enum
+{
+    /** @brief No measurement mode. */
+    EMIOS_ICU_MODE_NO_MEASUREMENT                   = 0x0U,
+    /** @brief Signal edge detect measurement mode. */
+    EMIOS_ICU_MODE_SIGNAL_EDGE_DETECT               = 0x1U,
+    /** @brief Signal measurement mode.*/
+    EMIOS_ICU_MODE_SIGNAL_MEASUREMENT               = 0x2U,
+    /** @brief Timestamp measurement mode.*/
+    EMIOS_ICU_MODE_TIMESTAMP                        = 0x4U,
+    /** @brief Edge counter measurement mode.*/
+    EMIOS_ICU_MODE_EDGE_COUNTER                     = 0x8U
+} eMios_Icu_Ip_ModeType; 
+
+/** @brief Enable/disable DMA support for timestamp. */
+typedef enum
+{
+    /* Disable DMA support. */
+    EMIOS_ICU_MODE_WITHOUT_DMA = 0U,
+    /* Enable DMA support. */
+    EMIOS_ICU_MODE_WITH_DMA    = 1U
+} eMios_Icu_Ip_SubModeType;
+
+/** @brief Stores the state in which a signal measurement is. */
+typedef enum
+{
+    /* This is the initial state of measurement */
+    EMIOS_ICU_MEASUREMENT_PENDING       = 0U,
+    /* First edge has triggered - measuring duty cycle */
+    EMIOS_ICU_MEASUREMENT_DUTY          = 1U,
+    /* Second edge has triggered - measuring period */
+    EMIOS_ICU_MEASUREMENT_PERIOD        = 2U
+} eMios_Icu_Ip_MeasStatusType;
+
+/** @brief Type of operation for signal measurement. */
+typedef enum
+{
+    /** @brief No measurement. */
+    EMIOS_ICU_NO_MEASUREMENT = 0U,
+    /** @brief The time measurement for OFF period. */ 
+    EMIOS_ICU_LOW_TIME       = 1U,
+    /** @brief The time measurement for ON period. */ 
+    EMIOS_ICU_HIGH_TIME      = 2U,
+    /** @brief Period measurement between two consecutive falling/raising edges. */
+    EMIOS_ICU_PERIOD_TIME    = 4U,
+    /** @brief The fraction of active period. */
+    EMIOS_ICU_DUTY_CYCLE     = 8U
+} eMios_Icu_Ip_MeasType; 
+
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+/** @brief Type of operation for timestamp. */
+typedef enum
+{
+    /** @brief No timestamp. */
+    EMIOS_ICU_NO_TIMESTAMP      = 0U,
+    /** @brief The timestamp with circular buffer . */ 
+    EMIOS_ICU_CIRCULAR_BUFFER   = 1U,
+    /** @brief The timestamp with linear buffer . */ 
+    EMIOS_ICU_LINEAR_BUFFER     = 2U
+} eMios_Icu_Ip_TimestampBufferType; 
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_GET_INPUT_LEVEL_API)
+/** @brief Enumeration used for returning the level of input pin. */
+typedef enum
+{
+    /** @brief Low level state.  */
+    EMIOS_ICU_LEVEL_LOW   = 0x0U,
+    /** @brief High level state. */
+    EMIOS_ICU_LEVEL_HIGH  = 0x1U
+} eMios_Icu_Ip_LevelType;
+#endif
+#if (EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON)
+/** @brief Definition of prescaler type (Normal or Alternate) */
+typedef enum
+{
+    EMIOS_ICU_NORMAL_CLK        = 0x0U,  /**< @brief Normal prescaler         */
+    EMIOS_ICU_ALTERNATE_CLK     = 0x1U   /**< @brief Alternate prescaler      */
+} eMios_Icu_Ip_ClockModeType;
+#endif
+
+/** @brief Definition of master bus type */
+typedef enum
+{
+    EMIOS_ICU_BUS_A                 = 0x0U, /**< @brief Bus A            */
+    EMIOS_ICU_BUS_DIVERSE           = 0x1U, /**< @brief Bus diverse      */
+    EMIOS_ICU_BUS_F                 = 0x2U, /**< @brief Bus F            */
+    EMIOS_ICU_BUS_INTERNAL_COUNTER  = 0x3U  /**< @brief Internal counter */
+} eMios_Icu_Ip_BusType;
+
+/** @brief Generic error codes. */
+typedef enum
+{
+    /** @brief Generic operation success status. */
+    EMIOS_IP_STATUS_SUCCESS                  = 0x00U,
+    /** @brief Generic operation failure status. */
+    EMIOS_IP_STATUS_ERROR                    = 0x01U
+} eMios_Icu_Ip_StatusType;
+
+/** @brief Selection of the signal measurement mode when IcuSignalMeasurementProperty is ICU_DUTY_CYCLE. */
+typedef enum
+{
+    /** @brief un-initialized. */
+    EMIOS_ICU_UNINIT                = 0x00U,
+    /** @brief SAIC mode. */
+    EMIOS_ICU_SAIC                  = 0x01U,
+    /** @brief IPWM mode. */
+    EMIOS_ICU_IPM                   = 0x02U,
+    /** @brief IPWM mode. */
+    EMIOS_ICU_IPWM                  = 0x03U
+} eMios_Icu_Ip_UCModeType;
+
+
+/** @brief Selects the clock divider value for the UC internal prescaler. */
+typedef enum
+{
+    /** @brief EMIOS_PRESCALER_DIVIDE_1. */
+    EMIOS_PRESCALER_DIVIDE_1                    = 0x00U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_2. */
+    EMIOS_PRESCALER_DIVIDE_2                    = 0x01U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_3. */
+    EMIOS_PRESCALER_DIVIDE_3                    = 0x02U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_4. */
+    EMIOS_PRESCALER_DIVIDE_4                    = 0x03U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_5. */
+    EMIOS_PRESCALER_DIVIDE_5                    = 0x04U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_6. */
+    EMIOS_PRESCALER_DIVIDE_6                    = 0x05U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_7. */
+    EMIOS_PRESCALER_DIVIDE_7                    = 0x06U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_8. */
+    EMIOS_PRESCALER_DIVIDE_8                    = 0x07U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_9. */
+    EMIOS_PRESCALER_DIVIDE_9                    = 0x08U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_10. */
+    EMIOS_PRESCALER_DIVIDE_10                   = 0x09U,
+    /** @brief EMIOS_PRESCALER_DIVIDE_11. */
+    EMIOS_PRESCALER_DIVIDE_11                   = 0x0AU,
+    /** @brief EMIOS_PRESCALER_DIVIDE_12. */
+    EMIOS_PRESCALER_DIVIDE_12                   = 0x0BU,
+    /** @brief EMIOS_PRESCALER_DIVIDE_13. */
+    EMIOS_PRESCALER_DIVIDE_13                   = 0x0CU,
+    /** @brief EMIOS_PRESCALER_DIVIDE_14. */
+    EMIOS_PRESCALER_DIVIDE_14                   = 0x0DU,
+    /** @brief EMIOS_PRESCALER_DIVIDE_15. */
+    EMIOS_PRESCALER_DIVIDE_15                   = 0x0EU,
+    /** @brief EMIOS_PRESCALER_DIVIDE_16. */
+    EMIOS_PRESCALER_DIVIDE_16                   = 0x0FU
+} eMios_Icu_Ip_PrescalerType;
+
+/** @brief Selects the the input filter. */
+typedef enum
+{
+    /** @brief EMIOS_DIGITAL_FILTER_BYPASSED. */
+    EMIOS_DIGITAL_FILTER_BYPASSED              = 0x00U,
+    /** @brief EMIOS_DIGITAL_FILTER_02. */
+    EMIOS_DIGITAL_FILTER_02                    = 0x01U,
+    /** @brief EMIOS_DIGITAL_FILTER_04. */
+    EMIOS_DIGITAL_FILTER_04                    = 0x02U,
+    /** @brief EMIOS_DIGITAL_FILTER_08. */
+    EMIOS_DIGITAL_FILTER_08                    = 0x04U,
+    /** @brief EMIOS_DIGITAL_FILTER_16. */
+    EMIOS_DIGITAL_FILTER_16                    = 0x08U
+} eMios_Icu_Ip_FilterType;
+
+/*==================================================================================================
+                                 STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+/** @brief The notification functions shall have no parameters and no return value.*/
+typedef void (*eMios_Icu_Ip_NotifyType)(void);
+
+/**
+* @brief Structure that contains ICU Duty cycle parameters. It contains the values needed for
+*        calculating duty cycles i.e Period time value and active time value.
+* @implements eMios_Icu_Ip_DutyCycleType_struct
+*/
+typedef struct
+{
+    eMios_Icu_ValueType   ActiveTime;         /**< @brief Low or High time value. */
+    eMios_Icu_ValueType   PeriodTime;         /**< @brief Period time value. */
+} eMios_Icu_Ip_DutyCycleType;
+
+/** @brief HLD Callback type for each channel reporting events or events and overflow . */
+typedef void (*eMios_Icu_Ip_CallbackType)(uint16 callbackParam1, boolean callbackParam2);
+
+/** @brief Callback type for each channel. */
+typedef void (*eMios_Icu_Ip_LogicChStateCbType)(uint16 logicChannel, uint8 mask, boolean set);
+
+typedef struct
+{
+    uint8                               hwChannel;                  /*!< Channel Id */
+    eMios_Icu_Ip_UCModeType             ucMode;                     /*!< eMios UC mode of operation  */
+    boolean                             FreezeEn;                   /*!< Freeze enable for UC */
+    eMios_Icu_Ip_PrescalerType          Prescaler;                  /*!< Channel Prescaler */
+    eMios_Icu_Ip_PrescalerType          AltPrescaler;               /*!< Channel Alternate Prescaler */
+    eMios_Icu_Ip_BusType                CntBus;                     /*!< Channel Counter bus selection */
+    eMios_Icu_Ip_ModeType               chMode;                     /*!< eMios module ICU mode of operation  */
+    eMios_Icu_Ip_SubModeType            chSubMode;                  /*!< eMios ICU mode with or without DMA  */
+    eMios_Icu_Ip_MeasType               measurementMode;            /*!< subMode selection for Signal Measurement*/
+    eMios_Icu_Ip_EdgeType               edgeAlignement;             /*!< Edge alignment for measurement */
+    eMios_Icu_Ip_FilterType             Filter;                     /*!< Channel Digital Input Filter */
+    eMios_Icu_Ip_CallbackType           callback;                   /*!< The HLD callback function for channels events */
+    eMios_Icu_Ip_LogicChStateCbType     logicChStateCallback;      /*!< The HLD callback function for changing logic channels status */
+    uint8                               callbackParams;             /*!< The HLD logical channel serviced */
+    boolean                             bWithoutInterrupt;          /*!< Measurement of ICU signal property without using interrupt */
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+    eMios_Icu_Ip_TimestampBufferType    timestampBufferType;        /*!< Timestamp buffer type for timestamp mode*/
+#endif
+#if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+    /** @brief Dma Channel Id. */
+    uint8                               dmaChannel;
+#endif /* ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)) */
+    eMios_Icu_Ip_NotifyType             eMiosChannelNotification;   /*!< The notification and overflow have no parameters and no return value and are generated */
+    eMios_Icu_Ip_NotifyType             eMiosOverflowNotification;  /*!< based on channel run environment - HLD or IPL - statically,precompile configured*/
+} eMios_Icu_Ip_ChannelConfigType;
+
+/**
+* @brief      eTimer IP specific configuration structure type
+*/
+typedef struct
+{
+    /** @brief Number of eMios channels in the Icu configuration */
+    uint8                           nNumChannels;
+    /** @brief Pointer to the configured channels for eMios */
+    const eMios_Icu_Ip_ChannelConfigType (*pChannelsConfig)[];
+} eMios_Icu_Ip_ConfigType;
+
+
+/** @brief This structure is used by the IPL driver for internal logic. */
+typedef struct
+{
+    /** @brief eMios UC mode of operation. */
+    eMios_Icu_Ip_UCModeType                         operationMode;
+    /** @brief Master bus selection. */
+    eMios_Icu_Ip_BusType                            BusSelected;
+    /** @brief EMIOS channel mode. */
+    eMios_Icu_Ip_ModeType                           channelMode;
+    /** @brief Support DMA or not. */
+    eMios_Icu_Ip_SubModeType                        dmaMode;
+    /** @brief Type of edge used for activation. */
+    eMios_Icu_Ip_EdgeType                           edgeTrigger;
+    /** @brief Calback for other types of measurement.*/
+    eMios_Icu_Ip_CallbackType                       callback;
+    /** @brief Calback for HLD logic channel status changes */
+    eMios_Icu_Ip_LogicChStateCbType                 logicChStateCallback;
+    /** @brief Logic channel for which callback is executed. */
+    uint16                                          callbackParam;
+    /** @brief Measurement of ICU signal property without using interrupt. */
+    boolean                                         msWithoutInterrupt;
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API)
+    /** @brief Timestamp buffer type for timestamp mode. */
+    eMios_Icu_Ip_TimestampBufferType                timestampBufferType;
+    /** @brief Pointer to the buffer-array where the timestamp values shall be placed. */
+    eMios_Icu_ValueType                             *eMios_Icu_Ip_aBuffer;
+    /** @brief Variable for saving the size of the external buffer (number of entries). */
+    uint16                                          eMios_Icu_Ip_aBufferSize;
+    /** @brief Variable for saving Notification interval (number of events). */
+    uint16                                          eMios_Icu_Ip_aBufferNotify;
+    /** @brief Variable for saving the number of notify counts. */
+    uint16                                          eMios_Icu_Ip_aNotifyCount;
+    /** @brief Variable for saving the time stamp index. */
+    uint16                                          eMios_Icu_Ip_aBufferIndex;
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API) */
+#if (defined(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API) && (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API))
+    /** @brief Store the status of the first measurement. */
+    boolean                                         firstEdge;
+    /** @brief Signal measurement mode. */
+    eMios_Icu_Ip_MeasType                           measurement;
+    /** @brief Variable for saving the period. */
+    eMios_Icu_ValueType                             eMios_Icu_Ip_aPeriod;
+    /** @brief Variable for saving the pulse width of active time. */
+    eMios_Icu_ValueType                             eMios_Icu_Ip_aActivePulseWidth;
+#endif /* (defined(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API) && (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API)) */
+#if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+    /** @brief Dma Channel Id. */
+    uint8                                           dmaChannel;
+#endif /* ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)) */
+#if (defined(EMIOS_ICU_IP_EDGE_COUNT_API) && (STD_ON == EMIOS_ICU_IP_EDGE_COUNT_API))
+    /** @brief Logic variable to count edges. */
+    uint16                                          edgeNumbers;
+
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+    /** @brief Logic variable to count edges. */
+    uint32                                          maxCounterValue;
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+#endif /* (defined(EMIOS_ICU_IP_EDGE_COUNT_API) && (STD_ON == EMIOS_ICU_IP_EDGE_COUNT_API)) */
+    /** @brief The notification functions for TIME_STAMP or SIGNAL_EDGE_DETECT mode. */
+    eMios_Icu_Ip_NotifyType                         eMiosChannelNotification;
+    /** @brief The notification functions for TIME_STAMP or SIGNAL_EDGE_DETECT mode. */
+    eMios_Icu_Ip_NotifyType                         eMiosOverflowNotification;
+    /** @brief Enables or disables the user notification call */
+    boolean                                         notificationEnable;
+    /* State of initialized EMIOS modules. */
+    boolean                                         channelsInitState;
+} eMios_Icu_Ip_ChStateType;
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+/*==================================================================================================
+                                 GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+                                     FUNCTION PROTOTYPES
+==================================================================================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif  /* EMIOS_ICU_IP_TYPES_H */

--- a/s32/drivers/s32k3/Icu/src/Emios_Icu_Ip.c
+++ b/s32/drivers/s32k3/Icu/src/Emios_Icu_Ip.c
@@ -1,0 +1,1782 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ *     @file       File with source code used to implement ICU driver functionality on EMIOS module.
+ *     @details    This file contains the source code for all functions which are using EMIOS module.
+ *     @addtogroup emios_icu_ip EMIOS IPL
+ *     @{
+ */
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/*==================================================================================================
+*                                         INCLUDE FILES
+* 1) system and project includes
+* 2) needed interfaces from external units
+* 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "Emios_Icu_Ip.h"
+#include "SchM_Icu.h"
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+        #include "Devassert.h"
+    #endif
+    
+    #if (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)
+        #define USER_MODE_REG_PROT_ENABLED  (EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)
+        #include "RegLockMacros.h"
+    #endif
+
+    #if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+        #include "Dma_Ip.h"
+    #endif
+    
+#endif  /* EMIOS_ICU_IP_USED */
+/*==================================================================================================
+*                                        LOCAL MACROS
+==================================================================================================*/
+#define EMIOS_ICU_IP_VENDOR_ID_C                       43
+#define EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION_C        4
+#define EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION_C        7
+#define EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION_C     0
+#define EMIOS_ICU_IP_SW_MAJOR_VERSION_C                3
+#define EMIOS_ICU_IP_SW_MINOR_VERSION_C                0
+#define EMIOS_ICU_IP_SW_PATCH_VERSION_C                0
+
+/*==================================================================================================
+*                                      FILE VERSION CHECKS
+==================================================================================================*/
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    #if (STD_ON == EMIOS_ICU_IP_USED)
+        #if (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)
+            /* Check if the files Emios_Icu_Ip.c and RegLockMacros.h are of the same version */
+            #if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION_C != REGLOCKMACROS_AR_RELEASE_MAJOR_VERSION) || \
+                (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION_C != REGLOCKMACROS_AR_RELEASE_MINOR_VERSION))
+                #error "AutoSar Version Numbers of Emios_Icu_Ip.c and RegLockMacros.h are different"
+            #endif
+        #endif
+
+        #if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+            /* Check if header file and Dma_Ip.h file are of the same Autosar version */
+            #if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION_C != DMA_IP_AR_RELEASE_MAJOR_VERSION) || \
+                 (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION_C != DMA_IP_AR_RELEASE_MINOR_VERSION))
+                #error "AutoSar Version Numbers of Emios_Icu_Ip.c and Dma_Ip.h are different"
+            #endif
+        #endif
+    #endif  /* EMIOS_ICU_IP_USED */
+    
+    /* Check if this header file and SchM_Icu.h file are of the same Autosar version */
+    #if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION != SCHM_ICU_AR_RELEASE_MAJOR_VERSION) || \
+        (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION != SCHM_ICU_AR_RELEASE_MINOR_VERSION))
+        #error "AutoSar Version Numbers of Emios_Icu_Ip.c and SchM_Icu.h are different"
+    #endif
+#endif
+
+/* Check if source file and ICU header file are of the same vendor */
+#if (EMIOS_ICU_IP_VENDOR_ID_C != EMIOS_ICU_IP_VENDOR_ID)
+    #error "Emios_Icu_Ip.c and Emios_Icu_Ip.h have different vendor IDs"
+#endif
+/* Check if source file and Emios_Icu_Ip header file are of the same Autosar version */
+#if (  (EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION) || \
+       (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION) || \
+       (EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip.c and Emios_Icu_Ip.h are different"
+#endif
+/* Check if source file and Icu_eMIOS header file are of the same Software version */
+#if ((EMIOS_ICU_IP_SW_MAJOR_VERSION_C != EMIOS_ICU_IP_SW_MAJOR_VERSION) || \
+        (EMIOS_ICU_IP_SW_MINOR_VERSION_C != EMIOS_ICU_IP_SW_MINOR_VERSION) || \
+        (EMIOS_ICU_IP_SW_PATCH_VERSION_C != EMIOS_ICU_IP_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip.c and Emios_Icu_Ip.h are different"
+#endif
+
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    #if (STD_ON == EMIOS_ICU_IP_USED)
+        #if(EMIOS_ICU_IP_DEV_ERROR_DETECT == STD_ON)
+            /* Check if this header file and Devassert.h file are of the same Autosar version */
+            #if ((EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION_C != DEVASSERT_AR_RELEASE_MAJOR_VERSION) || \
+                (EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION_C != DEVASSERT_AR_RELEASE_MINOR_VERSION))
+                #error "AutoSar Version Numbers of Emios_Icu_Ip.c and Devassert.h are different"
+            #endif
+        #endif
+    #endif  /* EMIOS_ICU_IP_USED */
+#endif
+/*==================================================================================================
+*                                           LOCAL MACROS
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if (defined (MCAL_EMIOS_REG_PROT_AVAILABLE))
+        #if ((STD_ON == MCAL_EMIOS_REG_PROT_AVAILABLE) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT))
+            #define Call_Emios_Icu_Ip_SetUserAccessAllowed(BaseAddr) OsIf_Trusted_Call1param(Emios_Icu_Ip_SetUserAccessAllowed,(BaseAddr))
+        #else
+            #define Call_Emios_Icu_Ip_SetUserAccessAllowed(BaseAddr)
+        #endif
+    #else
+        #define Call_Emios_Icu_Ip_SetUserAccessAllowed(BaseAddr)
+    #endif
+#endif  /* EMIOS_ICU_IP_USED */
+/*==================================================================================================
+*                                       LOCAL CONSTANTS
+==================================================================================================*/
+
+
+/*==================================================================================================
+*                                       LOCAL VARIABLES
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+#define ICU_START_SEC_VAR_CLEARED_BOOLEAN
+#include "Icu_MemMap.h"
+
+/* State of initialized EMIOS modules. */
+static boolean eMios_Icu_Ip_bInstanceState[EMIOS_ICU_IP_INSTANCE_COUNT];
+
+#define ICU_STOP_SEC_VAR_CLEARED_BOOLEAN
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+static uint32 eMios_Icu_Ip_u32aEdgeCurrent_Value[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#endif /* EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+/**
+* @brief      eMios_Icu_Ip_u8NumOvflByCounterBus
+* @details    The number of active channels has the overflow notification function using masterbus.
+*/
+static uint8 eMios_Icu_Ip_u8NumOvflByCounterBus[EMIOS_ICU_IP_INSTANCE_COUNT][EMIOS_ICU_IP_NUM_OF_CHANNELS];
+#endif /* EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON */
+#endif /* ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)) */
+
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
+#include "Icu_MemMap.h"
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+/** @brief Array for saving value of DMA **/
+volatile uint32 Emios_Icu_Ip_aDmaBuffer[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED][EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT];
+
+/** @brief Array for saving the period */
+volatile uint32 Emios_Icu_Ip_aIsSecondInterrupt[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+
+/** @brief Array for saving the period */
+volatile uint32 Emios_Icu_Ip_aFirstEdgeTimeStamp[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+
+#endif /* EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL */
+
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
+
+#include "Icu_MemMap.h"
+/*==================================================================================================
+                                       GLOBAL CONSTANTS
+==================================================================================================*/
+#define ICU_START_SEC_CONST_UNSPECIFIED
+#include "Icu_MemMap.h"
+/* Table of base addresses for EMIOS instances. */
+eMIOS_Type * const s_emiosBase[] = IP_eMIOS_BASE_PTRS;
+#define ICU_STOP_SEC_CONST_UNSPECIFIED
+#include "Icu_MemMap.h"
+/*==================================================================================================
+*                                       GLOBAL VARIABLES
+==================================================================================================*/
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+eMios_Icu_Ip_MeasStatusType eMios_Icu_Ip_aeInt_Counter[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+eMios_Icu_ValueType eMios_Icu_Ip_CapturedActivePulseWidth[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+eMios_Icu_ValueType eMios_Icu_Ip_TimeStart[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+eMios_Icu_ValueType eMios_Icu_Ip_BufferPtr[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#endif /* EMIOS_ICU_IP_TIMESTAMP_API == STD_ON */
+
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+eMios_Icu_Ip_ChStateType eMios_Icu_Ip_ChState[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_INIT_8
+#include "Icu_MemMap.h"
+/* This array stores the positions in the eMios_Icu_Ip_ChState array of the configured eMios channels. */
+uint8 eMios_Icu_Ip_IndexInChState[EMIOS_ICU_IP_INSTANCE_COUNT][EMIOS_ICU_IP_NUM_OF_CHANNELS] = EMIOS_ICU_IP_INITIAL_INDEX_OF_CHANNELS;
+#define ICU_STOP_SEC_VAR_INIT_8
+#include "Icu_MemMap.h"
+
+/*==================================================================================================
+*                                   LOCAL FUNCTION PROTOTYPES
+==================================================================================================*/
+#define ICU_START_SEC_CODE
+#include "Icu_MemMap.h"
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+extern void Emios_Icu_Ip_SignalMeasurementHandler(const uint8 instance, const uint8 hwChannel, boolean bOverflow);
+#endif
+
+#if (EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON)
+/**
+ * @brief      Icu driver function that sets the channel prescaler.
+ * @details    This function:
+ *             - Writes prescaling rate at UCPRE[0:1] bits in EMIOSC[n] register
+ *             - Enables channel prescaler by setting UCPREN bit in EMIOSC[n] register
+ *
+ * @param[in]  instance                - eMIOS module index
+ * @param[in]  hwChannel               - eMIOS encoded hardware channel
+ * @param[in]  u32ChannelPrescaler     - prescaler for the hardware channel
+ */
+static inline void Emios_Icu_Ip_SetPrescaler
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    const uint32 u32ChannelPrescaler
+);
+#endif  /* EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+/**
+* @brief      Icu driver function that enable the master buses Interrupt.
+* @details    This function:
+*             - Only using for the following functions:
+*                   - Emios_Icu_Ip_StartSignalMeasurement: Used for enable master buses interrupt that hwChannel uses as an overflow notification.
+*                   - Emios_Icu_Ip_StartTimestamp: Used for enable master buses interrupt that hwChannel uses as an overflow notification.
+*
+* @param[in]  instance        - eMIOS module index
+* @param[in]  hwChannel       - eMIOS encoded hardware channel using master bus
+* @api
+*/
+static inline void Emios_Icu_Ip_EnableMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+
+/**
+* @brief      Icu driver function that disable the master buses Interrupt.
+* @details    This function:
+*             - Only using for the following functions:
+*                   - Emios_Icu_Ip_StartSignalMeasurement: Used for disable master buses interrupt that hwChannel uses as an overflow notification.
+*                   - Emios_Icu_Ip_StartTimestamp: Used for disable master buses interrupt that hwChannel uses as an overflow notification.
+*
+* @param[in]  instance        - eMIOS module index
+* @param[in]  hwChannel       - eMIOS encoded hardware channel using master bus
+* @api
+*/
+static inline void Emios_Icu_Ip_DisableMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+#endif /* EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON */
+#endif
+
+/**
+* @brief      Emios_Icu_Ip_UCSetMode
+* @details    This function sets CCR_MODE bitfield, the mode of operation of the Unified Channel
+*
+* @param[in]  instance  - eMIOS module index
+* @param[in]  hwChannel - eMIOS Channel index
+* @param[in]  u32Mode   - CCR_MODE bitfield value to be set
+* @api
+*/
+static inline void Emios_Icu_Ip_UCSetMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    const uint32 u32Mode
+);
+
+/**
+* @brief   Function to return the channel id of master bus of current channel
+* @details Function to return the channel id of master bus of current channel
+* @param[in]  hwChannel - eMIOS Channel index
+* @param[in]  u32Bus    - the used bus for current channels
+* @param[out] - The id of master bus
+*/
+static inline uint8 Emios_Icu_Ip_GetMasterBus
+(
+    uint8 hwChannel,
+    eMios_Icu_Ip_BusType u32Bus
+);
+
+#if (defined(EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT))
+#if (defined(MCAL_EMIOS_REG_PROT_AVAILABLE))
+#if (STD_ON == MCAL_EMIOS_REG_PROT_AVAILABLE)
+/**
+* @brief        Enables EMIOS registers writing in User Mode by configuring REG_PROT
+* @details      Sets the UAA (User Access Allowed) bit of the EMIOS IP allowing EMIOS registers writing in User Mode
+*
+* @param[in]    EmiosBaseAddr
+*
+* @return       none
+*
+* @pre          Should be executed in supervisor mode
+* @post         none
+*
+*/
+void Emios_Icu_Ip_SetUserAccessAllowed(uint32 EmiosBaseAddr);
+#endif /* (STD_ON == MCAL_EMIOS_REG_PROT_AVAILABLE) */
+#endif /* (defined(MCAL_EMIOS_REG_PROT_AVAILABLE)) */
+#endif /* (defined(EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)) */
+
+
+/*==================================================================================================
+*                                       LOCAL FUNCTIONS
+==================================================================================================*/
+static inline void Emios_Icu_Ip_UCSetMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    const uint32 u32Mode
+)
+{
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_48();
+    /* Clear MODE bitfield - GPIO mode */
+    s_emiosBase[instance]->CH.UC[hwChannel].C &= ~eMIOS_C_MODE_MASK;
+    /* Set desired mode */
+    s_emiosBase[instance]->CH.UC[hwChannel].C |= (u32Mode & eMIOS_C_MODE_MASK);
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_48();
+}
+
+static inline uint8 Emios_Icu_Ip_GetMasterBus
+(
+    uint8 hwChannel,
+    eMios_Icu_Ip_BusType u32Bus
+)
+{
+    uint8 u8MasterBusChannelIdx = (uint8)0U;
+
+    if (EMIOS_ICU_BUS_DIVERSE == u32Bus)
+    {
+        if (EMIOS_ICU_IP_CHANNEL_7 >= hwChannel) /* bus B */
+        {
+            u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_0;
+        }
+        else if (EMIOS_ICU_IP_CHANNEL_15 >= hwChannel) /* Bus C */
+        {
+            u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_8;
+        }
+        else if (EMIOS_ICU_IP_CHANNEL_23 >= hwChannel) /* bus D */
+        {
+            u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_16;
+        }
+        else /* Bus E remaining */
+        {
+            u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_24;
+        }
+    }
+    else if (EMIOS_ICU_BUS_A == u32Bus) /* bus A */
+    {
+        u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_23;
+    }
+    else if (EMIOS_ICU_BUS_F == u32Bus) /* bus F remaining */
+    {
+        u8MasterBusChannelIdx = EMIOS_ICU_IP_CHANNEL_22;
+    }
+    else
+    {
+        /*Empty else to fix misra*/
+    }
+    return u8MasterBusChannelIdx;
+}
+
+#if (EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON)
+static inline void Emios_Icu_Ip_SetPrescaler
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    const uint32 u32ChannelPrescaler
+)
+{
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_53();
+
+    /* Clear UCPREN bit */
+    s_emiosBase[instance]->CH.UC[hwChannel].C &= ~eMIOS_C_UCPREN_MASK;
+    /* Write prescaling rate at UCEXTPRE[0:3] bits in EMIOSC2[n] */
+    s_emiosBase[instance]->CH.UC[hwChannel].C2 &= ~eMIOS_C2_UCEXTPRE_MASK;
+
+    s_emiosBase[instance]->CH.UC[hwChannel].C2 |= eMIOS_C2_UCEXTPRE(u32ChannelPrescaler);
+    /* Enable channel prescaler */
+    s_emiosBase[instance]->CH.UC[hwChannel].C |= eMIOS_C_UCPREN_MASK;
+
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_53();
+}
+#endif  /* EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+static inline void Emios_Icu_Ip_EnableMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    uint8      nMasterBusHwChannel;
+
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        nMasterBusHwChannel = Emios_Icu_Ip_GetMasterBus(hwChannel, eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected);
+        if (nMasterBusHwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS)
+        {
+            if((uint8)0U == eMios_Icu_Ip_u8NumOvflByCounterBus[instance][nMasterBusHwChannel])
+            {
+                /* Clear pending interrupts */
+                s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+                /* Enable Interrupt for master bus*/
+                Emios_Icu_Ip_EnableInterrupt(instance, nMasterBusHwChannel);
+            }
+            eMios_Icu_Ip_u8NumOvflByCounterBus[instance][nMasterBusHwChannel]++;
+        }
+    }
+}
+
+static inline void Emios_Icu_Ip_DisableMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    uint8      nMasterBusHwChannel;
+
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        nMasterBusHwChannel = Emios_Icu_Ip_GetMasterBus(hwChannel, eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected);
+        if (nMasterBusHwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS)
+        {
+            eMios_Icu_Ip_u8NumOvflByCounterBus[instance][nMasterBusHwChannel]--;
+            if((uint8)0U == eMios_Icu_Ip_u8NumOvflByCounterBus[instance][nMasterBusHwChannel])
+            {
+                /* Disable Interrupt for master bus*/
+                Emios_Icu_Ip_DisableInterrupt(instance, nMasterBusHwChannel);
+            }
+        }
+    }
+}
+#endif /* EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON */
+#endif /* (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) */
+
+/*==================================================================================================
+*                                       GLOBAL FUNCTIONS
+==================================================================================================*/
+#if (defined(EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT))
+#if (defined(MCAL_EMIOS_REG_PROT_AVAILABLE))
+#if (STD_ON == MCAL_EMIOS_REG_PROT_AVAILABLE)
+void Emios_Icu_Ip_SetUserAccessAllowed(uint32 EmiosBaseAddr)
+{
+    SET_USER_ACCESS_ALLOWED(EmiosBaseAddr, EMIOS_PROT_MEM_U32);
+}
+#endif /* (STD_ON == MCAL_EMIOS_REG_PROT_AVAILABLE) */
+#endif /* (defined(MCAL_EMIOS_REG_PROT_AVAILABLE)) */
+#endif /* (defined(EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT)) */
+
+
+/** @implements Emios_Icu_Ip_EnableInterrupt_Activity */
+void Emios_Icu_Ip_EnableInterrupt(uint8 instance, uint8 hwChannel)
+{
+    /* Clear pending flag */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= eMIOS_S_FLAG_MASK;
+
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_46();
+    /* Enable interrupt */
+    s_emiosBase[instance]->CH.UC[hwChannel].C |= eMIOS_C_FEN_MASK;
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_46();
+}
+
+/** @implements Emios_Icu_Ip_DisableInterrupt_Activity */
+void Emios_Icu_Ip_DisableInterrupt(uint8 instance, uint8 hwChannel)
+{
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_47();
+    /* Disable interrupt */
+    s_emiosBase[instance]->CH.UC[hwChannel].C &= ~eMIOS_C_FEN_MASK;
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_47();
+}
+
+/* @implements Emios_Icu_Ip_Init_Activity */
+eMios_Icu_Ip_StatusType Emios_Icu_Ip_Init(uint8 instance, const eMios_Icu_Ip_ConfigType *userConfig)
+{
+    uint8                       hwChannel;
+    uint32                      u32RegCCR;
+    uint8                       u8MasterBusMode[EMIOS_ICU_IP_NUM_OF_CHANNELS];
+    uint8                       index;
+    uint8                       u8MasterBusChannelIdx;
+    eMios_Icu_Ip_StatusType     retStatus   = EMIOS_IP_STATUS_SUCCESS;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(userConfig != NULL_PTR);
+#endif 
+    if (FALSE == eMios_Icu_Ip_bInstanceState[instance])
+    {
+        eMios_Icu_Ip_bInstanceState[instance] = TRUE;
+        for (index=0U; index < EMIOS_ICU_IP_NUM_OF_CHANNELS; index++)
+        {
+            if (eMios_Icu_Ip_IndexInChState[instance][index] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED)
+            {                
+                eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][index]].channelsInitState = FALSE;
+            }
+            u8MasterBusMode[index] = EMIOS_ICU_IP_CB_NONE;
+        }
+        /* Register Protection - Set UAA bit in GCR - allow USER MODE access */
+        Call_Emios_Icu_Ip_SetUserAccessAllowed((uint32)s_emiosBase[instance]);
+
+        for (index=0U; index < userConfig->nNumChannels; index++)
+        {
+            hwChannel   = (*userConfig->pChannelsConfig)[index].hwChannel;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelsInitState = TRUE;
+            
+            /* Initialize the state for calling user notification - can be HLD or IPL direct user notification */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification = (*userConfig->pChannelsConfig)[index].eMiosChannelNotification;
+            
+            /* Take HLD callback pointer and logic channel and store them in state configuration. */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosOverflowNotification = (*userConfig->pChannelsConfig)[index].eMiosOverflowNotification;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callback      = (*userConfig->pChannelsConfig)[index].callback;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].logicChStateCallback = (*userConfig->pChannelsConfig)[index].logicChStateCallback;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callbackParam = (*userConfig->pChannelsConfig)[index].callbackParams;
+            
+            /* Set the event which will generate the interrupt */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].edgeTrigger   = (*userConfig->pChannelsConfig)[index].edgeAlignement;
+
+            /* Clear channel config for hwChannel */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_NO_MEASUREMENT;
+#if (defined(EMIOS_ICU_IP_EDGE_COUNT_API) && (STD_ON == EMIOS_ICU_IP_EDGE_COUNT_API))
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].maxCounterValue = EMIOS_ICU_IP_INIT_CADR_U32;
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+#endif /* (defined(EMIOS_ICU_IP_EDGE_COUNT_API) && (STD_ON == EMIOS_ICU_IP_EDGE_COUNT_API)) */
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API)
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement = EMIOS_ICU_NO_MEASUREMENT;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod = (uint16)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = (uint16)0U;
+#endif
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API)
+    #if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+            /* Reset aBufferPtr */
+            eMios_Icu_Ip_BufferPtr[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = 0U;
+    #endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer = NULL_PTR;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize = (uint16)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify = (uint16)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount = (uint16)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex = (uint16)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType = (*userConfig->pChannelsConfig)[index].timestampBufferType;
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API) */
+#if ((STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL) || (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL))
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel =  (*userConfig->pChannelsConfig)[index].dmaChannel;
+#endif
+
+#if (STD_ON == EMIOS_ICU_USES_MCL_DRIVER)             
+            /* Enable EMIOS Channel. */
+            Emios_Mcl_Ip_EnableChannel(instance, hwChannel);
+#endif
+
+            /* Enter GPIO Mode to Configure Channel */
+            /* Reset mode for selected channel */
+            s_emiosBase[instance]->CH.UC[hwChannel].C = EMIOS_ICU_IP_CCR_CLEAR_U32;
+
+            /* Initialize channel filter, freeze enable, and bus select and disable the
+            * Set Default Edge (included)
+            */
+            u32RegCCR = eMIOS_C_UCPREN_MASK | eMIOS_C_FCK_MASK;
+            u32RegCCR |= eMIOS_C_FREN(((*userConfig->pChannelsConfig)[index].FreezeEn)?1U:0U);
+            u32RegCCR |= eMIOS_C_IF((*userConfig->pChannelsConfig)[index].Filter);
+            u32RegCCR |= eMIOS_C_BSL((*userConfig->pChannelsConfig)[index].CntBus);
+
+            s_emiosBase[instance]->CH.UC[hwChannel].C |= u32RegCCR;
+            
+            /* Initialize prescaler value */
+            s_emiosBase[instance]->CH.UC[hwChannel].C2 &= ~eMIOS_C2_UCEXTPRE_MASK;
+            s_emiosBase[instance]->CH.UC[hwChannel].C2 |= eMIOS_C2_UCEXTPRE((*userConfig->pChannelsConfig)[index].Prescaler);
+            
+            /* Disable interrupt */
+            Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+            /* Clear pending interrupt flag (and other flags) for the channel */
+            s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+
+            Emios_Icu_Ip_SetActivation( instance, hwChannel, eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].edgeTrigger);
+
+            /* Set Configuration for hwChannel */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaMode = (*userConfig->pChannelsConfig)[index].chSubMode;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].operationMode = (*userConfig->pChannelsConfig)[index].ucMode;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].msWithoutInterrupt = (*userConfig->pChannelsConfig)[index].bWithoutInterrupt;
+        #if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API)
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement = (*userConfig->pChannelsConfig)[index].measurementMode;
+        #endif
+            /* Store bus select of hwChannel */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected = (*userConfig->pChannelsConfig)[index].CntBus;
+
+            if (EMIOS_ICU_BUS_INTERNAL_COUNTER != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+            {
+                u8MasterBusChannelIdx = (uint8)Emios_Icu_Ip_GetMasterBus(hwChannel, eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected);
+                if(EMIOS_ICU_IP_CB_NONE == u8MasterBusMode[u8MasterBusChannelIdx]) /* This master bus have not been configured*/
+                {
+                    /* store master bus mode and master bus pre-scaler*/
+                    u8MasterBusMode[u8MasterBusChannelIdx] = (uint8)EMIOS_ICU_IP_MCB_INT_CLOCK_U32;
+                    eMios_Icu_Ip_IndexInChState[instance][u8MasterBusChannelIdx] = EMIOS_ICU_IP_MASTERBUS_CHANNEL_USED;
+#if (STD_ON == EMIOS_ICU_USES_MCL_DRIVER) 
+                    /* Enable EMIOS Channel to make registers write-able. */
+                    Emios_Mcl_Ip_EnableChannel(instance, hwChannel);
+#endif
+                }
+            }
+        }
+
+        /* configuration for master bus */
+        for (index=0U; index < EMIOS_ICU_IP_NUM_OF_CHANNELS; index++)
+        {
+            if(EMIOS_ICU_IP_CB_NONE != u8MasterBusMode[index]) /* Master bus is used */
+            {
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+                /* Reset the number of active channels has the overflow notification function using masterbus. */
+                eMios_Icu_Ip_u8NumOvflByCounterBus[instance][index] = 0;
+#endif
+#endif
+            }
+        }
+    }
+    else
+    {
+        /* Module already initialized - use de-initialize first */
+        retStatus = EMIOS_IP_STATUS_ERROR;
+    }
+    return retStatus;
+}
+
+#if (EMIOS_ICU_IP_DEINIT_API == STD_ON)
+/* @implements Emios_Icu_Ip_DeinitChannel_Activity */
+eMios_Icu_Ip_StatusType Emios_Icu_Ip_Deinit(uint8 instance)
+{
+    eMios_Icu_Ip_ModeType       nMeasMode;
+    uint8                       hwChannel;
+    
+    eMios_Icu_Ip_StatusType     retStatus   = EMIOS_IP_STATUS_SUCCESS;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+#endif 
+
+    if (TRUE == eMios_Icu_Ip_bInstanceState[instance])
+    {
+        eMios_Icu_Ip_bInstanceState[instance] = FALSE;
+        
+        for (hwChannel=0U; hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS; hwChannel++)
+        {
+            if (eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED)
+            {
+                if (TRUE == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelsInitState)
+                {
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelsInitState = FALSE;
+                    
+                    nMeasMode = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode;
+        
+                    /* Set all channel registers as after reset */
+                    s_emiosBase[instance]->CH.UC[hwChannel].C = EMIOS_ICU_IP_CCR_CLEAR_U32;
+                    s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_CCR_CLEAR_U32;
+    
+                    switch (nMeasMode)
+                    {
+                        case EMIOS_ICU_MODE_SIGNAL_MEASUREMENT:
+                        {
+                            s_emiosBase[instance]->CH.UC[hwChannel].B = EMIOS_ICU_IP_CCR_CLEAR_U32;
+                        }
+                        break;
+        
+                        case EMIOS_ICU_MODE_EDGE_COUNTER:
+                        {
+                            s_emiosBase[instance]->CH.UC[hwChannel].CNT = EMIOS_ICU_IP_CCR_CLEAR_U32;
+                        }
+                        break;
+        
+                        default:
+                        {
+                            /*For Misra Compliance*/
+                        }
+                        break;
+                    }
+                    /* Clear CSR register */
+                    s_emiosBase[instance]->CH.UC[hwChannel].S = EMIOS_ICU_IP_CSR_CLEAR_U32;
+
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+                    /* Clear all aEdgeCurrent_Value */
+                    eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = (uint32)(0x0U);
+#endif /* EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON */
+
+                    /* if channel using master bus, so de-init for master bus */
+                    if (EMIOS_ICU_BUS_INTERNAL_COUNTER != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+                    {
+#if (STD_ON == EMIOS_ICU_USES_MCL_DRIVER)    
+                        /* Disable eMIOS Channel */
+                        Emios_Mcl_Ip_DisableChannel(instance, hwChannel);
+#endif
+                    }            
+                    /* Clear config for hardware channel */
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].operationMode = EMIOS_ICU_UNINIT;
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected   = EMIOS_ICU_BUS_INTERNAL_COUNTER;
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode   = EMIOS_ICU_MODE_NO_MEASUREMENT;
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API)
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement   = EMIOS_ICU_NO_MEASUREMENT;
+#endif
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API)
+                    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType = EMIOS_ICU_NO_TIMESTAMP;
+#endif
+                }
+            }
+            if (EMIOS_ICU_IP_MASTERBUS_CHANNEL_USED == eMios_Icu_Ip_IndexInChState[instance][hwChannel])
+            {
+                eMios_Icu_Ip_IndexInChState[instance][hwChannel] = EMIOS_ICU_IP_CHANNEL_NOT_USED;
+            }
+        }
+    }
+    else
+    {
+        /* Module already de-init - use init first */
+        retStatus = EMIOS_IP_STATUS_ERROR;
+    }
+    return retStatus;
+}
+#endif
+
+#if (EMIOS_ICU_IP_SET_MODE_API == STD_ON)
+void Emios_Icu_Ip_SetSleepMode(uint8 instance, uint8 hwChannel)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    /* Stop eMIOS channel */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+}
+
+void Emios_Icu_Ip_SetNormalMode(uint8 instance, uint8 hwChannel)
+{
+    uint32 u32Value_CCR_FEN;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    /* u32Value_CCR_FEN will indicate whether the interrupt is enabled or not*/
+    u32Value_CCR_FEN  = (s_emiosBase[instance]->CH.UC[hwChannel].C & eMIOS_C_FEN_MASK);
+    /* if interrupt is not enabled*/
+    if(0U == u32Value_CCR_FEN)
+    {
+        Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+    }
+}
+#endif  /* EMIOS_ICU_IP_SET_MODE_API */
+
+/* @implements Emios_Icu_Ip_SetActivation_Activity */
+void Emios_Icu_Ip_SetActivation(uint8 instance, uint8 hwChannel, eMios_Icu_Ip_EdgeType edge)
+{
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+    uint32 u32RegEmiosCCR;
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_50();
+    switch (edge)
+    {
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+        case EMIOS_OPPOSITE_EDGES:
+        {
+            u32RegEmiosCCR = s_emiosBase[instance]->CH.UC[hwChannel].C;
+            s_emiosBase[instance]->CH.UC[hwChannel].C = (u32RegEmiosCCR ^ eMIOS_C_EDPOL_MASK);
+        }
+        break;
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+
+        case EMIOS_ICU_BOTH_EDGES:
+        {
+            s_emiosBase[instance]->CH.UC[hwChannel].C |= eMIOS_C_EDSEL_MASK;
+        }
+        break;
+
+        case EMIOS_ICU_RISING_EDGE:
+        {
+            s_emiosBase[instance]->CH.UC[hwChannel].C &= ~eMIOS_C_EDSEL_MASK;
+            s_emiosBase[instance]->CH.UC[hwChannel].C |= eMIOS_C_EDPOL_MASK;
+        }
+        break;
+
+        default:
+        {
+            /* EMIOS_ICU_FALLING_EDGE */
+            s_emiosBase[instance]->CH.UC[hwChannel].C &= ~(eMIOS_C_EDSEL_MASK|eMIOS_C_EDPOL_MASK);
+        }
+        break;
+    }
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_50();
+}
+
+#if (EMIOS_ICU_IP_EDGE_DETECT_API == STD_ON)
+/* @implements Emios_Icu_Ip_EnableEdgeDetection_Activity */
+void Emios_Icu_Ip_EnableEdgeDetection(uint8 instance, uint8 hwChannel)
+{
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Enable SAIC mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_SAIC_U32);
+
+    /* Enable Interrupt */
+    Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+
+    /* Set Channel Config */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_SIGNAL_EDGE_DETECT;
+
+}
+
+/* @implements Emios_Icu_Ip_DisableEdgeDetection_Activity */
+void Emios_Icu_Ip_DisableEdgeDetection(uint8 instance, uint8 hwChannel)
+{
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Clear Channel Config */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_NO_MEASUREMENT;
+
+}
+#endif /* EMIOS_ICU_IP_EDGE_DETECT_API */
+
+/* @implements Emios_Icu_Ip_EnableNotification_Activity */
+void Emios_Icu_Ip_EnableNotification(uint8 instance, uint8 hwChannel)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].notificationEnable =  TRUE;
+}
+
+/* @implements Emios_Icu_Ip_DisableNotification_Activity */
+void Emios_Icu_Ip_DisableNotification(uint8 instance, uint8 hwChannel)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].notificationEnable =  FALSE;
+}
+
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+/* @implements Emios_Icu_Ip_StartTimestamp_Activity */
+void Emios_Icu_Ip_StartTimestamp
+(
+    uint8 instance,
+    uint8 hwChannel,
+    eMios_Icu_ValueType * bufferPtr,
+    uint16 bufferSize,
+    uint16 notifyInterval
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+        Dma_Ip_LogicChannelTransferListType global_DmaChannelTransferList[11U];
+#endif /* (EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL == STD_ON) */
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_51();
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer = bufferPtr;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize = bufferSize;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify = notifyInterval;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount = (uint16)0U;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex = (uint16)0U;
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_51();
+    
+    /* Reset aBufferPtr */
+    eMios_Icu_Ip_BufferPtr[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = 0U;
+    
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+    /* Setup DMA in Dma_Ip*/
+    if (0xFFU != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel)
+    {
+        /* Create the desired configuration list. */
+        global_DmaChannelTransferList[0U].Param = DMA_IP_CH_SET_SOURCE_ADDRESS;
+        global_DmaChannelTransferList[0U].Value = Emios_Icu_Ip_GetStartAddress(instance, hwChannel);
+        /* Compiler_Warning: DMA TCD addresses are restricted to 32 bits, so casting from pointer type to uint32 is safe.
+         * The application should ensure that only addresses that fit in uint32 are used for configuring DMA. */
+        global_DmaChannelTransferList[1U].Param = DMA_IP_CH_SET_DESTINATION_ADDRESS;
+        global_DmaChannelTransferList[1U].Value = (uint32)bufferPtr;
+        global_DmaChannelTransferList[2U].Param = DMA_IP_CH_SET_DESTINATION_TRANSFER_SIZE; 
+        global_DmaChannelTransferList[2U].Value = (uint32)DMA_IP_TRANSFER_SIZE_4_BYTE;
+        global_DmaChannelTransferList[3U].Param = DMA_IP_CH_SET_SOURCE_TRANSFER_SIZE;
+        global_DmaChannelTransferList[3U].Value = (uint32)DMA_IP_TRANSFER_SIZE_4_BYTE;
+        global_DmaChannelTransferList[4U].Param = DMA_IP_CH_SET_SOURCE_SIGNED_OFFSET;
+        global_DmaChannelTransferList[4U].Value = (uint32)0U;
+        global_DmaChannelTransferList[5U].Param = DMA_IP_CH_SET_DESTINATION_SIGNED_OFFSET;
+        global_DmaChannelTransferList[5U].Value = (uint32)4U;
+        global_DmaChannelTransferList[6U].Param = DMA_IP_CH_SET_SOURCE_MODULO;
+        global_DmaChannelTransferList[6U].Value = (uint32)0U;
+        global_DmaChannelTransferList[7U].Param = DMA_IP_CH_SET_DESTINATION_MODULO;
+        global_DmaChannelTransferList[7U].Value = (uint32)0U;
+        
+        if ((notifyInterval >= bufferSize) || (notifyInterval == (uint16)0))
+        {
+            global_DmaChannelTransferList[8U].Param = DMA_IP_CH_SET_MINORLOOP_SIZE;
+            global_DmaChannelTransferList[8U].Value = 4U;
+            global_DmaChannelTransferList[9U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+            global_DmaChannelTransferList[9U].Value = bufferSize;
+            if ((uint8) EMIOS_ICU_CIRCULAR_BUFFER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType)
+            {
+                global_DmaChannelTransferList[10U].Param = DMA_IP_CH_SET_DESTINATION_SIGNED_LAST_ADDR_ADJ;
+                global_DmaChannelTransferList[10U].Value = (uint32) (~(bufferSize * 4U)) + 1U;
+            }
+            else
+            {
+                global_DmaChannelTransferList[10U].Param = DMA_IP_CH_SET_CONTROL_DIS_AUTO_REQUEST;
+                global_DmaChannelTransferList[10U].Value = (uint32)1U;
+            }
+        }
+        else if (notifyInterval < bufferSize)
+        {
+            global_DmaChannelTransferList[8U].Param = DMA_IP_CH_SET_MINORLOOP_SIZE;
+            global_DmaChannelTransferList[8U].Value = 4U;
+            global_DmaChannelTransferList[9U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+            global_DmaChannelTransferList[9U].Value = notifyInterval;
+            if ((uint8) EMIOS_ICU_CIRCULAR_BUFFER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType)
+            {
+        
+                global_DmaChannelTransferList[10U].Param = DMA_IP_CH_SET_DESTINATION_SIGNED_LAST_ADDR_ADJ;
+                global_DmaChannelTransferList[10U].Value = (uint32)0U;
+            }
+            else
+            {
+                global_DmaChannelTransferList[10U].Param = DMA_IP_CH_SET_CONTROL_DIS_AUTO_REQUEST;
+                global_DmaChannelTransferList[10U].Value = (uint32)0U;
+            }
+        }
+        else
+        {
+            /* Nothing to be done */
+        }
+        
+        Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, global_DmaChannelTransferList, (uint32)11U);
+        Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_SET_HARDWARE_REQUEST);
+    }
+#endif  /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+
+    /* Make sure channel is in GPIO mode before switching modes */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Clear pending interrupts */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+
+    /* Enable SAIC mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_SAIC_U32);
+
+    if(EMIOS_ICU_MODE_WITH_DMA == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaMode)
+    {
+        SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_51();
+        s_emiosBase[instance]->CH.UC[hwChannel].C |= (eMIOS_C_DMA_MASK);
+        SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_51();
+    }
+
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        /* Set Max. A value */
+        s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_INIT_CADR_U32;
+    }
+
+    /* Set channel Config*/
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_TIMESTAMP;
+    /* Enable Interrupt */
+    Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+    /* Enable Interrupt for masterbus*/
+    Emios_Icu_Ip_EnableMasterBusInterrupt(instance ,hwChannel);
+#endif
+}
+
+/* @implements Emios_Icu_Ip_GetTimestampIndex_Activity */
+uint16 Emios_Icu_Ip_GetTimestampIndex
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    uint16 timestampIndex = 0U;
+
+#if (EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL == STD_ON)
+    uint32          startIter;
+    uint32          crtIter;
+    uint32* const   pStartIter = &startIter;
+    uint32* const   pCrtIter = &crtIter;
+#endif
+    
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+    if (0xFFU != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel)
+    {
+        if (NULL_PTR == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer)
+        {
+            timestampIndex = 0U;
+        }
+        else
+        {
+            Dma_Ip_GetLogicChannelParam(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_GET_BEGIN_ITER_COUNT, pStartIter);
+            Dma_Ip_GetLogicChannelParam(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_GET_CURRENT_ITER_COUNT, pCrtIter);
+            crtIter = startIter - crtIter;
+            timestampIndex =  eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex + (uint16)crtIter;
+        }
+    }
+    else
+    {
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+        if (NULL_PTR == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer)
+        {
+            timestampIndex = 0U;
+        }
+        else
+        {
+            timestampIndex = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex;
+        }
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+    }
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+
+    return timestampIndex;
+}
+
+/* @implements Emios_Icu_Ip_StopTimestamp_Activity */
+void Emios_Icu_Ip_StopTimestamp(uint8 instance, uint8 hwChannel)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+    /* Disable Dma for Timestamp */
+    if (0xFFU != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel)
+    {
+        Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_CLEAR_HARDWARE_REQUEST);
+    }  
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Clear channel Config */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_NO_MEASUREMENT;
+    
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        /* Set Max. A value */
+        s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_CCR_CLEAR_U32;;
+    }
+
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+    /* Disable Interrupt for masterbus*/
+    Emios_Icu_Ip_DisableMasterBusInterrupt(instance, hwChannel);
+#endif
+}
+#endif  /* EMIOS_ICU_IP_TIMESTAMP_API */
+
+#if ((EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_USES_DMA == STD_ON))
+uint32 Emios_Icu_Ip_GetStartAddress
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif
+    /*return the value of A register*/
+    return (uint32)(&s_emiosBase[instance]->CH.UC[hwChannel].A);
+}
+#endif
+
+
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+
+/* @implements Emios_Icu_Ip_ResetEdgeCount_Activity */
+void Emios_Icu_Ip_ResetEdgeCount
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    uint32  u32PrevMode;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    u32PrevMode = (s_emiosBase[instance]->CH.UC[hwChannel].C & eMIOS_C_MODE_MASK);
+
+    /* Disable timer interrupts */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Reset counter */
+    s_emiosBase[instance]->CH.UC[hwChannel].CNT = EMIOS_ICU_IP_INIT_CCNTR_U32;
+
+    /* Max. value for register A. If reached, overflow interrupt */
+    s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_INIT_CADR_U32;
+
+    /* Clear pending interrupts */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+
+    /* Restore previous mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, u32PrevMode);
+
+    /* Cleare Current Value*/
+    eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = (uint32)0U;
+    /* Enable timer interrupts */
+    Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+}
+
+/* @implements Emios_Icu_Ip_EnableEdgeCount_Activity */
+void Emios_Icu_Ip_EnableEdgeCount(uint8 instance, uint8 hwChannel)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+    /* Make sure channel is in GPIO mode before switching modes */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Set Max. A value */
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+    s_emiosBase[instance]->CH.UC[hwChannel].A = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].maxCounterValue;
+#else
+    s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_INIT_CADR_U32;
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+
+
+    /* Sync. eMIOS counter value. (Needed in case of stopping and re-enabling counting)
+     * Note: Setting GPIO mode, the internal counter was cleared and must be restored
+     */
+
+    /* When call again affter call Emios_Icu_Ip_DisableEdgeCount*/
+    s_emiosBase[instance]->CH.UC[hwChannel].CNT = eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]];
+
+    /* Modulus counter mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_MCB_EXT_CLOCK_U32);
+
+    /* Clear pending interrupts */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+
+    /* Enable interrupt */
+    Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+
+    /* Set Channel config */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_EDGE_COUNTER;
+
+
+}
+
+/* @implements Emios_Icu_Ip_DisableEdgeCount_Activity */
+void Emios_Icu_Ip_DisableEdgeCount
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Clear pending interrupts */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+
+    /* Save count, before going to GPIO mode (because counter is reset to 0x0000) */
+    eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = s_emiosBase[instance]->CH.UC[hwChannel].CNT;
+
+    /* Disable MCB mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_NO_MEASUREMENT;
+    
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].maxCounterValue = EMIOS_ICU_IP_INIT_CADR_U32;
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+}
+
+
+/* @implements Emios_Icu_Ip_GetEdgeNumbers_Activity */
+eMios_Icu_ValueType Emios_Icu_Ip_GetEdgeNumbers
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    uint32 u32Mode;
+    eMios_Icu_ValueType u16Result = (eMios_Icu_ValueType)0U;
+    u32Mode = (s_emiosBase[instance]->CH.UC[hwChannel].C & eMIOS_C_MODE_MASK);
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    /* Check mode after call Emios_Icu_Ip_DisableEdgeCount */
+    if(EMIOS_ICU_IP_CCR_MODE_GPI_U32 == u32Mode)
+    {
+        u16Result = (eMios_Icu_ValueType)eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]];
+    }
+    else
+    {
+        u16Result = (eMios_Icu_ValueType)s_emiosBase[instance]->CH.UC[hwChannel].CNT;
+    }
+    return u16Result;
+
+}
+
+#if (STD_ON == EMIOS_ICU_IP_SET_INITIAL_COUNTER)
+/* @implements Emios_Icu_Ip_SetInitialCounterValue_Activity */
+void Emios_Icu_Ip_SetInitialCounterValue
+(
+    uint8 instance,
+    uint8 hwChannel,
+    uint32 initialCounter
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance   < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel  < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif
+
+    /* Save initial counter for channel */
+    eMios_Icu_Ip_u32aEdgeCurrent_Value[eMios_Icu_Ip_IndexInChState[instance][hwChannel]]= initialCounter;
+}
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_INITIAL_COUNTER */
+
+#if (STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER)
+/* @implements Emios_Icu_Ip_SetMaxCounterValue_Activity */
+void Emios_Icu_Ip_SetMaxCounterValue
+(
+    uint8 instance,
+    uint8 hwChannel,
+    uint32 maxCounter
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance   < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel  < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(maxCounter < EMIOS_ICU_IP_COUNTER_MASK);
+#endif
+
+    /* Save max counter for channel */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].maxCounterValue = maxCounter;
+}
+#endif  /* STD_ON == EMIOS_ICU_IP_SET_MAX_COUNTER */
+#endif  /* EMIOS_ICU_IP_EDGE_COUNT_API */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/* @implements Emios_Icu_Ip_StartSignalMeasurement_Activity */
+void Emios_Icu_Ip_StartSignalMeasurement
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    eMios_Icu_Ip_UCModeType eMiosOperationMode;
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+    /* Setup DMA for this channel */
+    uint8 u8index = 0U;
+    Dma_Ip_LogicChannelTransferListType global_DmaChannelTransferList[10U];
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+    /* Setup DMA for this channel */
+    if (0xFFU != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel)
+    {
+        Emios_Icu_Ip_aIsSecondInterrupt[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = 0U;
+        /* initialize the members of the structure */
+        global_DmaChannelTransferList[0U].Param = DMA_IP_CH_SET_SOURCE_ADDRESS;
+        global_DmaChannelTransferList[0U].Value = Emios_Icu_Ip_GetStartAddress(instance, hwChannel);
+        global_DmaChannelTransferList[1U].Param = DMA_IP_CH_SET_DESTINATION_ADDRESS;
+        global_DmaChannelTransferList[1U].Value = (uint32)&Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][0];
+        global_DmaChannelTransferList[2U].Param = DMA_IP_CH_SET_DESTINATION_TRANSFER_SIZE;
+        global_DmaChannelTransferList[2U].Value = (uint32)DMA_IP_TRANSFER_SIZE_4_BYTE;
+        global_DmaChannelTransferList[3U].Param = DMA_IP_CH_SET_SOURCE_TRANSFER_SIZE;
+        global_DmaChannelTransferList[3U].Value = (uint32)DMA_IP_TRANSFER_SIZE_4_BYTE;
+        global_DmaChannelTransferList[4U].Param = DMA_IP_CH_SET_SOURCE_SIGNED_OFFSET;
+        global_DmaChannelTransferList[4U].Value = (uint32)0U;
+        global_DmaChannelTransferList[5U].Param = DMA_IP_CH_SET_DESTINATION_SIGNED_OFFSET;
+        global_DmaChannelTransferList[5U].Value = (uint32)4U;
+        global_DmaChannelTransferList[6U].Param = DMA_IP_CH_SET_SOURCE_MODULO;
+        global_DmaChannelTransferList[6U].Value = (uint32)0U;
+        global_DmaChannelTransferList[7U].Param = DMA_IP_CH_SET_DESTINATION_MODULO;
+        global_DmaChannelTransferList[7U].Value = (uint32)0U;
+        global_DmaChannelTransferList[8U].Param = DMA_IP_CH_SET_MINORLOOP_SIZE;
+        global_DmaChannelTransferList[8U].Value = (uint32)4U;
+        global_DmaChannelTransferList[9U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+        global_DmaChannelTransferList[9U].Value = (uint32)1U;
+                              
+        Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, global_DmaChannelTransferList, (uint32)10U);
+        Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_SET_HARDWARE_REQUEST);
+
+        /*Clear the DMA result buffer for configured DMA channel*/
+        for(u8index = 0U; u8index < EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT; u8index++)
+        {
+             Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][u8index] = (uint16)0;
+        }     
+    }
+#endif
+
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod = (eMios_Icu_ValueType)0U;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = (eMios_Icu_ValueType)0U;
+
+    /* Reset capture and timestart of hwChannel */
+    eMios_Icu_Ip_CapturedActivePulseWidth[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = 0U;
+    eMios_Icu_Ip_TimeStart[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = 0U;
+
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    /* Set activation condition */
+    Emios_Icu_Ip_SetActivation(instance, hwChannel, eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].edgeTrigger);
+
+    /* Get operation mode of hardware channel */
+    if(EMIOS_ICU_MODE_WITH_DMA == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaMode)\
+    {
+        SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_52();
+        s_emiosBase[instance]->CH.UC[hwChannel].C |= (eMIOS_C_DMA_MASK);
+        SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_52();
+    }
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_SIGNAL_MEASUREMENT;
+    
+    eMiosOperationMode = (eMios_Icu_Ip_UCModeType)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].operationMode;
+
+    switch (eMiosOperationMode)
+    {
+        case EMIOS_ICU_IPWM:
+            {
+                /* Enable IPWM mode */
+                Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_IPWM_U32);
+            }
+        break;
+
+        case EMIOS_ICU_IPM:
+            {
+                /* Enable IPM mode */
+                Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_IPM_U32);
+            }
+        break;
+
+        default:
+            {
+                /* Enable SAIC mode */
+                Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_SAIC_U32);
+            }
+        break;
+    }
+    
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        /* Set Max. A value */
+        s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_INIT_CADR_U32;
+    }
+    /* Clear pending interrupt flag (and other flags) for the channel */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+    /* Clear the counter for signal measurement */
+    eMios_Icu_Ip_aeInt_Counter[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = EMIOS_ICU_MEASUREMENT_PENDING;
+    if (TRUE != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].msWithoutInterrupt)
+    {
+        /* Enable Interrupt */
+        Emios_Icu_Ip_EnableInterrupt(instance, hwChannel);
+    }
+
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+    /* Enable Interrupt for masterbus*/
+    Emios_Icu_Ip_EnableMasterBusInterrupt(instance, hwChannel);
+#endif
+}
+
+/* @implements Emios_Icu_Ip_StopSignalMeasurement_Activity */
+void Emios_Icu_Ip_StopSignalMeasurement
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    /* Disable interrupt */
+    Emios_Icu_Ip_DisableInterrupt(instance, hwChannel);
+
+    /* Enter GPIO Mode */
+    Emios_Icu_Ip_UCSetMode(instance, hwChannel, EMIOS_ICU_IP_CCR_MODE_GPI_U32);
+
+    SchM_Enter_Icu_ICU_EXCLUSIVE_AREA_49();
+    /* EDSEL is set to 1 to discard the input in GPIO mode (not to repond the input signal
+       in GPIO mode)*/
+    /* Disables the flag generation as defined by EDPOL Bit */
+    s_emiosBase[instance]->CH.UC[hwChannel].C |= eMIOS_C_EDSEL_MASK;
+    SchM_Exit_Icu_ICU_EXCLUSIVE_AREA_49();
+    
+    if (EMIOS_ICU_BUS_INTERNAL_COUNTER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected)
+    {
+        /* Set Max. A value */
+        s_emiosBase[instance]->CH.UC[hwChannel].A = EMIOS_ICU_IP_CCR_CLEAR_U32;
+    }
+    /* Clear pending interrupt flag (and other flags) for the channel */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK);
+    /* Clear channel config */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode = EMIOS_ICU_MODE_NO_MEASUREMENT;
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_ON)
+    /* Disable Interrupt for masterbus*/
+    Emios_Icu_Ip_DisableMasterBusInterrupt(instance, hwChannel);
+#endif
+}
+
+/* @implements Emios_Icu_Ip_GetTimeElapsed_Activity */
+eMios_Icu_ValueType Emios_Icu_Ip_GetTimeElapsed
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    eMios_Icu_ValueType timeElapsed = (eMios_Icu_ValueType)0U;
+    
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    if((EMIOS_ICU_DUTY_CYCLE != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement) && \
+        (EMIOS_ICU_NO_MEASUREMENT != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement))
+    {
+        if ((eMios_Icu_Ip_MeasType)EMIOS_ICU_PERIOD_TIME == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement)
+        {
+            timeElapsed = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod = (eMios_Icu_ValueType)0U;
+        }
+        else
+        {
+            timeElapsed = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = (eMios_Icu_ValueType)0U;
+        }
+    }
+    #if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    else
+    {
+        DevAssert(TRUE);
+    }
+    #endif
+    return timeElapsed;
+}
+
+/* @implements Emios_Icu_Ip_GetDutyCycleValues_Activity */
+void Emios_Icu_Ip_GetDutyCycleValues
+(
+    uint8 instance,
+    uint8 hwChannel,
+    eMios_Icu_Ip_DutyCycleType*  dutyCycleValues 
+)
+{
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+    if(EMIOS_ICU_DUTY_CYCLE == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].measurement)
+    {
+        if ((eMios_Icu_ValueType)0U != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod)
+        {
+            dutyCycleValues->ActiveTime = (eMios_Icu_ValueType)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth;
+            dutyCycleValues->PeriodTime = (eMios_Icu_ValueType)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = (eMios_Icu_ValueType)0U;
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod           = (eMios_Icu_ValueType)0U;
+        }
+        else
+        {
+            dutyCycleValues->ActiveTime = (eMios_Icu_ValueType)0U;
+            dutyCycleValues->PeriodTime = (eMios_Icu_ValueType)0U;
+        }
+    }
+    #if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    else
+    {
+        DevAssert(TRUE);
+    }
+    #endif 
+}
+
+/**
+ * @brief Emios_Icu_Ip_SetPWandPeriod
+ */
+void Emios_Icu_Ip_SetPWandPeriod(uint8 instance, \
+                               uint8 hwChannel, \
+                               eMios_Icu_ValueType activePulseWidth, \
+                               eMios_Icu_ValueType period)
+{
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = activePulseWidth;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod           = period;
+}
+#endif  /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API */
+
+#if (EMIOS_ICU_IP_GET_INPUT_STATE_API == STD_ON)
+boolean Emios_Icu_Ip_GetInputState
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    boolean bResult = FALSE;
+    uint32 u32ValueCCRFEN;
+    uint32 u32ValueCSRFLAG;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    u32ValueCCRFEN  = (s_emiosBase[instance]->CH.UC[hwChannel].C & eMIOS_C_FEN_MASK);
+    u32ValueCSRFLAG = (s_emiosBase[instance]->CH.UC[hwChannel].S & eMIOS_S_FLAG_MASK);
+
+    /* Interrupt not enabled, flag bit was set */
+    if ( (eMIOS_C_FEN_MASK != u32ValueCCRFEN) && (eMIOS_S_FLAG_MASK == u32ValueCSRFLAG))
+    {
+
+        /* Clear pending interrupt */
+        s_emiosBase[instance]->CH.UC[hwChannel].S |= eMIOS_S_FLAG_MASK;
+        bResult = TRUE;
+    }
+
+    return bResult;
+}
+#endif  /* EMIOS_ICU_IP_GET_INPUT_STATE_API */
+
+#if (EMIOS_ICU_IP_GET_INPUT_LEVEL_API == STD_ON)
+/* @implements  Emios_Icu_Ip_GetInputLevel_Activity */
+eMios_Icu_Ip_LevelType Emios_Icu_Ip_GetInputLevel
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    return ((0U != ((s_emiosBase[instance]->CH.UC[hwChannel].S & eMIOS_S_UCIN_MASK)>> eMIOS_S_UCIN_SHIFT))? \
+            EMIOS_ICU_LEVEL_HIGH : EMIOS_ICU_LEVEL_LOW);
+}
+#endif /* EMIOS_ICU_IP_GET_INPUT_LEVEL_API == STD_ON */
+
+boolean Emios_Icu_Ip_GetOverflow
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    uint32 u32RegCSR = (uint32) 0U;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    u32RegCSR = s_emiosBase[instance]->CH.UC[hwChannel].S;
+
+    /* Clear pending interrupt serviced */
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= eMIOS_S_OVFL_MASK;
+
+    return ((eMIOS_S_OVFL_MASK == (u32RegCSR & eMIOS_S_OVFL_MASK)) ? TRUE : FALSE);
+}
+
+#if (EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON)
+void Emios_Icu_Ip_SetClockMode
+(
+    uint8 instance,
+    const eMios_Icu_Ip_ConfigType                   *peMiosIpConfig,
+    const eMios_Icu_Ip_ClockModeType                Prescaler
+)
+{
+    /* logical channel */
+    uint8   index;
+    uint8   hwChannel;
+    eMios_Icu_Ip_BusType  nCtrlBus;
+    uint8   u8MasterBusChannelIdx;
+    uint8   u8MasterBusUse[EMIOS_ICU_IP_NUM_OF_CHANNELS];
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+#endif 
+    for (index=0U; index < (uint8)EMIOS_ICU_IP_NUM_OF_CHANNELS; index++)
+    {
+        u8MasterBusUse[index] = (uint8)EMIOS_ICU_IP_CB_NONE;
+    }
+
+    for (index=0U; index < peMiosIpConfig->nNumChannels; index++)
+    {
+        hwChannel   = (*peMiosIpConfig->pChannelsConfig)[index].hwChannel;
+        nCtrlBus = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected;
+
+        if (EMIOS_ICU_BUS_INTERNAL_COUNTER == nCtrlBus)
+        {
+            if (EMIOS_ICU_NORMAL_CLK == Prescaler)
+            {
+                Emios_Icu_Ip_SetPrescaler(  instance,
+                                            hwChannel,
+                                            (uint32)(*peMiosIpConfig->pChannelsConfig)[index].Prescaler
+                                          );
+            }
+            else
+            {
+                Emios_Icu_Ip_SetPrescaler(  instance,
+                                            hwChannel,
+                                            (uint32)(*peMiosIpConfig->pChannelsConfig)[index].AltPrescaler
+                                          );
+            }
+        }
+        else
+        {
+            u8MasterBusChannelIdx = (uint8)Emios_Icu_Ip_GetMasterBus(hwChannel, nCtrlBus);
+
+            if(u8MasterBusChannelIdx < EMIOS_ICU_IP_NUM_OF_CHANNELS)
+            {
+                if(u8MasterBusUse[u8MasterBusChannelIdx] == EMIOS_ICU_IP_CB_NONE)
+                {
+                    if (EMIOS_ICU_NORMAL_CLK == Prescaler)
+                    {
+                        Emios_Icu_Ip_SetPrescaler(  instance,
+                                                u8MasterBusChannelIdx,
+                                                (uint32)(*peMiosIpConfig->pChannelsConfig)[index].Prescaler
+                                              );
+                    }
+                    else
+                    {
+                        Emios_Icu_Ip_SetPrescaler(  instance,
+                                                u8MasterBusChannelIdx,
+                                                (uint32)(*peMiosIpConfig->pChannelsConfig)[index].AltPrescaler
+                                              );
+                    }
+                    u8MasterBusUse[u8MasterBusChannelIdx] = (uint8)1U;
+                }
+            }
+        }
+    }
+}
+#endif  /* EMIOS_ICU_IP_DUAL_CLOCK_MODE_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_CAPTURERGISTER_API == STD_ON) && ((EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)))
+/** @implements Emios_Icu_Ip_GetCaptureRegValue_Activity */
+uint32 Emios_Icu_Ip_GetCaptureRegValue
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    return s_emiosBase[instance]->CH.UC[hwChannel].A;
+}
+#endif  /* (EMIOS_ICU_IP_CAPTURERGISTER_API == STD_ON) && ((EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)) */
+
+#if ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+/* @implements Emios_Icu_Ip_GetPulseWidth_Activity */
+void Emios_Icu_Ip_GetPulseWidth
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif 
+    Emios_Icu_Ip_SignalMeasurementHandler(instance, hwChannel, FALSE);
+}
+#endif /* ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))*/
+
+#if ((EMIOS_ICU_IP_VALIDATE_GLOBAL_CALL == STD_ON) && ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)))
+Std_ReturnType Emios_Icu_Ip_ValidateSignalMeasureWithoutInterrupt
+(
+    uint8 instance,
+    uint8 hwChannel
+)
+{
+    /*return ICU signal property without using interrupt*/
+    return (eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].msWithoutInterrupt)?(Std_ReturnType)E_OK:(Std_ReturnType)E_NOT_OK;
+}
+#endif /* ((EMIOS_ICU_IP_GET_PULSE_WIDTH_API == STD_ON) && (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))*/
+
+#define ICU_STOP_SEC_CODE
+#include "Icu_MemMap.h"
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/s32/drivers/s32k3/Icu/src/Emios_Icu_Ip_Irq.c
+++ b/s32/drivers/s32k3/Icu/src/Emios_Icu_Ip_Irq.c
@@ -1,0 +1,1295 @@
+/*
+ * Copyright 2020-2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ *     @file       File with source code used to implement ICU driver functionality on EMIOS module.
+ *     @details    This file contains the source code for all functions which are using EMIOS module.
+ *     @addtogroup emios_icu_ip EMIOS IPL
+ *     @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/*==================================================================================================
+*                                         INCLUDE FILES
+* 1) system and project includes
+* 2) needed interfaces from external units
+* 3) internal and external interfaces from this unit
+==================================================================================================*/
+#include "Emios_Icu_Ip.h"
+#include "Emios_Icu_Ip_Irq.h"
+#include "SchM_Icu.h"
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+    #if (EMIOS_ICU_IP_DEV_ERROR_DETECT == STD_ON)
+        #include "Devassert.h"
+    #endif
+#endif  /* EMIOS_ICU_IP_USED */
+
+/*==================================================================================================
+*                                        LOCAL MACROS
+==================================================================================================*/
+#define EMIOS_ICU_IP_IRQ_VENDOR_ID_C                       43
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION_C        4
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION_C        7
+#define EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION_C     0
+#define EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION_C                3
+#define EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION_C                0
+#define EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION_C                0
+
+/*==================================================================================================
+*                                      FILE VERSION CHECKS
+==================================================================================================*/
+#if (EMIOS_ICU_IP_IRQ_VENDOR_ID_C != EMIOS_ICU_IP_IRQ_VENDOR_ID)
+    #error "Emios_Icu_Ip_Irq.c and Emios_Icu_Ip_Irq.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_Irq.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION_C != EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION_C != EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION_C != EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.c and Emios_Icu_Ip_Irq.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_Irq.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION_C != EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION_C != EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION_C != EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Irq.c and Emios_Icu_Ip_Irq.h are different"
+#endif
+
+#if (EMIOS_ICU_IP_IRQ_VENDOR_ID_C != EMIOS_ICU_IP_VENDOR_ID)
+    #error "Emios_Icu_Ip_Irq.c and Emios_Icu_Ip.h have different vendor ids"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_AR_RELEASE_REVISION_VERSION_C != EMIOS_ICU_IP_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.c and Emios_Icu_Ip.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_IRQ_SW_MAJOR_VERSION_C != EMIOS_ICU_IP_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_MINOR_VERSION_C != EMIOS_ICU_IP_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_IRQ_SW_PATCH_VERSION_C != EMIOS_ICU_IP_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Irq.c and Emios_Icu_Ip.h are different"
+#endif
+
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    /* Check if this header file and SchM_Icu.h file are of the same Autosar version */
+    #if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION_C != SCHM_ICU_AR_RELEASE_MAJOR_VERSION) || \
+        (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION_C != SCHM_ICU_AR_RELEASE_MINOR_VERSION))
+        #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.c and SchM_Icu.h are different"
+    #endif
+    
+    #if (STD_ON == EMIOS_ICU_IP_USED)
+        #if(EMIOS_ICU_IP_DEV_ERROR_DETECT == STD_ON)
+            /* Check if this header file and Devassert.h file are of the same Autosar version */
+            #if ((EMIOS_ICU_IP_IRQ_AR_RELEASE_MAJOR_VERSION_C != DEVASSERT_AR_RELEASE_MAJOR_VERSION) || \
+                (EMIOS_ICU_IP_IRQ_AR_RELEASE_MINOR_VERSION_C != DEVASSERT_AR_RELEASE_MINOR_VERSION))
+                #error "AutoSar Version Numbers of Emios_Icu_Ip_Irq.c and Devassert.h are different"
+            #endif
+        #endif
+    #endif  /* EMIOS_ICU_IP_USED */
+#endif
+/*==================================================================================================
+*                          LOCAL TYPEDEFS (STRUCTURES, UNIONS, ENUMS)
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       LOCAL CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       LOCAL VARIABLES
+==================================================================================================*/
+
+/*==================================================================================================
+                                       GLOBAL CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       GLOBAL VARIABLES
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+extern eMios_Icu_Ip_MeasStatusType eMios_Icu_Ip_aeInt_Counter[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+extern eMios_Icu_ValueType eMios_Icu_Ip_CapturedActivePulseWidth[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+extern eMios_Icu_ValueType eMios_Icu_Ip_TimeStart[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+extern eMios_Icu_ValueType eMios_Icu_Ip_BufferPtr[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#endif /* EMIOS_ICU_IP_TIMESTAMP_API == STD_ON */
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+extern eMios_Icu_Ip_ChStateType eMios_Icu_Ip_ChState[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_INIT_8
+#include "Icu_MemMap.h"
+/* This array stores the positions in the eMios_Icu_Ip_ChState array of the configured eMios channels. */
+extern uint8 eMios_Icu_Ip_IndexInChState[EMIOS_ICU_IP_INSTANCE_COUNT][EMIOS_ICU_IP_NUM_OF_CHANNELS];
+#define ICU_STOP_SEC_VAR_INIT_8
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_CONST_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+extern eMIOS_Type * const s_emiosBase[];
+
+#define ICU_STOP_SEC_CONST_UNSPECIFIED
+#include "Icu_MemMap.h"
+
+#define ICU_START_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
+#include "Icu_MemMap.h"
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+/** @brief Array for saving value of DMA **/
+extern uint32 Emios_Icu_Ip_aDmaBuffer[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED][EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT];
+
+/** @brief Array for saving the period */
+extern uint32 Emios_Icu_Ip_aIsSecondInterrupt[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+
+/** @brief Array for saving the period */
+extern uint32 Emios_Icu_Ip_aFirstEdgeTimeStamp[EMIOS_ICU_IP_NUM_OF_CHANNELS_USED];
+
+#endif /* EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL */
+
+#define ICU_STOP_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
+
+#include "Icu_MemMap.h"
+/*==================================================================================================
+*                                   LOCAL FUNCTION PROTOTYPES
+==================================================================================================*/
+#define ICU_START_SEC_CODE
+#include "Icu_MemMap.h"
+/**
+ * @brief 
+ * 
+ * @param instance 
+ * @param channel 
+ * @param bOverflow 
+ */
+static inline void Emios_Icu_Ip_ReportEvents(uint8 instance, uint8 hwChannel, boolean bOverflow);
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON))
+/**
+ * @brief 
+ * 
+ * @param instance 
+ * @param channel 
+ * @param bOverflow 
+ */
+static inline void Emios_Icu_Ip_ReportOverflow(uint8 instance, uint8 hwChannel, boolean bOverflow);
+#endif
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/**
+* @brief      Emios_Icu_Ip_GetCaptureRegB
+* @details    This function returns the register B of the given eMIOS Unified Channel
+* @param[in]  hwChannel  - eMIOS encoded hardware channel
+* @return     uint32 - Captured value of the register B
+*
+* @api
+*/
+static inline uint32 Emios_Icu_Ip_GetCaptureRegB
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/**
+* @brief      Emios_Icu_Ip_GetCaptureRegA
+* @details    This function returns the register A of the given eMIOS Unified Channel
+* @param[in]  hwChannel  - eMIOS encoded hardware channel
+* @return     uint32 - Captured value of the register A
+*
+* @api
+*/
+static inline uint32 Emios_Icu_Ip_GetCaptureRegA
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+#endif /* (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) */
+
+/**
+* @brief      Emios_Icu_Ip_ClearStatusFlags
+* @details    Clear the flags set only for selected interrupts that are enabled
+*
+* @param[in]      hwChannel    - eMIOS Hardware Channel
+* @param[in]      u32BitMask   - flags to be cleared
+*
+* @return void
+*
+**/
+static inline void Emios_Icu_Ip_ClearStatusFlags
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    uint32 u32BitMask
+);
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+/**
+* @brief      Icu driver function that checks the overflow flag
+* @details    This function returns clock mode of channel
+*
+* @param[in]  hwChannel - hardware channel eMIOS
+*
+* @return     uint32
+*
+* @api
+*/
+static inline uint32 Emios_Icu_Ip_GetChannelClockMode
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+
+static inline void Emios_Icu_Ip_SignalMeasurementStore(uint8  instance,
+                                                       uint8  hwChannel,
+                                                       eMios_Icu_ValueType activePulseWidth,
+                                                       eMios_Icu_ValueType period,
+                                                       boolean bOverflow);
+                                                       
+/**
+ @brief      This function is used to read the period values for channels
+ @details    This function returns the Counter Value based on the configuration
+ @param[in]  hwChannel - hardware channel eMIOS
+ @pre        Icu_Init must be called before.
+*/
+static inline uint32 Emios_Icu_Ip_ReadCounterBus
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+
+static inline void Emios_Icu_Ip_SignalMeasurementWithIPWMMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+);
+
+static inline void Emios_Icu_Ip_SignalMeasurementWithIPMMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+);
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+static inline void Emios_Icu_Ip_SignalMeasurementWithSAICMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+);
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+/**
+* @brief      Icu driver function that handles the masterbus interrupt of eMIOS channel.
+* @details    This function:
+*              - Report overflow to notify if necessary
+*
+* @param[in]  hwChannel - eMIOS hardware channel
+*
+*/
+static inline eMios_Icu_Ip_BusType Emios_Icu_Ip_ValidateChannelUsedMasterbus
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+#endif
+
+/**
+* @brief      Emios_Icu_Ip_GetStatusFlags
+* @details    Returns the flags set only for the enabled interrupts
+*
+* @param[in]   hwChannel - eMIOS Hardware Channel
+*
+* @return      uint32 - Flags set for enabled interrupts
+**/
+static inline uint32 Emios_Icu_Ip_GetStatusFlags
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+/**
+* @brief      Icu driver function that handles the masterbus interrupt of eMIOS channel.
+* @details    This function:
+*              - Report overflow to notify if necessary
+*
+* @param[in]  hwChannel - eMIOS hardware channel
+*/
+static inline void Emios_Icu_Ip_ProcessMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+);
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API )
+/**
+ * @brief      Icu driver function that handles the timestamp measurement type interrupt.
+ * @details    This service is  called when an  interrupt is recognized  as a Timestamp
+ *             Measurement type.
+ *
+ * @param[in]  hwChannel - The index of ICU channel for current configuration structure
+ * @param[in]  bOverflow        Parameter that indicates the source of report is an overflow
+ * @implements Emios_Icu_Ip_TimestampHandler_Activity
+*/
+static void Emios_Icu_Ip_TimestampHandler(uint8        instance,
+                                          uint8        hwChannel,
+                                          const eMios_Icu_ValueType *bufferPtr,
+                                          boolean      bOverflow);
+#endif /* STD_ON == EMIOS_ICU_IP_TIMESTAMP_API */                                 
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+extern void Emios_Icu_Ip_SetActivation
+(
+    uint8 instance,
+    uint8 hwChannel,
+    eMios_Icu_Ip_EdgeType edge
+);
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+/*==================================================================================================
+*                                       LOCAL FUNCTIONS
+==================================================================================================*/
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline uint32 Emios_Icu_Ip_GetCaptureRegB
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    /*return the value of shadow register*/
+    return s_emiosBase[instance]->CH.UC[hwChannel].B;
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline uint32 Emios_Icu_Ip_GetCaptureRegA
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif
+    /*get the value of A shadow register*/
+    return s_emiosBase[instance]->CH.UC[hwChannel].A;
+}
+#endif /* (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) */
+
+static inline void Emios_Icu_Ip_ClearStatusFlags
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    uint32 u32BitMask
+)
+{
+    s_emiosBase[instance]->CH.UC[hwChannel].S |= (u32BitMask & (eMIOS_S_OVR_MASK | eMIOS_S_OVFL_MASK | eMIOS_S_FLAG_MASK));
+}
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline uint32 Emios_Icu_Ip_GetChannelClockMode
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    /*return the value of mode selection*/
+    return (s_emiosBase[instance]->CH.UC[hwChannel].C & eMIOS_C_MODE_MASK);
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline void Emios_Icu_Ip_SignalMeasurementStore(uint8  instance,
+                                                       uint8  hwChannel,
+                                                       eMios_Icu_ValueType activePulseWidth,
+                                                       eMios_Icu_ValueType period,
+                                                       boolean bOverflow)
+{
+    /* Saving measurement data into state variable for later usage */
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aActivePulseWidth = activePulseWidth;
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aPeriod = period;
+
+    
+    /* Calling HLD logical channel status changer */
+    if(NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].logicChStateCallback)
+    {
+        eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].logicChStateCallback(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callbackParam, (1U << 1), TRUE);
+    }
+    
+    /* Calling HLD for reporting wakeup and overflow */
+    Emios_Icu_Ip_ReportOverflow(instance, hwChannel, bOverflow);
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline uint32 Emios_Icu_Ip_ReadCounterBus
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    uint32 u32Period = (uint32)0u;
+    uint32 u32BusChannelClockMode = (uint32)0u;
+
+    /* Get eMiosBus of hardware channel */
+    eMios_Icu_Ip_BusType u32ChannelEmiosBus = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected;
+
+    switch (u32ChannelEmiosBus)
+    {
+        case EMIOS_ICU_BUS_INTERNAL_COUNTER:
+        {
+            u32Period = EMIOS_ICU_IP_COUNTER_MASK;
+        }
+        break;
+
+        case EMIOS_ICU_BUS_DIVERSE:
+        {
+            if (EMIOS_ICU_IP_CHANNEL_7 >= hwChannel)
+            {
+                u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_0);
+                /* eMIOS Counter Bus_B Channel (EMIOS_ICU_IP_CHANNEL_0) is in Modulous counter buffer or
+                Modulous counter mode */
+                if (EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_0);
+                }
+                else
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_0);
+                }
+            }
+
+            /* eMIOS Channel configured is using Counter Bus_C */
+            else if (EMIOS_ICU_IP_CHANNEL_15 >= hwChannel)
+            {
+                u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_8);
+                /* eMIOS Counter Bus_C Channel (EMIOS_ICU_IP_CHANNEL_8) is in Modulous counter buffer or
+                 Modulous counter mode */
+                if (EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_8);
+                }
+                else
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_8);
+                }
+            }
+
+            /* eMIOS Channel configured is using Counter Bus_D */
+            else if (EMIOS_ICU_IP_CHANNEL_23 >= hwChannel )
+            {
+                u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_16);
+                /* eMIOS Counter Bus_D Channel (EMIOS_ICU_IP_CHANNEL_16) is in Modulous counter buffer or
+                 Modulous counter mode */
+                if (EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_16);
+                }
+                else
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_16);
+                }
+            }
+
+#if (STD_ON == EMIOS_ICU_IP_CHANNEL_24_USED)
+            /* eMIOS Channel configured is using Counter Bus_E */
+            else if (EMIOS_ICU_IP_CHANNEL_31  >= hwChannel)
+            {
+                u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_24);
+                /* eMIOS Counter Bus_E Channel (EMIOS_ICU_IP_CHANNEL_24) is in Modulous counter buffer or
+                 Modulous counter mode */
+                if (EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_24);
+                }
+                else
+                {
+                    u32Period= (uint32)Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_24);
+                }
+            }
+#endif
+            else
+            {
+                /* Do Nothing */
+            }
+        }
+        break;
+
+        case EMIOS_ICU_BUS_A:
+        {
+            /* Get clock mode */
+            u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_23);
+
+            if(EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+            {
+                u32Period  = (uint32) Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_23);
+            }
+            else
+            {
+                u32Period  = (uint32) Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_23);
+            }
+        }
+        break;
+
+        case EMIOS_ICU_BUS_F:
+        {
+            /* Get clock mode of bus F */
+            u32BusChannelClockMode = Emios_Icu_Ip_GetChannelClockMode(instance, EMIOS_ICU_IP_CHANNEL_22);
+
+            if(EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == u32BusChannelClockMode)
+            {
+                u32Period  = (uint32) Emios_Icu_Ip_GetCaptureRegA(instance, EMIOS_ICU_IP_CHANNEL_22);
+            }
+            else
+            {
+                u32Period  = (uint32) Emios_Icu_Ip_GetCaptureRegB(instance, EMIOS_ICU_IP_CHANNEL_22);
+            }
+        }
+        break;
+
+        default:
+        {
+            /* Rule 16.1 requires switch well-formed */
+        }
+        break;
+    }
+
+    /* return u32Period */
+    return (u32Period);
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline void Emios_Icu_Ip_SignalMeasurementWithIPWMMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+)
+{
+    uint8 u8ChIndex = eMios_Icu_Ip_IndexInChState[instance][hwChannel];
+    eMios_Icu_ValueType activePulseWidth;
+    eMios_Icu_ValueType IcuPeriod;
+    eMios_Icu_ValueType Bus_Period;
+    eMios_Icu_Ip_MeasType nMeasurement_property = eMios_Icu_Ip_ChState[u8ChIndex].measurement;
+    
+    eMios_Icu_ValueType IcuTempA = (eMios_Icu_ValueType)Emios_Icu_Ip_GetCaptureRegA(instance, hwChannel);
+    eMios_Icu_ValueType IcuTempB = (eMios_Icu_ValueType)Emios_Icu_Ip_GetCaptureRegB(instance, hwChannel);
+
+    if ((EMIOS_ICU_HIGH_TIME == nMeasurement_property) || \
+        (EMIOS_ICU_LOW_TIME == nMeasurement_property))
+    {
+        if (IcuTempA > IcuTempB)
+        {
+            activePulseWidth = (eMios_Icu_ValueType)(IcuTempA - IcuTempB);
+        }
+        else /*Counter overflow Case*/
+        {
+            Bus_Period = (eMios_Icu_ValueType)Emios_Icu_Ip_ReadCounterBus(instance, hwChannel);
+            activePulseWidth = (eMios_Icu_ValueType)(IcuTempA + ((uint32)Bus_Period - IcuTempB) + 1U);
+        }
+
+        Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, activePulseWidth, 0U, bOverflow);
+    }
+    /* Duty cycle */
+    else
+    {
+        /* Check if a complete signal was acquired */
+        if (EMIOS_ICU_MEASUREMENT_PENDING == eMios_Icu_Ip_aeInt_Counter[u8ChIndex])
+        {
+            /* Mark that the complete signal was acquired */
+            eMios_Icu_Ip_aeInt_Counter[u8ChIndex] = EMIOS_ICU_MEASUREMENT_DUTY;
+            /* Report event and possible overflow to HLD or IPL user overflow notification */
+            Emios_Icu_Ip_ReportOverflow (instance, hwChannel, bOverflow);
+        }
+        else
+        {
+            /* Compute Period of the signal */
+            if (IcuTempB > eMios_Icu_Ip_TimeStart[u8ChIndex])
+            {
+                IcuPeriod = IcuTempB - eMios_Icu_Ip_TimeStart[u8ChIndex];
+            }
+            else     /*Counter overflow Case */
+            {
+                Bus_Period = (eMios_Icu_ValueType)Emios_Icu_Ip_ReadCounterBus(instance, hwChannel);
+                IcuPeriod = (eMios_Icu_ValueType)\
+                (IcuTempB + ((uint32)Bus_Period - eMios_Icu_Ip_TimeStart[u8ChIndex]) + 1U);
+            }
+            activePulseWidth = eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex];
+
+            if (EMIOS_ICU_DUTY_CYCLE == nMeasurement_property)
+            {
+                Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, activePulseWidth, IcuPeriod, bOverflow);
+            }
+            else if (EMIOS_ICU_PERIOD_TIME == nMeasurement_property)
+            {
+                Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, 0U, IcuPeriod, bOverflow);
+            }
+            else
+            {
+                /* Nothing to do */
+            }
+        }
+    }
+
+    if (IcuTempA > IcuTempB)
+    {
+        eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex] = (eMios_Icu_ValueType)(IcuTempA - IcuTempB);
+    }
+    else /*Counter overflow Case */
+    {
+        Bus_Period = (eMios_Icu_ValueType)Emios_Icu_Ip_ReadCounterBus(instance, hwChannel);
+        eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex] = (eMios_Icu_ValueType)(IcuTempA + ((uint32)Bus_Period - IcuTempB) + 1U);
+    }
+    eMios_Icu_Ip_TimeStart[u8ChIndex] = (eMios_Icu_ValueType)IcuTempB;
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+static inline void Emios_Icu_Ip_SignalMeasurementWithIPMMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+)
+{
+    eMios_Icu_ValueType IcuPeriod;
+    eMios_Icu_ValueType Bus_Period;
+    eMios_Icu_ValueType IcuTempA = (eMios_Icu_ValueType)Emios_Icu_Ip_GetCaptureRegA(instance, hwChannel);
+    eMios_Icu_ValueType IcuTempB = (eMios_Icu_ValueType)Emios_Icu_Ip_GetCaptureRegB(instance, hwChannel);
+
+    if (IcuTempA > IcuTempB)
+    {
+        IcuPeriod = (eMios_Icu_ValueType)(IcuTempA - IcuTempB);
+    }
+    else     /*Counter overflow Case*/
+    {
+        Bus_Period = (eMios_Icu_ValueType)Emios_Icu_Ip_ReadCounterBus(instance, hwChannel);
+        IcuPeriod = (eMios_Icu_ValueType)(IcuTempA + ((uint32)Bus_Period - IcuTempB) + 1U);
+    }
+    Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, 0U, IcuPeriod, bOverflow);
+}
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+static inline void Emios_Icu_Ip_SignalMeasurementWithSAICMode
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+)
+{
+    uint8 u8ChIndex = eMios_Icu_Ip_IndexInChState[instance][hwChannel];
+    eMios_Icu_ValueType activePulseWidth;
+    eMios_Icu_ValueType IcuPeriod;
+    eMios_Icu_ValueType Bus_Period;
+    eMios_Icu_Ip_MeasType nMeasurement_property = eMios_Icu_Ip_ChState[u8ChIndex].measurement;
+    eMios_Icu_ValueType IcuTempA = (eMios_Icu_ValueType)Emios_Icu_Ip_GetCaptureRegA(instance, hwChannel);
+    eMios_Icu_ValueType Previous_Value;
+    eMios_Icu_ValueType Pulse_Width;
+ 
+    Emios_Icu_Ip_SetActivation (instance, hwChannel, EMIOS_OPPOSITE_EDGES);
+
+    if (EMIOS_ICU_MEASUREMENT_PENDING == eMios_Icu_Ip_aeInt_Counter[u8ChIndex])
+    {
+        /* store the first value */
+        eMios_Icu_Ip_TimeStart[u8ChIndex] = IcuTempA;
+        eMios_Icu_Ip_aeInt_Counter[u8ChIndex] = EMIOS_ICU_MEASUREMENT_DUTY;
+    }
+    else
+    {
+        Previous_Value = eMios_Icu_Ip_TimeStart[u8ChIndex];
+        /* if first value is greater than the second value */
+        if (IcuTempA < Previous_Value)
+        {
+            Bus_Period = (eMios_Icu_ValueType)Emios_Icu_Ip_ReadCounterBus(instance, hwChannel);
+            Pulse_Width = (Bus_Period - Previous_Value) + IcuTempA + 1U;
+        }
+        else
+        {
+            Pulse_Width = IcuTempA - Previous_Value;
+        }
+
+        /* HIGH TIME or LOW TIME measurement */
+        if ((EMIOS_ICU_HIGH_TIME == nMeasurement_property) ||   \
+            (EMIOS_ICU_LOW_TIME == nMeasurement_property)
+           )
+        {
+            activePulseWidth = Pulse_Width;
+            /* clear to measure next LOW/HIGH pulse */
+            eMios_Icu_Ip_aeInt_Counter[u8ChIndex] = EMIOS_ICU_MEASUREMENT_PENDING;
+            Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, activePulseWidth, (eMios_Icu_ValueType)0U, bOverflow);
+        }
+        /* Duty Cycle */
+        else
+        {
+            /* DUTYCYCLE or PERIOD measurement */
+            if (EMIOS_ICU_MEASUREMENT_DUTY == eMios_Icu_Ip_aeInt_Counter[u8ChIndex])
+            {
+                eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex] = Pulse_Width;
+                eMios_Icu_Ip_aeInt_Counter[u8ChIndex] = EMIOS_ICU_MEASUREMENT_PERIOD;
+                if(eMios_Icu_Ip_ChState[u8ChIndex].callback != NULL_PTR)
+                {
+                    eMios_Icu_Ip_ChState[u8ChIndex].callback(eMios_Icu_Ip_ChState[u8ChIndex].callbackParam, bOverflow);
+                }
+            }
+            else
+            {
+                /* eMios_Icu_Ip_aeInt_Counter is for period */
+                IcuPeriod = eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex] + Pulse_Width;
+                activePulseWidth = eMios_Icu_Ip_CapturedActivePulseWidth[u8ChIndex];
+                
+                /* set to Duty to find active pulse width next time */
+                eMios_Icu_Ip_aeInt_Counter[u8ChIndex] = EMIOS_ICU_MEASUREMENT_DUTY;
+                if (EMIOS_ICU_DUTY_CYCLE == nMeasurement_property)
+                {
+                    Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, activePulseWidth, IcuPeriod, bOverflow);
+                }
+                else if (EMIOS_ICU_PERIOD_TIME == nMeasurement_property)
+                {
+                    Emios_Icu_Ip_SignalMeasurementStore(instance, hwChannel, (eMios_Icu_ValueType)0U, IcuPeriod, bOverflow);
+                }
+                else
+                {
+                    /**/
+                }
+            }
+            /* store for next time */
+            eMios_Icu_Ip_TimeStart[u8ChIndex] = IcuTempA;
+        }
+    }
+}
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+#endif /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+static inline eMios_Icu_Ip_BusType Emios_Icu_Ip_ValidateChannelUsedMasterbus
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    eMios_Icu_Ip_BusType busResult = (eMios_Icu_Ip_BusType)EMIOS_ICU_BUS_INTERNAL_COUNTER;
+    
+    /*change bus if it is not the mode of no measurement*/
+    if (EMIOS_ICU_MODE_NO_MEASUREMENT != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].channelMode)
+    {
+        busResult = (eMios_Icu_Ip_BusType)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].BusSelected;
+    }
+    return busResult;
+}
+#endif
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_API )
+static void Emios_Icu_Ip_TimestampHandler(uint8        instance,
+                                          uint8        hwChannel,
+                                          const eMios_Icu_ValueType *bufferPtr,
+                                          boolean      bOverflow)
+{
+    Emios_Icu_Ip_ReportOverflow(instance, hwChannel, bOverflow);
+    
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer[eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex] = bufferPtr[0U];
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex++;
+
+    if (eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex >= eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize)
+    {
+        if(EMIOS_ICU_CIRCULAR_BUFFER == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType)
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex = 0U;
+        }
+        else
+        {
+            Emios_Icu_Ip_StopTimestamp(instance, hwChannel);
+            if (NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].logicChStateCallback)
+            {
+                eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].logicChStateCallback(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callbackParam, (1U << 3), FALSE);
+            } 
+
+        }
+    }
+
+    if (0U != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+    {
+        eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount++;
+        if (eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount >= eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount = 0U;
+            
+            /* Call User Notification Function for IPL and HLD */
+            if ((NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification) && \
+                ((boolean)TRUE == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].notificationEnable))
+            {
+                eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification();
+            }
+        }
+    }
+}
+#endif  /* EMIOS_ICU_IP_TIMESTAMP_API */
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+static inline void Emios_Icu_Ip_ProcessMasterBusInterrupt
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    uint8 nCounter;
+    boolean bOverflowUsingMasterbus = FALSE;
+    eMios_Icu_Ip_ModeType nMeasMode;
+    eMios_Icu_Ip_BusType BusSelected;
+
+    for(nCounter=0U; nCounter < EMIOS_ICU_IP_NUM_OF_CHANNELS; nCounter++)
+    {
+        if (eMios_Icu_Ip_IndexInChState[instance][nCounter] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED)
+        {
+            bOverflowUsingMasterbus = FALSE;
+            BusSelected = Emios_Icu_Ip_ValidateChannelUsedMasterbus(instance, nCounter);
+            switch(BusSelected)
+            {
+                case EMIOS_ICU_BUS_DIVERSE:
+                {
+                    if
+                    (
+                        ((hwChannel % ((uint8)8U)) == 0U) && \
+                        (nCounter <= (hwChannel + ((uint8)7U))) && (nCounter >= (hwChannel + ((uint8)1U)))
+                    )
+                    {
+                        bOverflowUsingMasterbus = TRUE;
+                    }
+                }
+                break;
+                case EMIOS_ICU_BUS_A:
+                {
+                    if(EMIOS_ICU_IP_CHANNEL_23 == hwChannel)
+                    {
+                        bOverflowUsingMasterbus = TRUE;
+                    }
+                }
+                break;
+                case EMIOS_ICU_BUS_F:
+                {
+                    if(EMIOS_ICU_IP_CHANNEL_22 == hwChannel)
+                    {
+                        bOverflowUsingMasterbus = TRUE;
+                    }
+                }
+                break;
+                default:
+                {
+                    /* Do nothing. */
+                }
+                break;
+            }
+            if(TRUE == bOverflowUsingMasterbus)
+            {
+                nMeasMode = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][nCounter]].channelMode;
+                if((EMIOS_ICU_MODE_TIMESTAMP == nMeasMode) || (EMIOS_ICU_MODE_SIGNAL_MEASUREMENT == nMeasMode))
+                {
+                    Emios_Icu_Ip_ReportOverflow(instance, nCounter, TRUE);
+                }
+            }
+        }
+    }
+}
+#endif
+
+static inline uint32 Emios_Icu_Ip_GetStatusFlags
+(
+    const uint8 instance,
+    const uint8 hwChannel
+)
+{
+    /*return the value of status*/
+    return s_emiosBase[instance]->CH.UC[hwChannel].S ;
+}
+
+
+static inline void Emios_Icu_Ip_ReportEvents(uint8 instance, uint8 hwChannel, boolean bOverflow)
+{  
+    /* Calling HLD Report Events for the logical channel */
+    if(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callback != NULL_PTR)
+    {
+        eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callback(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callbackParam, bOverflow);
+    }
+    else
+    {
+        /* Calling Notification for the IPL channel */
+        if ((NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification) && \
+           ((boolean)TRUE == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].notificationEnable))
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification();
+        }
+        
+        /* Calling User Overflow Notification for the IPL channel */
+        if ( bOverflow && (NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosOverflowNotification))
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosOverflowNotification();
+        }
+    }
+}
+
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON))
+static inline void Emios_Icu_Ip_ReportOverflow(uint8 instance, uint8 hwChannel, boolean bOverflow)
+{
+    /* Calling HLD Report wakeup and overflow for the logical channel */
+    if(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callback != NULL_PTR)
+    {
+        eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callback(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].callbackParam, bOverflow);
+    }
+    else
+    {
+        /* Calling User Overflow Notification for the IPL channel */
+        if ((NULL_PTR != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosOverflowNotification) && bOverflow)
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosOverflowNotification();
+        }
+    }
+}
+#endif
+
+/*==================================================================================================
+*                                        GLOBAL FUNCTIONS
+==================================================================================================*/
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+void Emios_Icu_Ip_SignalMeasurementHandler
+(
+    const uint8 instance,
+    const uint8 hwChannel,
+    boolean bOverflow
+)
+{
+    eMios_Icu_Ip_UCModeType eMios_OperationMode;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(hwChannel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+    DevAssert(eMios_Icu_Ip_IndexInChState[instance][hwChannel] < EMIOS_ICU_IP_NUM_OF_CHANNELS_USED);
+#endif 
+
+    eMios_OperationMode = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].operationMode;
+    switch(eMios_OperationMode)
+    { 
+        case EMIOS_ICU_IPWM :
+        {
+            Emios_Icu_Ip_SignalMeasurementWithIPWMMode(instance, hwChannel, bOverflow);
+        }
+        break;
+        
+        case EMIOS_ICU_IPM :
+        {
+            Emios_Icu_Ip_SignalMeasurementWithIPMMode(instance, hwChannel, bOverflow);
+        }
+        break;
+#if (STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE)
+        case EMIOS_ICU_SAIC :
+        {
+            Emios_Icu_Ip_SignalMeasurementWithSAICMode(instance, hwChannel, bOverflow);
+        }
+        break;
+#endif  /* STD_ON == EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE */
+        default:
+        {
+                /* Do nothing. */
+        }
+        break;
+    }
+}
+#endif  /* EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON */
+
+/* @implements Emios_Icu_Ip_IrqHandler_Activity */
+void Emios_Icu_Ip_IrqHandler(uint8 instance, uint8 channel)
+{
+    eMios_Icu_Ip_ModeType nMeasMode;
+    uint32      u32RegCSR;
+
+#if (STD_ON == EMIOS_ICU_IP_DEV_ERROR_DETECT)
+    DevAssert(instance < EMIOS_ICU_IP_INSTANCE_COUNT);
+    DevAssert(channel < EMIOS_ICU_IP_NUM_OF_CHANNELS);
+#endif
+
+    uint8 u8ChIndex = eMios_Icu_Ip_IndexInChState[instance][channel];
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+    uint32 u32RegCCR = s_emiosBase[instance]->CH.UC[channel].C;
+#endif    
+    boolean     bOverflow    = FALSE;
+    boolean     bEnableInter = FALSE;
+    /* Read UC Status Register */
+    u32RegCSR = Emios_Icu_Ip_GetStatusFlags(instance, channel);
+
+    if (eMIOS_C_FEN_MASK == (s_emiosBase[instance]->CH.UC[channel].C & eMIOS_C_FEN_MASK))
+    {
+        /* Note: what if this channel is Counter Bus -> MCL must clear the flags. */
+        Emios_Icu_Ip_ClearStatusFlags(instance, channel, u32RegCSR);
+        bEnableInter = TRUE;
+    }
+
+    /* MCL common ISR checks for spurios interrupts already */
+    if(u8ChIndex < (uint8)EMIOS_ICU_IP_NUM_OF_CHANNELS_USED)
+    {
+        if((EMIOS_ICU_MODE_NO_MEASUREMENT != eMios_Icu_Ip_ChState[u8ChIndex].channelMode) && bEnableInter)
+        {
+#if (EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API == STD_OFF)
+            bOverflow = ((eMIOS_S_OVFL_MASK == (u32RegCSR & eMIOS_S_OVFL_MASK)) ? TRUE : FALSE);
+#endif
+            nMeasMode = eMios_Icu_Ip_ChState[u8ChIndex].channelMode;
+            switch (nMeasMode)
+            {
+                case EMIOS_ICU_MODE_SIGNAL_EDGE_DETECT:
+                {
+                    Emios_Icu_Ip_ReportEvents (instance, channel, bOverflow);
+                }
+                break;
+#if (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)
+                case EMIOS_ICU_MODE_TIMESTAMP:
+                {
+                    if(EMIOS_ICU_MODE_WITHOUT_DMA == eMios_Icu_Ip_ChState[u8ChIndex].dmaMode)
+                    {
+                        /* Copy the Counter value in the Timestamp Buffer. */
+                        eMios_Icu_Ip_BufferPtr[u8ChIndex] = (eMios_Icu_ValueType)s_emiosBase[instance]->CH.UC[channel].A;
+
+                        /* Call timestamp handler. */
+                        Emios_Icu_Ip_TimestampHandler(instance, channel, &eMios_Icu_Ip_BufferPtr[u8ChIndex], bOverflow);
+                    }
+#if (EMIOS_ICU_IP_TIMESTAMP_USES_DMA == STD_ON)
+                    else
+                    {
+                        /* Note: - look if the existing EMIOSs hardware need this branch. */
+                        if(eMios_Icu_Ip_ChState[u8ChIndex].callback != NULL_PTR)
+                        {
+                            eMios_Icu_Ip_ChState[u8ChIndex].callback(eMios_Icu_Ip_ChState[u8ChIndex].callbackParam, bOverflow);
+                        }
+                    }
+#endif
+                }
+                break;
+#endif /* EMIOS_ICU_IP_TIMESTAMP_API == STD_ON */
+
+#if (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON)
+                case EMIOS_ICU_MODE_SIGNAL_MEASUREMENT:
+                {
+                    Emios_Icu_Ip_SignalMeasurementHandler(instance, channel, bOverflow);
+                }
+                break;
+#endif
+#if (EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON)
+                case EMIOS_ICU_MODE_EDGE_COUNTER:
+                {
+                    /* Calling HLD Report Wakeup and Overflow for the logical channel */
+                    /* Note: - actual version of emios does not have IRQ for overflow, in some configuration this will not get executed */
+                    Emios_Icu_Ip_ReportOverflow(instance, channel, TRUE);
+                }
+                break;
+#endif
+                default:
+                {
+                    /* Rule 16.1 requires switch well-formed */
+                }
+                break;
+            }
+        }
+        else
+        {
+            /* Nothing to do */
+        }
+    }
+#if ((EMIOS_ICU_IP_TIMESTAMP_API == STD_ON)||(EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON))
+    else if ((uint8)EMIOS_ICU_IP_MASTERBUS_CHANNEL_USED == u8ChIndex)
+    {
+        if(((0U == (channel & (uint8)EMIOS_ICU_IP_CB_DIVERSE)) || (EMIOS_ICU_IP_CHANNEL_22 == channel) || (EMIOS_ICU_IP_CHANNEL_23 == channel)) \
+            && (EMIOS_ICU_IP_MCB_INT_CLOCK_U32 == (u32RegCCR & eMIOS_C_MODE_MASK)))
+        {
+            Emios_Icu_Ip_ProcessMasterBusInterrupt(instance, channel);
+        }
+    }
+#endif
+    else 
+    {
+        /* Nothing to do */
+    }
+}
+
+#if (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL)
+/*   @implements  Emios_Icu_Ip_TimestampDmaProcessing */
+void Emios_Icu_Ip_TimestampDmaProcessing(uint8 instance, uint8 hwChannel)
+{
+    uint32 crtIterCount;
+    uint16 noOfBufferElemToFill = 0U;
+
+    Dma_Ip_LogicChannelTransferListType Dma_IpChUpdateDestAddress[1U];
+    Dma_Ip_LogicChannelTransferListType Dma_IpChUpdateIterCount[2U];
+
+    Dma_Ip_GetLogicChannelParam(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_GET_BEGIN_ITER_COUNT, &crtIterCount);  
+   
+    eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex += (uint16)crtIterCount;
+    noOfBufferElemToFill = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize - eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex;
+
+    /* Handling notification*/
+    if (0U != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+    {
+        eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount += (uint16)crtIterCount;
+        if  (eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount == eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount = 0U;
+            /* Call User Notification Function and/or Wakeup Function */
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMiosChannelNotification();
+        }
+    }
+
+    if (0U == noOfBufferElemToFill)
+    {
+        if ((uint8) EMIOS_ICU_CIRCULAR_BUFFER ==  eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].timestampBufferType)
+        {
+            eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferIndex = 0U;
+            if ((eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify < eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize) &&
+            (0U != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify))
+            {
+                Dma_IpChUpdateDestAddress[0U].Param = DMA_IP_CH_SET_DESTINATION_ADDRESS;
+                Dma_IpChUpdateDestAddress[0U].Value = (uint32)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBuffer;
+                Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateDestAddress, 1U);
+            }
+
+            if ((eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferSize > (eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify - eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount)) &&
+                (0U != eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify))
+            {
+                Dma_IpChUpdateIterCount[0U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+                Dma_IpChUpdateIterCount[0U].Value = (uint32)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify - (uint32)eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aNotifyCount;
+                Dma_IpChUpdateIterCount[1U].Param = DMA_IP_CH_SET_DESTINATION_SIGNED_LAST_ADDR_ADJ;
+                Dma_IpChUpdateIterCount[1U].Value = (uint32)0U;
+                Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateIterCount, 2U);
+            }
+        }
+        else /* if linear buffer stop the timestamp*/
+        {
+            Emios_Icu_Ip_StopTimestamp(instance, hwChannel);
+        }
+    }
+    else
+    {
+        if (crtIterCount < eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+        {
+            Dma_IpChUpdateIterCount[0U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+            Dma_IpChUpdateIterCount[0U].Value = eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify;
+            Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateIterCount, 1U);
+        }
+        if (noOfBufferElemToFill < eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].eMios_Icu_Ip_aBufferNotify)
+        {
+            Dma_IpChUpdateIterCount[0U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+            Dma_IpChUpdateIterCount[0U].Value = noOfBufferElemToFill;
+            Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateIterCount, 1U);
+        }
+    }
+}
+#endif /* (STD_ON == EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL) */
+
+#if (STD_ON == EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL)
+/*   @implements  Emios_Icu_Ip_TimestampDmaProcessing */
+void Emios_Icu_Ip_SignalMeasurementDmaProcessing(uint8 instance, uint8 hwChannel)
+{
+    uint8 u8index;
+    uint32 BufferValue1;
+    uint32 BufferValue2;
+    uint32 BufferValue3;
+    Dma_Ip_LogicChannelTransferListType Dma_IpChUpdateDestAddress[1U];
+    Dma_Ip_LogicChannelTransferListType Dma_IpChUpdateIterCount[1U];
+
+    uint32 Emios_Icu_Ip_aActivePulseWidth;
+    uint32 Emios_Icu_Ip_aPeriod;
+
+    Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_CLEAR_HARDWARE_REQUEST);
+
+    if ((uint32)1 == Emios_Icu_Ip_aIsSecondInterrupt[eMios_Icu_Ip_IndexInChState[instance][hwChannel]])
+    {
+        BufferValue1 = Emios_Icu_Ip_aFirstEdgeTimeStamp[eMios_Icu_Ip_IndexInChState[instance][hwChannel]];
+        BufferValue2 = Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][0];
+        BufferValue3 = Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][1];
+        Dma_IpChUpdateDestAddress[0U].Param = DMA_IP_CH_SET_DESTINATION_ADDRESS;
+        Dma_IpChUpdateDestAddress[0U].Value = (uint32)&Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][0];
+        Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateDestAddress, 1U);
+        Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_SET_HARDWARE_REQUEST);
+
+        /* Store the aPeriod value */
+
+        if(BufferValue2 > BufferValue1)
+        {
+            Emios_Icu_Ip_aActivePulseWidth = BufferValue2 - BufferValue1;
+        }
+        else
+        {
+            Emios_Icu_Ip_aActivePulseWidth = (EMIOS_ICU_IP_COUNTER_MASK - BufferValue1) + BufferValue2;
+        }
+
+        /* Store the aPeriod value */
+        if(BufferValue3 > BufferValue1)
+        {
+            Emios_Icu_Ip_aPeriod =  BufferValue3 - BufferValue1;
+        }
+        else
+        {
+            Emios_Icu_Ip_aPeriod = (EMIOS_ICU_IP_COUNTER_MASK- BufferValue1) + BufferValue3;
+        }
+        Emios_Icu_Ip_SetPWandPeriod(instance, hwChannel, Emios_Icu_Ip_aActivePulseWidth, Emios_Icu_Ip_aPeriod);
+
+        Emios_Icu_Ip_aFirstEdgeTimeStamp[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][1];
+    }
+    else
+    {
+        Emios_Icu_Ip_aIsSecondInterrupt[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = (uint16)1;
+        Emios_Icu_Ip_aFirstEdgeTimeStamp[eMios_Icu_Ip_IndexInChState[instance][hwChannel]] = Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][0];
+        Dma_IpChUpdateDestAddress[0U].Param = DMA_IP_CH_SET_DESTINATION_ADDRESS;
+        Dma_IpChUpdateDestAddress[0U].Value = (uint32)&Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][0];
+        Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateDestAddress, 1U);
+        Dma_IpChUpdateIterCount[0U].Param = DMA_IP_CH_SET_MAJORLOOP_COUNT;
+        Dma_IpChUpdateIterCount[0U].Value = (uint16)EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT;
+        Dma_Ip_SetLogicChannelTransferList(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, Dma_IpChUpdateIterCount, 1U);
+        Dma_Ip_SetLogicChannelCommand(eMios_Icu_Ip_ChState[eMios_Icu_Ip_IndexInChState[instance][hwChannel]].dmaChannel, DMA_IP_CH_SET_HARDWARE_REQUEST);
+        for(u8index = 0U; u8index < EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT; u8index++)
+        {
+            Emios_Icu_Ip_aDmaBuffer[eMios_Icu_Ip_IndexInChState[instance][hwChannel]][u8index] = (uint16)0;
+        }
+        Emios_Icu_Ip_SetActivation(instance, hwChannel, EMIOS_ICU_BOTH_EDGES);
+    }
+}
+#endif
+
+#define ICU_STOP_SEC_CODE
+#include "Icu_MemMap.h"
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_Cfg.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_Cfg.h
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_CFG_H
+#define EMIOS_ICU_IP_CFG_H
+
+/**
+ *   @file    Emios_Icu_Ip_Cfg.h
+ *   @version 3.0.0
+ *
+ *   @brief   AUTOSAR Icu - contains the data exported by the ICU module.
+ *   @details Contains the information that will be exported by the module, as requested by AUTOSAR.
+ *
+ *   @addtogroup emios_icu_ip EMIOS IPL
+ *   @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+/*==================================================================================================
+*                                          INCLUDE FILES
+* 1) system and project includes
+* 2) needed interfaces from external units
+* 3) internal and external interfaces from this unit
+==================================================================================================*/
+/* Include all variants header files. */
+#include "Emios_Icu_Ip_SA_Init_PBcfg.h"
+
+/*==================================================================================================
+*                                 SOURCE FILE VERSION INFORMATION
+==================================================================================================*/
+#define EMIOS_ICU_IP_CFG_VENDOR_ID                    43
+#define EMIOS_ICU_IP_CFG_AR_RELEASE_MAJOR_VERSION     4
+#define EMIOS_ICU_IP_CFG_AR_RELEASE_MINOR_VERSION     7
+#define EMIOS_ICU_IP_CFG_AR_RELEASE_REVISION_VERSION  0
+#define EMIOS_ICU_IP_CFG_SW_MAJOR_VERSION             3
+#define EMIOS_ICU_IP_CFG_SW_MINOR_VERSION             0
+#define EMIOS_ICU_IP_CFG_SW_PATCH_VERSION             0
+
+/*==================================================================================================
+*                                       FILE VERSION CHECKS
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+#if (EMIOS_ICU_IP_CFG_VENDOR_ID != EMIOS_ICU_IP_SA_INIT_PBCFG_VENDOR_ID)
+    #error "Emios_Icu_Ip_Cfg.h and Emios_Icu_Ip_SA_INIT_PBcfg.h have different vendor IDs"
+#endif
+
+/* Check if  header file and Emios_Icu_Ip_SA_Init_PBcfg.h file are of the same Autosar version */
+#if ((EMIOS_ICU_IP_CFG_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_CFG_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_CFG_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_Cfg.h and Emios_Icu_Ip_SA_Init_PBcfg.h are different"
+#endif
+
+/* Check if header file and Emios_Icu_Ip_SA_Init_PBcfg.h file are of the same Software version */
+#if ((EMIOS_ICU_IP_CFG_SW_MAJOR_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_CFG_SW_MINOR_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_CFG_SW_PATCH_VERSION != EMIOS_ICU_IP_SA_INIT_PBCFG_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_Cfg.h and Emios_Icu_Ip_SA_Init_PBcfg.h are different"
+#endif
+
+/*==================================================================================================
+*                                            CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       DEFINES AND MACROS
+==================================================================================================*/
+/** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_0_USED
+    #define EMIOS_0_CH_0_USED
+#else
+    #error "EMIOS_0_CH_0 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_1_USED
+    #define EMIOS_0_CH_1_USED
+#else
+    #error "EMIOS_0_CH_1 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_2_USED
+    #define EMIOS_0_CH_2_USED
+#else
+    #error "EMIOS_0_CH_2 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_3_USED
+    #define EMIOS_0_CH_3_USED
+#else
+    #error "EMIOS_0_CH_3 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_4_USED
+    #define EMIOS_0_CH_4_USED
+#else
+    #error "EMIOS_0_CH_4 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_5_USED
+    #define EMIOS_0_CH_5_USED
+#else
+    #error "EMIOS_0_CH_5 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_6_USED
+    #define EMIOS_0_CH_6_USED
+#else
+    #error "EMIOS_0_CH_6 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_7_USED
+    #define EMIOS_0_CH_7_USED
+#else
+    #error "EMIOS_0_CH_7 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_8_USED
+    #define EMIOS_0_CH_8_USED
+#else
+    #error "EMIOS_0_CH_8 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_9_USED
+    #define EMIOS_0_CH_9_USED
+#else
+    #error "EMIOS_0_CH_9 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_10_USED
+    #define EMIOS_0_CH_10_USED
+#else
+    #error "EMIOS_0_CH_10 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_11_USED
+    #define EMIOS_0_CH_11_USED
+#else
+    #error "EMIOS_0_CH_11 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_12_USED
+    #define EMIOS_0_CH_12_USED
+#else
+    #error "EMIOS_0_CH_12 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_13_USED
+    #define EMIOS_0_CH_13_USED
+#else
+    #error "EMIOS_0_CH_13 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_14_USED
+    #define EMIOS_0_CH_14_USED
+#else
+    #error "EMIOS_0_CH_14 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_15_USED
+    #define EMIOS_0_CH_15_USED
+#else
+    #error "EMIOS_0_CH_15 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_16_USED
+    #define EMIOS_0_CH_16_USED
+#else
+    #error "EMIOS_0_CH_16 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_17_USED
+    #define EMIOS_0_CH_17_USED
+#else
+    #error "EMIOS_0_CH_17 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_18_USED
+    #define EMIOS_0_CH_18_USED
+#else
+    #error "EMIOS_0_CH_18 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_19_USED
+    #define EMIOS_0_CH_19_USED
+#else
+    #error "EMIOS_0_CH_19 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_20_USED
+    #define EMIOS_0_CH_20_USED
+#else
+    #error "EMIOS_0_CH_20 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_21_USED
+    #define EMIOS_0_CH_21_USED
+#else
+    #error "EMIOS_0_CH_21 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_0_CH_22_USED
+    #define EMIOS_0_CH_22_USED
+#else
+    #error "EMIOS_0_CH_22 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_0_USED
+    #define EMIOS_1_CH_0_USED
+#else
+    #error "EMIOS_1_CH_0 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_1_USED
+    #define EMIOS_1_CH_1_USED
+#else
+    #error "EMIOS_1_CH_1 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_2_USED
+    #define EMIOS_1_CH_2_USED
+#else
+    #error "EMIOS_1_CH_2 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_3_USED
+    #define EMIOS_1_CH_3_USED
+#else
+    #error "EMIOS_1_CH_3 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_4_USED
+    #define EMIOS_1_CH_4_USED
+#else
+    #error "EMIOS_1_CH_4 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_5_USED
+    #define EMIOS_1_CH_5_USED
+#else
+    #error "EMIOS_1_CH_5 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_6_USED
+    #define EMIOS_1_CH_6_USED
+#else
+    #error "EMIOS_1_CH_6 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_7_USED
+    #define EMIOS_1_CH_7_USED
+#else
+    #error "EMIOS_1_CH_7 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_8_USED
+    #define EMIOS_1_CH_8_USED
+#else
+    #error "EMIOS_1_CH_8 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_9_USED
+    #define EMIOS_1_CH_9_USED
+#else
+    #error "EMIOS_1_CH_9 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_10_USED
+    #define EMIOS_1_CH_10_USED
+#else
+    #error "EMIOS_1_CH_10 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_11_USED
+    #define EMIOS_1_CH_11_USED
+#else
+    #error "EMIOS_1_CH_11 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_12_USED
+    #define EMIOS_1_CH_12_USED
+#else
+    #error "EMIOS_1_CH_12 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_13_USED
+    #define EMIOS_1_CH_13_USED
+#else
+    #error "EMIOS_1_CH_13 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_14_USED
+    #define EMIOS_1_CH_14_USED
+#else
+    #error "EMIOS_1_CH_14 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_15_USED
+    #define EMIOS_1_CH_15_USED
+#else
+    #error "EMIOS_1_CH_15 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_16_USED
+    #define EMIOS_1_CH_16_USED
+#else
+    #error "EMIOS_1_CH_16 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_17_USED
+    #define EMIOS_1_CH_17_USED
+#else
+    #error "EMIOS_1_CH_17 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_18_USED
+    #define EMIOS_1_CH_18_USED
+#else
+    #error "EMIOS_1_CH_18 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_19_USED
+    #define EMIOS_1_CH_19_USED
+#else
+    #error "EMIOS_1_CH_19 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_20_USED
+    #define EMIOS_1_CH_20_USED
+#else
+    #error "EMIOS_1_CH_20 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_21_USED
+    #define EMIOS_1_CH_21_USED
+#else
+    #error "EMIOS_1_CH_21 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_1_CH_22_USED
+    #define EMIOS_1_CH_22_USED
+#else
+    #error "EMIOS_1_CH_22 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_0_USED
+    #define EMIOS_2_CH_0_USED
+#else
+    #error "EMIOS_2_CH_0 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_1_USED
+    #define EMIOS_2_CH_1_USED
+#else
+    #error "EMIOS_2_CH_1 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_2_USED
+    #define EMIOS_2_CH_2_USED
+#else
+    #error "EMIOS_2_CH_2 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_3_USED
+    #define EMIOS_2_CH_3_USED
+#else
+    #error "EMIOS_2_CH_3 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_4_USED
+    #define EMIOS_2_CH_4_USED
+#else
+    #error "EMIOS_2_CH_4 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_5_USED
+    #define EMIOS_2_CH_5_USED
+#else
+    #error "EMIOS_2_CH_5 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_6_USED
+    #define EMIOS_2_CH_6_USED
+#else
+    #error "EMIOS_2_CH_6 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_7_USED
+    #define EMIOS_2_CH_7_USED
+#else
+    #error "EMIOS_2_CH_7 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_8_USED
+    #define EMIOS_2_CH_8_USED
+#else
+    #error "EMIOS_2_CH_8 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_9_USED
+    #define EMIOS_2_CH_9_USED
+#else
+    #error "EMIOS_2_CH_9 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_10_USED
+    #define EMIOS_2_CH_10_USED
+#else
+    #error "EMIOS_2_CH_10 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_11_USED
+    #define EMIOS_2_CH_11_USED
+#else
+    #error "EMIOS_2_CH_11 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_12_USED
+    #define EMIOS_2_CH_12_USED
+#else
+    #error "EMIOS_2_CH_12 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_13_USED
+    #define EMIOS_2_CH_13_USED
+#else
+    #error "EMIOS_2_CH_13 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_14_USED
+    #define EMIOS_2_CH_14_USED
+#else
+    #error "EMIOS_2_CH_14 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_15_USED
+    #define EMIOS_2_CH_15_USED
+#else
+    #error "EMIOS_2_CH_15 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_16_USED
+    #define EMIOS_2_CH_16_USED
+#else
+    #error "EMIOS_2_CH_16 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_17_USED
+    #define EMIOS_2_CH_17_USED
+#else
+    #error "EMIOS_2_CH_17 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_18_USED
+    #define EMIOS_2_CH_18_USED
+#else
+    #error "EMIOS_2_CH_18 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_19_USED
+    #define EMIOS_2_CH_19_USED
+#else
+    #error "EMIOS_2_CH_19 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_20_USED
+    #define EMIOS_2_CH_20_USED
+#else
+    #error "EMIOS_2_CH_20 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_21_USED
+    #define EMIOS_2_CH_21_USED
+#else
+    #error "EMIOS_2_CH_21 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+#ifndef EMIOS_2_CH_22_USED
+    #define EMIOS_2_CH_22_USED
+#else
+    #error "EMIOS_2_CH_22 channel cannot be used by ICU. Instance locked by another driver!"
+#endif
+    
+#define EMIOS_ICU_CONFIG_EXT \
+        EMIOS_ICU_CONFIG_SA_INIT_PB \
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* EMIOS_ICU_IP_CFG_H */
+

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_DEFINES_H
+#define EMIOS_ICU_IP_DEFINES_H
+
+/**
+ *   @file
+ *   @implements Emios_Icu_Ip_Defines.h_Artifact
+ *   @addtogroup emios_icu_ip EMIOS IPL
+ *   @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+ /*==================================================================================================
+ *                                         INCLUDE FILES
+ * 1) system and project includes
+ * 2) needed interfaces from external units
+ * 3) internal and external interfaces from this unit
+ *================================================================================================*/
+#include "Std_Types.h"
+#include "S32K344_EMIOS.h"
+
+
+/*==================================================================================================
+ *                              SOURCE FILE VERSION INFORMATION
+ *================================================================================================*/
+#define EMIOS_ICU_IP_DEFINES_VENDOR_ID                    43
+#define EMIOS_ICU_IP_DEFINES_AR_RELEASE_MAJOR_VERSION     4
+#define EMIOS_ICU_IP_DEFINES_AR_RELEASE_MINOR_VERSION     7
+#define EMIOS_ICU_IP_DEFINES_AR_RELEASE_REVISION_VERSION  0
+#define EMIOS_ICU_IP_DEFINES_SW_MAJOR_VERSION             3
+#define EMIOS_ICU_IP_DEFINES_SW_MINOR_VERSION             0
+#define EMIOS_ICU_IP_DEFINES_SW_PATCH_VERSION             0
+
+/*==================================================================================================
+*                                       FILE VERSION CHECKS
+==================================================================================================*/
+/* Check if header file and Std_Types.h file are of the same Autosar version */
+#ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    #if ((EMIOS_ICU_IP_DEFINES_AR_RELEASE_MAJOR_VERSION != STD_AR_RELEASE_MAJOR_VERSION) || \
+         (EMIOS_ICU_IP_DEFINES_AR_RELEASE_MINOR_VERSION != STD_AR_RELEASE_MINOR_VERSION))
+        #error "AutoSar Version Numbers of Emios_Icu_Ip_Defines.h and Std_Types.h are different"
+    #endif
+#endif
+
+/*==================================================================================================
+*                                            CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       DEFINES AND MACROS
+==================================================================================================*/
+#define EMIOS_ICU_IP_USED          (STD_ON)
+
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+#define EMIOS_ICU_IP_CHANNEL_24_USED               (STD_OFF)
+/** @brief The number of EMIOS instances available on platform */
+#define EMIOS_ICU_IP_INSTANCE_COUNT                (3U)
+
+/** @brief The number of channels available on each EMIOS instance */
+#define EMIOS_ICU_IP_NUM_OF_CHANNELS               (24U)
+
+/** @brief The number of eMios channels are used in configuration */
+#define EMIOS_ICU_IP_NUM_OF_CHANNELS_USED         ((uint8)69U)
+
+#define EMIOS_ICU_IP_CHANNEL_NOT_USED             ((uint8)0xFF)
+
+#define EMIOS_ICU_IP_MASTERBUS_CHANNEL_USED       ((uint8)0xFE)
+
+/** @brief Switches the Development Error Detection and Notification on or off.  */
+#define EMIOS_ICU_IP_DEV_ERROR_DETECT             (STD_OFF)
+#define EMIOS_ICU_IP_VALIDATE_GLOBAL_CALL         (EMIOS_ICU_IP_DEV_ERROR_DETECT)
+
+
+/** @brief Adds or removes all services related to the timestamp functionality. */
+#define EMIOS_ICU_IP_TIMESTAMP_API                (STD_ON)
+/** @brief Adds or removes all services related to the edge detect functionality. */
+#define EMIOS_ICU_IP_EDGE_DETECT_API              (STD_ON)
+/** @brief Adds or removes all services related to the signal mesurement functionality. */
+#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API       (STD_ON)
+/** @brief Adds or removes all services related to the input level. */
+#define EMIOS_ICU_IP_GET_INPUT_LEVEL_API          (STD_ON)
+/** @brief Adds or removes all services related to the deinitialization functionality. */
+#define EMIOS_ICU_IP_DEINIT_API                   (STD_ON)
+/** @brief Adds or removes all services related to edge count functionality. */
+#define EMIOS_ICU_IP_EDGE_COUNT_API               (STD_ON)
+
+#define EMIOS_ICU_IP_CAPTURERGISTER_API           (STD_ON)
+
+/** @brief Adds or Removes the code related to overflow notification */
+#define EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API    (STD_ON)
+
+/** @brief define SAIC mode if any channels not supporting IPWM or IPM mode is configured. */
+#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE  (STD_ON)
+
+/** @brief Adds or removes the service set Max Counter for eMios. */
+#define EMIOS_ICU_IP_SET_MAX_COUNTER              (STD_ON)
+
+/** @brief Adds or removes the service set Initial Counter for eMios. */
+#define EMIOS_ICU_IP_SET_INITIAL_COUNTER          (STD_ON)
+
+/** @brief Adds or removes all services related to mode set functionality. */
+#define EMIOS_ICU_IP_SET_MODE_API                 (STD_OFF)
+
+/** @brief Adds or removes all services related to input state functionality. */
+#define EMIOS_ICU_IP_GET_INPUT_STATE_API          (STD_ON)
+
+/** @brief Adds or removes all services related to dual clock edge functionality. */
+#define EMIOS_ICU_IP_DUAL_CLOCK_MODE_API          (STD_ON)
+
+/** @brief Adds or removes the support measurement with DMA. */
+#define EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA   (STD_OFF)
+#define EMIOS_ICU_IP_TIMESTAMP_USES_DMA           (STD_OFF)
+
+/** @brief Adds or removes the support measurement with DMA in IPL */
+#define EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA_IPL   (STD_OFF)
+#define EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT              (2U)
+#define EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL           (STD_OFF)
+
+#define EMIOS_ICU_IP_GET_PULSE_WIDTH_API          (STD_ON)
+    /** @brief Support for User mode.
+ *  If this parameter has been configured to STD_ON, the EMIOS driver code
+ *  can be executed from both supervisor and user mode. */
+#define EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT     (STD_OFF)
+
+/* Verification for user mode support. */
+#ifndef MCAL_ENABLE_USER_MODE_SUPPORT
+    #if (defined (EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT) && (STD_ON == EMIOS_ICU_IP_ENABLE_USER_MODE_SUPPORT))
+        #error MCAL_ENABLE_USER_MODE_SUPPORT is not enabled. For running Icu in user mode the MCAL_ENABLE_USER_MODE_SUPPORT needs to be defined
+    #endif
+#endif
+
+#define EMIOS_ICU_USES_MCL_DRIVER          (STD_ON)
+
+#if ((EMIOS_ICU_IP_EDGE_COUNT_API == STD_ON) || (EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API == STD_ON) || (EMIOS_ICU_IP_TIMESTAMP_API == STD_ON))
+#define EMIOS_ICU_IP_COUNTER_MASK              ((uint32)65535)
+#endif
+#define EMIOS_ICU_IP_INITIAL_INDEX_OF_CHANNELS \
+  { \
+      {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U, 10U, 11U, 12U, 13U, 14U, 15U, 16U, 17U, 18U, 19U, 20U, 21U, 22U, 255U}, \
+      {23U, 24U, 25U, 26U, 27U, 28U, 29U, 30U, 31U, 32U, 33U, 34U, 35U, 36U, 37U, 38U, 39U, 40U, 41U, 42U, 43U, 44U, 45U, 255U}, \
+      {46U, 47U, 48U, 49U, 50U, 51U, 52U, 53U, 54U, 55U, 56U, 57U, 58U, 59U, 60U, 61U, 62U, 63U, 64U, 65U, 66U, 67U, 68U, 255U} \
+  } \
+
+
+/*==================================================================================================
+*                                              ENUMS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                  STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+/**
+*   @brief Implementation specific. This type shall be chosen in order to have the most efficient
+*       implementation on a specific microcontroller platform.
+*       Range: 0  to width of the timer register.
+*       Description: Width of the buffer for timestamp ticks and measured elapsed timeticks
+*/
+typedef uint32 eMios_Icu_ValueType;
+/*==================================================================================================
+*                                  GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       FUNCTION PROTOTYPES
+==================================================================================================*/
+
+#endif /* EMIOS_ICU_IP_USED */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif  /* EMIOS_ICU_IP_DEFINES_H */
+

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
@@ -90,38 +90,38 @@ extern "C"{
 /** @brief Adds or removes all services related to the timestamp functionality. */
 #define EMIOS_ICU_IP_TIMESTAMP_API                (STD_ON)
 /** @brief Adds or removes all services related to the edge detect functionality. */
-#define EMIOS_ICU_IP_EDGE_DETECT_API              (STD_ON)
+#define EMIOS_ICU_IP_EDGE_DETECT_API              (STD_OFF)
 /** @brief Adds or removes all services related to the signal mesurement functionality. */
-#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API       (STD_ON)
+#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_API       (STD_OFF)
 /** @brief Adds or removes all services related to the input level. */
 #define EMIOS_ICU_IP_GET_INPUT_LEVEL_API          (STD_ON)
 /** @brief Adds or removes all services related to the deinitialization functionality. */
-#define EMIOS_ICU_IP_DEINIT_API                   (STD_ON)
+#define EMIOS_ICU_IP_DEINIT_API                   (STD_OFF)
 /** @brief Adds or removes all services related to edge count functionality. */
-#define EMIOS_ICU_IP_EDGE_COUNT_API               (STD_ON)
+#define EMIOS_ICU_IP_EDGE_COUNT_API               (STD_OFF)
 
-#define EMIOS_ICU_IP_CAPTURERGISTER_API           (STD_ON)
+#define EMIOS_ICU_IP_CAPTURERGISTER_API           (STD_OFF)
 
 /** @brief Adds or Removes the code related to overflow notification */
-#define EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API    (STD_ON)
+#define EMIOS_ICU_IP_OVERFLOW_NOTIFICATION_API    (STD_OFF)
 
 /** @brief define SAIC mode if any channels not supporting IPWM or IPM mode is configured. */
-#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE  (STD_ON)
+#define EMIOS_ICU_IP_SIGNAL_MEASUREMENT_USES_SAIC_MODE  (STD_OFF)
 
 /** @brief Adds or removes the service set Max Counter for eMios. */
-#define EMIOS_ICU_IP_SET_MAX_COUNTER              (STD_ON)
+#define EMIOS_ICU_IP_SET_MAX_COUNTER              (STD_OFF)
 
 /** @brief Adds or removes the service set Initial Counter for eMios. */
-#define EMIOS_ICU_IP_SET_INITIAL_COUNTER          (STD_ON)
+#define EMIOS_ICU_IP_SET_INITIAL_COUNTER          (STD_OFF)
 
 /** @brief Adds or removes all services related to mode set functionality. */
 #define EMIOS_ICU_IP_SET_MODE_API                 (STD_OFF)
 
 /** @brief Adds or removes all services related to input state functionality. */
-#define EMIOS_ICU_IP_GET_INPUT_STATE_API          (STD_ON)
+#define EMIOS_ICU_IP_GET_INPUT_STATE_API          (STD_OFF)
 
 /** @brief Adds or removes all services related to dual clock edge functionality. */
-#define EMIOS_ICU_IP_DUAL_CLOCK_MODE_API          (STD_ON)
+#define EMIOS_ICU_IP_DUAL_CLOCK_MODE_API          (STD_OFF)
 
 /** @brief Adds or removes the support measurement with DMA. */
 #define EMIOS_ICU_IP_SIGNALMEASUREMENT_USES_DMA   (STD_OFF)
@@ -132,7 +132,7 @@ extern "C"{
 #define EMIOS_ICU_IP_DMA_MAJORLOOP_COUNT              (2U)
 #define EMIOS_ICU_IP_TIMESTAMP_USES_DMA_IPL           (STD_OFF)
 
-#define EMIOS_ICU_IP_GET_PULSE_WIDTH_API          (STD_ON)
+#define EMIOS_ICU_IP_GET_PULSE_WIDTH_API          (STD_OFF)
     /** @brief Support for User mode.
  *  If this parameter has been configured to STD_ON, the EMIOS driver code
  *  can be executed from both supervisor and user mode. */

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_Defines.h
@@ -27,6 +27,13 @@ extern "C"{
 #include "Std_Types.h"
 #include "S32K344_EMIOS.h"
 
+#include <zephyr/devicetree.h>
+
+#define _PWM_NXP_S32_CAPTURE_USED(node_id)  \
+        COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, pwm_mode, SAIC), (+ 1), (+ 0))
+
+#define PWM_NXP_S32_CAPTURE_USED(node_id)     \
+        DT_FOREACH_CHILD_STATUS_OKAY(node_id, _PWM_NXP_S32_CAPTURE_USED)
 
 /*==================================================================================================
  *                              SOURCE FILE VERSION INFORMATION
@@ -57,7 +64,7 @@ extern "C"{
 /*==================================================================================================
 *                                       DEFINES AND MACROS
 ==================================================================================================*/
-#define EMIOS_ICU_IP_USED          (STD_ON)
+#define EMIOS_ICU_IP_USED          (0 || (DT_FOREACH_STATUS_OKAY(nxp_s32_emios_pwm, PWM_NXP_S32_CAPTURE_USED)))
 
 #if (STD_ON == EMIOS_ICU_IP_USED)
 
@@ -69,7 +76,7 @@ extern "C"{
 #define EMIOS_ICU_IP_NUM_OF_CHANNELS               (24U)
 
 /** @brief The number of eMios channels are used in configuration */
-#define EMIOS_ICU_IP_NUM_OF_CHANNELS_USED         ((uint8)69U)
+#define EMIOS_ICU_IP_NUM_OF_CHANNELS_USED         0 DT_FOREACH_STATUS_OKAY(nxp_s32_emios_pwm, PWM_NXP_S32_CAPTURE_USED)
 
 #define EMIOS_ICU_IP_CHANNEL_NOT_USED             ((uint8)0xFF)
 

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_SA_Init_PBcfg.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_SA_Init_PBcfg.h
@@ -68,7 +68,38 @@ extern "C"{
 ==================================================================================================*/
 #if (STD_ON == EMIOS_ICU_IP_USED)
 
+#if DT_REG_ADDR(DT_INST(0, nxp_s32_emios)) == IP_EMIOS_0_BASE
+#define EMIOS_0_DRV_INST    0
+#elif DT_REG_ADDR(DT_INST(1, nxp_s32_emios)) == IP_EMIOS_0_BASE
+#define EMIOS_0_DRV_INST    1
+#else
+#define EMIOS_0_DRV_INST    2
+#endif
 
+#if DT_REG_ADDR(DT_INST(0, nxp_s32_emios)) == IP_EMIOS_1_BASE
+#define EMIOS_1_DRV_INST    0
+#elif DT_REG_ADDR(DT_INST(1, nxp_s32_emios)) == IP_EMIOS_1_BASE
+#define EMIOS_1_DRV_INST    1
+#else
+#define EMIOS_1_DRV_INST    2
+#endif
+
+#if DT_REG_ADDR(DT_INST(0, nxp_s32_emios)) == IP_EMIOS_2_BASE
+#define EMIOS_2_DRV_INST    0
+#elif DT_REG_ADDR(DT_INST(1, nxp_s32_emios)) == IP_EMIOS_2_BASE
+#define EMIOS_2_DRV_INST    1
+#else
+#define EMIOS_2_DRV_INST    2
+#endif
+
+#define EMIOS_PWM_NODE(n)   DT_CHILD(DT_INST(n, nxp_s32_emios), pwm)
+
+#define EMIOS_ICU_CHANNEL(node_id, ch)                                   \
+        IF_ENABLED(DT_ENUM_HAS_VALUE(node_id, pwm_mode, SAIC),           \
+                  ((DT_PROP(node_id, channel) == ch) ||))
+
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 0) 0
 #ifndef ICU_EMIOS_0_CH_0_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_0_ISR_USED    (STD_ON)
@@ -78,7 +109,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_0_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 1) 0
 #ifndef ICU_EMIOS_0_CH_1_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_1_ISR_USED    (STD_ON)
@@ -88,7 +122,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_1_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 2) 0
 #ifndef ICU_EMIOS_0_CH_2_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_2_ISR_USED    (STD_ON)
@@ -98,7 +135,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_2_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 3) 0
 #ifndef ICU_EMIOS_0_CH_3_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_3_ISR_USED    (STD_ON)
@@ -108,7 +148,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_3_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 4) 0
 #ifndef ICU_EMIOS_0_CH_4_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_4_ISR_USED    (STD_ON)
@@ -118,7 +161,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_4_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 5) 0
 #ifndef ICU_EMIOS_0_CH_5_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_5_ISR_USED    (STD_ON)
@@ -128,7 +174,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_5_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 6) 0
 #ifndef ICU_EMIOS_0_CH_6_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_6_ISR_USED    (STD_ON)
@@ -138,7 +187,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_6_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 7) 0
 #ifndef ICU_EMIOS_0_CH_7_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_7_ISR_USED    (STD_ON)
@@ -148,7 +200,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_7_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 8) 0
 #ifndef ICU_EMIOS_0_CH_8_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_8_ISR_USED    (STD_ON)
@@ -158,7 +213,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_8_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 9) 0
 #ifndef ICU_EMIOS_0_CH_9_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_9_ISR_USED    (STD_ON)
@@ -168,7 +226,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_9_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 10) 0
 #ifndef ICU_EMIOS_0_CH_10_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_10_ISR_USED    (STD_ON)
@@ -178,7 +239,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_10_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 11) 0
 #ifndef ICU_EMIOS_0_CH_11_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_11_ISR_USED    (STD_ON)
@@ -188,7 +252,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_11_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 12) 0
 #ifndef ICU_EMIOS_0_CH_12_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_12_ISR_USED    (STD_ON)
@@ -198,7 +265,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_12_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 13) 0
 #ifndef ICU_EMIOS_0_CH_13_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_13_ISR_USED    (STD_ON)
@@ -208,7 +278,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_13_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 14) 0
 #ifndef ICU_EMIOS_0_CH_14_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_14_ISR_USED    (STD_ON)
@@ -218,7 +291,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_14_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 15) 0
 #ifndef ICU_EMIOS_0_CH_15_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_15_ISR_USED    (STD_ON)
@@ -228,7 +304,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_15_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 16) 0
 #ifndef ICU_EMIOS_0_CH_16_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_16_ISR_USED    (STD_ON)
@@ -238,7 +317,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_16_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 17) 0
 #ifndef ICU_EMIOS_0_CH_17_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_17_ISR_USED    (STD_ON)
@@ -248,7 +330,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_17_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 18) 0
 #ifndef ICU_EMIOS_0_CH_18_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_18_ISR_USED    (STD_ON)
@@ -258,7 +343,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_18_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 19) 0
 #ifndef ICU_EMIOS_0_CH_19_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_19_ISR_USED    (STD_ON)
@@ -268,7 +356,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_19_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 20) 0
 #ifndef ICU_EMIOS_0_CH_20_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_20_ISR_USED    (STD_ON)
@@ -278,7 +369,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_20_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 21) 0
 #ifndef ICU_EMIOS_0_CH_21_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_21_ISR_USED    (STD_ON)
@@ -288,7 +382,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_21_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 22) 0
 #ifndef ICU_EMIOS_0_CH_22_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_0_CH_22_ISR_USED    (STD_ON)
@@ -298,7 +395,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_22_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_0_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 23) 0
 #ifndef ICU_EMIOS_0_CH_23_ISR_USED
     /** @brief Macros for check EMIOS channels used by MCL. */
     #define ICU_EMIOS_0_CH_23_ISR_USED          (STD_ON)
@@ -308,7 +408,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_0_CH_23_ISR_USED          (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 0) 0
 #ifndef ICU_EMIOS_1_CH_0_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_0_ISR_USED    (STD_ON)
@@ -318,7 +421,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_0_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 1) 0
 #ifndef ICU_EMIOS_1_CH_1_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_1_ISR_USED    (STD_ON)
@@ -328,7 +434,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_1_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 2) 0
 #ifndef ICU_EMIOS_1_CH_2_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_2_ISR_USED    (STD_ON)
@@ -338,7 +447,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_2_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 3) 0
 #ifndef ICU_EMIOS_1_CH_3_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_3_ISR_USED    (STD_ON)
@@ -348,7 +460,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_3_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 4) 0
 #ifndef ICU_EMIOS_1_CH_4_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_4_ISR_USED    (STD_ON)
@@ -358,7 +473,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_4_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 5) 0
 #ifndef ICU_EMIOS_1_CH_5_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_5_ISR_USED    (STD_ON)
@@ -368,7 +486,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_5_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 6) 0
 #ifndef ICU_EMIOS_1_CH_6_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_6_ISR_USED    (STD_ON)
@@ -378,7 +499,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_6_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 7) 0
 #ifndef ICU_EMIOS_1_CH_7_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_7_ISR_USED    (STD_ON)
@@ -388,7 +512,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_7_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 8) 0
 #ifndef ICU_EMIOS_1_CH_8_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_8_ISR_USED    (STD_ON)
@@ -398,7 +525,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_8_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 9) 0
 #ifndef ICU_EMIOS_1_CH_9_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_9_ISR_USED    (STD_ON)
@@ -408,7 +538,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_9_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 10) 0
 #ifndef ICU_EMIOS_1_CH_10_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_10_ISR_USED    (STD_ON)
@@ -418,7 +551,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_10_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 11) 0
 #ifndef ICU_EMIOS_1_CH_11_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_11_ISR_USED    (STD_ON)
@@ -428,7 +564,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_11_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 12) 0
 #ifndef ICU_EMIOS_1_CH_12_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_12_ISR_USED    (STD_ON)
@@ -438,7 +577,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_12_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 13) 0
 #ifndef ICU_EMIOS_1_CH_13_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_13_ISR_USED    (STD_ON)
@@ -448,7 +590,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_13_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 14) 0
 #ifndef ICU_EMIOS_1_CH_14_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_14_ISR_USED    (STD_ON)
@@ -458,7 +603,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_14_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 15) 0
 #ifndef ICU_EMIOS_1_CH_15_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_15_ISR_USED    (STD_ON)
@@ -468,7 +616,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_15_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 16) 0
 #ifndef ICU_EMIOS_1_CH_16_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_16_ISR_USED    (STD_ON)
@@ -478,7 +629,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_16_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 17) 0
 #ifndef ICU_EMIOS_1_CH_17_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_17_ISR_USED    (STD_ON)
@@ -488,7 +642,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_17_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 18) 0
 #ifndef ICU_EMIOS_1_CH_18_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_18_ISR_USED    (STD_ON)
@@ -498,7 +655,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_18_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 19) 0
 #ifndef ICU_EMIOS_1_CH_19_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_19_ISR_USED    (STD_ON)
@@ -508,7 +668,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_19_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 20) 0
 #ifndef ICU_EMIOS_1_CH_20_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_20_ISR_USED    (STD_ON)
@@ -518,7 +681,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_20_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 21) 0
 #ifndef ICU_EMIOS_1_CH_21_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_21_ISR_USED    (STD_ON)
@@ -528,7 +694,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_21_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 22) 0
 #ifndef ICU_EMIOS_1_CH_22_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_1_CH_22_ISR_USED    (STD_ON)
@@ -538,7 +707,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_22_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_1_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 23) 0
 #ifndef ICU_EMIOS_1_CH_23_ISR_USED
     /** @brief Macros for check EMIOS channels used by MCL. */
     #define ICU_EMIOS_1_CH_23_ISR_USED          (STD_ON)
@@ -548,7 +720,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_1_CH_23_ISR_USED          (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 0) 0
 #ifndef ICU_EMIOS_2_CH_0_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_0_ISR_USED    (STD_ON)
@@ -558,7 +733,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_0_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 1) 0
 #ifndef ICU_EMIOS_2_CH_1_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_1_ISR_USED    (STD_ON)
@@ -568,7 +746,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_1_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 2) 0
 #ifndef ICU_EMIOS_2_CH_2_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_2_ISR_USED    (STD_ON)
@@ -578,7 +759,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_2_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 3) 0
 #ifndef ICU_EMIOS_2_CH_3_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_3_ISR_USED    (STD_ON)
@@ -588,7 +772,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_3_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 4) 0
 #ifndef ICU_EMIOS_2_CH_4_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_4_ISR_USED    (STD_ON)
@@ -598,7 +785,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_4_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 5) 0
 #ifndef ICU_EMIOS_2_CH_5_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_5_ISR_USED    (STD_ON)
@@ -608,7 +798,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_5_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 6) 0
 #ifndef ICU_EMIOS_2_CH_6_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_6_ISR_USED    (STD_ON)
@@ -618,7 +811,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_6_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 7) 0
 #ifndef ICU_EMIOS_2_CH_7_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_7_ISR_USED    (STD_ON)
@@ -628,7 +824,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_7_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 8) 0
 #ifndef ICU_EMIOS_2_CH_8_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_8_ISR_USED    (STD_ON)
@@ -638,7 +837,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_8_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 9) 0
 #ifndef ICU_EMIOS_2_CH_9_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_9_ISR_USED    (STD_ON)
@@ -648,7 +850,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_9_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 10) 0
 #ifndef ICU_EMIOS_2_CH_10_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_10_ISR_USED    (STD_ON)
@@ -658,7 +863,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_10_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 11) 0
 #ifndef ICU_EMIOS_2_CH_11_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_11_ISR_USED    (STD_ON)
@@ -668,7 +876,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_11_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 12) 0
 #ifndef ICU_EMIOS_2_CH_12_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_12_ISR_USED    (STD_ON)
@@ -678,7 +889,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_12_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 13) 0
 #ifndef ICU_EMIOS_2_CH_13_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_13_ISR_USED    (STD_ON)
@@ -688,7 +902,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_13_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 14) 0
 #ifndef ICU_EMIOS_2_CH_14_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_14_ISR_USED    (STD_ON)
@@ -698,7 +915,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_14_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 15) 0
 #ifndef ICU_EMIOS_2_CH_15_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_15_ISR_USED    (STD_ON)
@@ -708,7 +928,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_15_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 16) 0
 #ifndef ICU_EMIOS_2_CH_16_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_16_ISR_USED    (STD_ON)
@@ -718,7 +941,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_16_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 17) 0
 #ifndef ICU_EMIOS_2_CH_17_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_17_ISR_USED    (STD_ON)
@@ -728,7 +954,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_17_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 18) 0
 #ifndef ICU_EMIOS_2_CH_18_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_18_ISR_USED    (STD_ON)
@@ -738,7 +967,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_18_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 19) 0
 #ifndef ICU_EMIOS_2_CH_19_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_19_ISR_USED    (STD_ON)
@@ -748,7 +980,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_19_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 20) 0
 #ifndef ICU_EMIOS_2_CH_20_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_20_ISR_USED    (STD_ON)
@@ -758,7 +993,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_20_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 21) 0
 #ifndef ICU_EMIOS_2_CH_21_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_21_ISR_USED    (STD_ON)
@@ -768,7 +1006,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_21_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 22) 0
 #ifndef ICU_EMIOS_2_CH_22_ISR_USED
     /** @brief Macros for indicate EMIOS interrupts used by ICU. */
     #define ICU_EMIOS_2_CH_22_ISR_USED    (STD_ON)
@@ -778,7 +1019,10 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_22_ISR_USED        (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
 
+#if DT_FOREACH_CHILD_STATUS_OKAY_VARGS(EMIOS_PWM_NODE(EMIOS_2_DRV_INST), \
+                                       EMIOS_ICU_CHANNEL, 23) 0
 #ifndef ICU_EMIOS_2_CH_23_ISR_USED
     /** @brief Macros for check EMIOS channels used by MCL. */
     #define ICU_EMIOS_2_CH_23_ISR_USED          (STD_ON)
@@ -788,6 +1032,8 @@ extern "C"{
     /** @brief Macros for indicate EMIOS interrupts used. */
     #define EMIOS_2_CH_23_ISR_USED          (STD_ON)
 #endif
+#endif /* DT_FOREACH_CHILD_STATUS_OKAY_VARGS */
+
 #define EMIOS_ICU_CONFIG_SA_INIT_PB
 
 #endif  /* EMIOS_ICU_IP_USED */

--- a/s32/soc/s32k344/include/Emios_Icu_Ip_SA_Init_PBcfg.h
+++ b/s32/soc/s32k344/include/Emios_Icu_Ip_SA_Init_PBcfg.h
@@ -1,0 +1,818 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef EMIOS_ICU_IP_SA_INIT_PBCFG_H
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_H
+
+/**
+ *   @file    Emios_Icu_Ip_SA_Init_PBCfg.h
+ *   @version 3.0.0
+ *
+ *   @brief   AUTOSAR Icu - contains the data exported by the ICU module.
+ *   @details Contains the information that will be exported by the module, as requested by Autosar.
+ *
+ *   @addtogroup emios_icu_ip EMIOS IPL
+ *   @{
+ */
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+ /*==================================================================================================
+ *                                         INCLUDE FILES
+ * 1) system and project includes
+ * 2) needed interfaces from external units
+ * 3) internal and external interfaces from this unit
+ *================================================================================================*/
+#include "Emios_Icu_Ip_Types.h"
+/*==================================================================================================
+ *                              SOURCE FILE VERSION INFORMATION
+ *================================================================================================*/
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_VENDOR_ID                    43
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MAJOR_VERSION     4
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MINOR_VERSION     7
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_REVISION_VERSION  0
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MAJOR_VERSION             3
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MINOR_VERSION             0
+#define EMIOS_ICU_IP_SA_INIT_PBCFG_SW_PATCH_VERSION             0
+
+/*==================================================================================================
+ *                                      FILE VERSION CHECKS
+ *================================================================================================*/
+/* Check if source file and ICU header file are of the same vendor */
+#if (EMIOS_ICU_IP_SA_INIT_PBCFG_VENDOR_ID != EMIOS_ICU_IP_TYPES_VENDOR_ID)
+    #error "Emios_Icu_Ip_SA_Init_PBcfg.h and Emios_Icu_Ip_Types.h have different vendor IDs"
+#endif
+/* Check if source file and ICU header file are of the same AutoSar version */
+#if ((EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MAJOR_VERSION    != EMIOS_ICU_IP_TYPES_AR_RELEASE_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_MINOR_VERSION    != EMIOS_ICU_IP_TYPES_AR_RELEASE_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_SA_INIT_PBCFG_AR_RELEASE_REVISION_VERSION != EMIOS_ICU_IP_TYPES_AR_RELEASE_REVISION_VERSION))
+    #error "AutoSar Version Numbers of Emios_Icu_Ip_SA_Init_PBcfg.h and Emios_Icu_Ip_Types.h are different"
+#endif
+/* Check if source file and ICU header file are of the same Software version */
+#if ((EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MAJOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MAJOR_VERSION) || \
+     (EMIOS_ICU_IP_SA_INIT_PBCFG_SW_MINOR_VERSION != EMIOS_ICU_IP_TYPES_SW_MINOR_VERSION) || \
+     (EMIOS_ICU_IP_SA_INIT_PBCFG_SW_PATCH_VERSION != EMIOS_ICU_IP_TYPES_SW_PATCH_VERSION))
+    #error "Software Version Numbers of Emios_Icu_Ip_SA_Init_PBcfg.h and Emios_Icu_Ip_Types.h are different"
+#endif
+/*==================================================================================================
+*                                            CONSTANTS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       DEFINES AND MACROS
+==================================================================================================*/
+#if (STD_ON == EMIOS_ICU_IP_USED)
+
+
+#ifndef ICU_EMIOS_0_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_0_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_0_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_1_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_1_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_2_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_2_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_3_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_3_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_4_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_4_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_5_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_5_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_6_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_6_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_7_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_7_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_8_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_8_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_9_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_9_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_10_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_10_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_11_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_11_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_12_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_12_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_13_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_13_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_14_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_14_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_15_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_15_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_16_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_16_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_17_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_17_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_18_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_18_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_19_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_19_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_20_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_20_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_21_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_21_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_0_CH_22_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_22_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_0_CH_23_ISR_USED
+    /** @brief Macros for check EMIOS channels used by MCL. */
+    #define ICU_EMIOS_0_CH_23_ISR_USED          (STD_ON)
+#endif
+
+#ifndef EMIOS_0_CH_23_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_0_CH_23_ISR_USED          (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_0_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_0_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_1_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_1_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_2_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_2_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_3_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_3_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_4_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_4_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_5_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_5_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_6_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_6_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_7_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_7_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_8_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_8_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_9_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_9_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_10_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_10_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_11_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_11_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_12_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_12_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_13_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_13_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_14_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_14_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_15_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_15_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_16_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_16_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_17_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_17_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_18_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_18_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_19_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_19_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_20_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_20_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_21_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_21_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_1_CH_22_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_22_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_1_CH_23_ISR_USED
+    /** @brief Macros for check EMIOS channels used by MCL. */
+    #define ICU_EMIOS_1_CH_23_ISR_USED          (STD_ON)
+#endif
+
+#ifndef EMIOS_1_CH_23_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_1_CH_23_ISR_USED          (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_0_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_0_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_0_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_1_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_1_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_1_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_2_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_2_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_2_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_3_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_3_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_3_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_4_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_4_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_4_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_5_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_5_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_5_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_6_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_6_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_6_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_7_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_7_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_7_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_8_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_8_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_8_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_9_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_9_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_9_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_10_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_10_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_10_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_11_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_11_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_11_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_12_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_12_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_12_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_13_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_13_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_13_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_14_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_14_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_14_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_15_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_15_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_15_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_16_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_16_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_16_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_17_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_17_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_17_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_18_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_18_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_18_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_19_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_19_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_19_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_20_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_20_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_20_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_21_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_21_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_21_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used by ICU. */
+    #define ICU_EMIOS_2_CH_22_ISR_USED    (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_22_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_22_ISR_USED        (STD_ON)
+#endif
+
+#ifndef ICU_EMIOS_2_CH_23_ISR_USED
+    /** @brief Macros for check EMIOS channels used by MCL. */
+    #define ICU_EMIOS_2_CH_23_ISR_USED          (STD_ON)
+#endif
+
+#ifndef EMIOS_2_CH_23_ISR_USED
+    /** @brief Macros for indicate EMIOS interrupts used. */
+    #define EMIOS_2_CH_23_ISR_USED          (STD_ON)
+#endif
+#define EMIOS_ICU_CONFIG_SA_INIT_PB
+
+#endif  /* EMIOS_ICU_IP_USED */
+
+/*==================================================================================================
+*                                              ENUMS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                  STRUCTURES AND OTHER TYPEDEFS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                  GLOBAL VARIABLE DECLARATIONS
+==================================================================================================*/
+
+/*==================================================================================================
+*                                       FUNCTION PROTOTYPES
+==================================================================================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* EMIOS_ICU_IP_SA_INIT_PBCFG_H */
+

--- a/s32/soc/s32k344/include/Emios_Mcl_Ip_Cfg_Defines.h
+++ b/s32/soc/s32k344/include/Emios_Mcl_Ip_Cfg_Defines.h
@@ -29,6 +29,7 @@ extern "C"
 * 3) internal and external interfaces from this unit
 ==================================================================================================*/
 #include "Emios_Mcl_Ip_Cfg_DeviceRegisters.h"
+#include "Emios_Icu_Ip_Cfg.h"
 #include "Emios_Pwm_Ip_CfgDefines.h"
 
 /*==================================================================================================
@@ -63,6 +64,11 @@ extern "C"
 #endif
 
 #ifndef DISABLE_MCAL_INTERMODULE_ASR_CHECK
+    /* Check if this header file and Emios_Icu_Ip_Cfg.h file are of the same Autosar version */
+    #if ((EMIOS_MCL_IP_CFG_DEFINES_AR_RELEASE_MAJOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MAJOR_VERSION) || \
+        (EMIOS_MCL_IP_CFG_DEFINES_AR_RELEASE_MINOR_VERSION != EMIOS_ICU_IP_CFG_AR_RELEASE_MINOR_VERSION))
+        #error "AutoSar Version Numbers of Emios_Mcl_Ip_Cfg_Defines.h and Emios_Icu_Ip_Cfg.h are different"
+    #endif
     /* Check if this header file and Emios_Pwm_Ip_CfgDefines.h file are of the same Autosar version */
     #if ((EMIOS_MCL_IP_CFG_DEFINES_AR_RELEASE_MAJOR_VERSION != EMIOS_PWM_IP_CFGDEFINES_AR_RELEASE_MAJOR_VERSION) || \
         (EMIOS_MCL_IP_CFG_DEFINES_AR_RELEASE_MINOR_VERSION != EMIOS_PWM_IP_CFGDEFINES_AR_RELEASE_MINOR_VERSION))
@@ -92,14 +98,26 @@ extern "C"
 #define EMIOS_CH_23                        ((uint16)23U)
 
 /* Macros that indicate EMIOS channels used by MCL. */
-#ifndef EMIOS_0_CH_0_USED
-    #define EMIOS_0_CH_0_USED
+#ifndef EMIOS_0_CH_23_USED
+    #define EMIOS_0_CH_23_USED
 #else
-    #error "EMIOS_0_CH_0 channel cannot be used by MCL driver. Channel locked by other driver!"
+    #error "EMIOS_0_CH_23 channel cannot be used by MCL driver. Channel locked by other driver!"
+#endif
+#ifndef EMIOS_1_CH_23_USED
+    #define EMIOS_1_CH_23_USED
+#else
+    #error "EMIOS_1_CH_23 channel cannot be used by MCL driver. Channel locked by other driver!"
+#endif
+#ifndef EMIOS_2_CH_23_USED
+    #define EMIOS_2_CH_23_USED
+#else
+    #error "EMIOS_2_CH_23 channel cannot be used by MCL driver. Channel locked by other driver!"
 #endif
 
 /* Macros used to save logic MCL EMIOS channel encoding. */
-#define MCL_EMIOS_LOGIC_CH0     (uint16)((0U << 8U) + EMIOS_CH_0)
+#define MCL_EMIOS_LOGIC_CH0     (uint16)((0U << 8U) + EMIOS_CH_23)
+#define MCL_EMIOS_LOGIC_CH1     (uint16)((1U << 8U) + EMIOS_CH_23)
+#define MCL_EMIOS_LOGIC_CH2     (uint16)((2U << 8U) + EMIOS_CH_23)
 
 #define EMIOS_MCL_IP_DEV_ERROR_DETECT      (STD_OFF)
 

--- a/s32/soc/s32k344/include/Emios_Pwm_Ip_Cfg.h
+++ b/s32/soc/s32k344/include/Emios_Pwm_Ip_Cfg.h
@@ -96,8 +96,15 @@ extern "C"{
 ==================================================================================================*/
 #define DT_DRV_COMPAT   nxp_s32_emios_pwm
 
+#define NUM_CHANNEL_USED(node_id)           COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, pwm_mode, SAIC), (+ 0), (+ 1))
+#define EMIOS_NUM_CHANNELS_USED(n)          DT_INST_FOREACH_CHILD_STATUS_OKAY(n, NUM_CHANNEL_USED)
+
+#define SET_INITIAL_MODE(node_id)           IF_ENABLED(UTIL_NOT(DT_ENUM_HAS_VALUE(node_id, pwm_mode, SAIC)),    \
+                                                       (EMIOS_PWM_IP_MODE_NODEFINE,))
+#define EMIOS_PWM_IP_SET_INITIAL_MODE(n)    DT_INST_FOREACH_CHILD_STATUS_OKAY(n, SET_INITIAL_MODE)
+
 /** @brief      Enable the Emios Ip */
-#define EMIOS_PWM_IP_USED                       (DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT))
+#define EMIOS_PWM_IP_USED                   ((DT_INST_FOREACH_STATUS_OKAY(EMIOS_NUM_CHANNELS_USED)) || 0)
 
 /** @brief      Switch to enable the development error detection. */
 #define EMIOS_PWM_IP_DEV_ERROR_DETECT           (STD_OFF)
@@ -132,13 +139,8 @@ extern "C"{
 {255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U}  \
 }
 
-#define NUM_CHANNEL_USED(node_id)           1 +
-#define SET_INITIAL_MODE(node_id)           EMIOS_PWM_IP_MODE_NODEFINE,
+#define EMIOS_PWM_IP_NUM_OF_CHANNELS_USED   0 DT_INST_FOREACH_STATUS_OKAY(EMIOS_NUM_CHANNELS_USED)
 
-#define EMIOS_NUM_CHANNELS_USED(n)          DT_INST_FOREACH_CHILD_STATUS_OKAY(n, NUM_CHANNEL_USED)
-
-#define EMIOS_PWM_IP_NUM_OF_CHANNELS_USED   DT_INST_FOREACH_STATUS_OKAY(EMIOS_NUM_CHANNELS_USED) 0
-#define EMIOS_PWM_IP_SET_INITIAL_MODE(n)    DT_INST_FOREACH_CHILD_STATUS_OKAY(n, SET_INITIAL_MODE)
 #define EMIOS_PWM_IP_INITIAL_MODES                                                \
 {                                                                                 \
     DT_INST_FOREACH_STATUS_OKAY(EMIOS_PWM_IP_SET_INITIAL_MODE)                    \

--- a/s32/soc/s32k344/include/Emios_Pwm_Ip_Init_PBcfg.h
+++ b/s32/soc/s32k344/include/Emios_Pwm_Ip_Init_PBcfg.h
@@ -97,25 +97,25 @@ extern "C"{
 
 #define EMIOS_OPWFMB_MODE_USED(node_id)                                                    \
             COND_CODE_1(DT_NODE_HAS_PROP(node_id, pwm_mode),                               \
-                (DT_ENUM_HAS_VALUE(node_id, pwm_mode, MODE_OPWFMB)),                       \
-                    (0)) ||
+                       (DT_ENUM_HAS_VALUE(node_id, pwm_mode, OPWFMB)),                     \
+                       (0)) ||
 
 #define IS_EMIOS_OPWFMB_MODE_USED(n)                                                       \
             DT_INST_FOREACH_CHILD_STATUS_OKAY(n, EMIOS_OPWFMB_MODE_USED)
 
 #define EMIOS_OPWMB_MODE_USED(node_id)                                                     \
             COND_CODE_1(DT_NODE_HAS_PROP(node_id, pwm_mode),                               \
-                (DT_ENUM_HAS_VALUE(node_id, pwm_mode, MODE_OPWMB)),                        \
-                    (0)) ||
+                       (DT_ENUM_HAS_VALUE(node_id, pwm_mode, OPWMB)),                      \
+                       (0)) ||
 
 #define IS_EMIOS_OPWMB_MODE_USED(n)                                                        \
             DT_INST_FOREACH_CHILD_STATUS_OKAY(n, EMIOS_OPWMB_MODE_USED)
 
 #define EMIOS_OPWMCB_MODE_USED(node_id)                                                    \
             COND_CODE_1(DT_NODE_HAS_PROP(node_id, pwm_mode),                               \
-                (DT_ENUM_HAS_VALUE(node_id, pwm_mode, MODE_OPWMCB_TRAIL_EDGE) ||           \
-                 DT_ENUM_HAS_VALUE(node_id, pwm_mode, MODE_OPWMCB_LEAD_EDGE)               \
-                ),(0)) ||
+                       (DT_ENUM_HAS_VALUE(node_id, pwm_mode, OPWMCB_TRAIL_EDGE) ||         \
+                        DT_ENUM_HAS_VALUE(node_id, pwm_mode, OPWMCB_LEAD_EDGE)             \
+                        ),(0)) ||
 
 #define IS_EMIOS_OPWMCB_MODE_USED(n)                                                       \
             DT_INST_FOREACH_CHILD_STATUS_OKAY(n, EMIOS_OPWMCB_MODE_USED)


### PR DESCRIPTION
This add bare-metal driver for eMIOS ICU and specific configuration for S32K344. EMIOS ICU driver will be used
for PWM pulse capture