### PR TITLE
CMSIS: AArch64: avoid redefining MPIDR_AFFLVL_MASK

### DIFF
--- a/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
+++ b/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
@@ -69,7 +69,9 @@
 #define GET_EL(_mode)		(((_mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
 /* MPIDR */
+#ifndef MPIDR_AFFLVL_MASK
 #define MPIDR_AFFLVL_MASK	(0xfful)
+#endif
 #define MPIDR_AFF0_SHIFT	(0)
 #define MPIDR_AFF1_SHIFT	(8)
 #define MPIDR_AFF2_SHIFT	(16)


### PR DESCRIPTION
There's already a definition of this register in the main repo code base, add a guard around it so it does not get redefined, fixes a build warning.