### PR TITLE
Revert "s32: enable clock control driver for S32ZE"

### DIFF
--- a/s32/drivers/s32ze/Mcu/CMakeLists.txt
+++ b/s32/drivers/s32ze/Mcu/CMakeLists.txt
@@ -1,22 +1,19 @@
-# Copyright 2022-2023 NXP
+# Copyright 2022 NXP
 # SPDX-License-Identifier: BSD-3-Clause
 
 zephyr_include_directories(include)
-
-zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NXP_S32
-  src/Clock_Ip.c
-  src/Clock_Ip_Data.c
-  src/Clock_Ip_Divider.c
-  src/Clock_Ip_DividerTrigger.c
-  src/Clock_Ip_ExtOsc.c
-  src/Clock_Ip_FracDiv.c
-  src/Clock_Ip_Frequency.c
-  src/Clock_Ip_Gate.c
-  src/Clock_Ip_IntOsc.c
-  src/Clock_Ip_Irq.c
-  src/Clock_Ip_Monitor.c
-  src/Clock_Ip_Pll.c
-  src/Clock_Ip_ProgFreqSwitch.c
-  src/Clock_Ip_Selector.c
-  src/Clock_Ip_Specific.c
-)
+zephyr_library_sources(src/Clock_Ip.c)
+zephyr_library_sources(src/Clock_Ip_Data.c)
+zephyr_library_sources(src/Clock_Ip_Divider.c)
+zephyr_library_sources(src/Clock_Ip_DividerTrigger.c)
+zephyr_library_sources(src/Clock_Ip_ExtOsc.c)
+zephyr_library_sources(src/Clock_Ip_FracDiv.c)
+zephyr_library_sources(src/Clock_Ip_Frequency.c)
+zephyr_library_sources(src/Clock_Ip_Gate.c)
+zephyr_library_sources(src/Clock_Ip_IntOsc.c)
+zephyr_library_sources(src/Clock_Ip_Irq.c)
+zephyr_library_sources(src/Clock_Ip_Monitor.c)
+zephyr_library_sources(src/Clock_Ip_Pll.c)
+zephyr_library_sources(src/Clock_Ip_ProgFreqSwitch.c)
+zephyr_library_sources(src/Clock_Ip_Selector.c)
+zephyr_library_sources(src/Clock_Ip_Specific.c)

--- a/s32/drivers/s32ze/Rte/CMakeLists.txt
+++ b/s32/drivers/s32ze/Rte/CMakeLists.txt
@@ -4,7 +4,7 @@
 zephyr_include_directories(include)
 zephyr_library_sources_ifdef(CONFIG_GPIO_NXP_S32 src/SchM_Dio.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_EIRQ src/SchM_Icu.c)
-zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_NXP_S32 src/SchM_Mcu.c)
+zephyr_library_sources(src/SchM_Mcu.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_NXP_S32 src/SchM_Port.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_SPI src/SchM_Spi.c)
 zephyr_library_sources_ifdef(CONFIG_UART_NXP_S32_LINFLEXD src/SchM_Uart.c)

--- a/s32/soc/s32z27/include/Clock_Ip_Cfg_Defines.h
+++ b/s32/soc/s32z27/include/Clock_Ip_Cfg_Defines.h
@@ -158,7 +158,7 @@ extern "C"{
 /**
 * @brief            Clock ip supports clock frequency.
 */
-#define CLOCK_IP_GET_FREQUENCY_API                (STD_ON)
+#define CLOCK_IP_GET_FREQUENCY_API                (STD_OFF)
 
 /**
 * @brief            Supports wait states configuration


### PR DESCRIPTION
This reverts commit 9eda94aaaf12e75be747e99a42c8bfa1b9c09ff6.