### PR TITLE
Fix mpid redefined

### DIFF
--- a/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
+++ b/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
@@ -69,9 +69,7 @@
 #define GET_EL(_mode)		(((_mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
 /* MPIDR */
-#ifndef MPIDR_AFFLVL_MASK
 #define MPIDR_AFFLVL_MASK	(0xfful)
-#endif
 #define MPIDR_AFF0_SHIFT	(0)
 #define MPIDR_AFF1_SHIFT	(8)
 #define MPIDR_AFF2_SHIFT	(16)

--- a/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
+++ b/mcux/mcux-sdk/CMSIS/Core_AArch64/Include/core_common.h
@@ -69,7 +69,7 @@
 #define GET_EL(_mode)		(((_mode) >> MODE_EL_SHIFT) & MODE_EL_MASK)
 
 /* MPIDR */
-#define MPIDR_AFFLVL_MASK	(0xfful)
+#define MPIDR_AFFLVL_MASK	(0xffULL)
 #define MPIDR_AFF0_SHIFT	(0)
 #define MPIDR_AFF1_SHIFT	(8)
 #define MPIDR_AFF2_SHIFT	(16)


### PR DESCRIPTION
Sync MPIDR_AFFLVL_MASK with Zephyr to avoid building warning for redefinition.