### PR TITLE
Support PIT for S32Z27

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -63,3 +63,5 @@ Patch List:
   2. mcux-sdk/drivers/caam/fsl_caam.c: Move used job descriptors in the CAAM driver from the stack to noncacheable section. At time of writing, there should
      be four being used for entropy in zephyr.
   3. fsl_common.h: add #ifdef ZEPHYR #endif to include Zephyr's sys utils
+  4. mcux-sdk/drivers/pit/fsl_pit.c: add guards to avoid compilation warnings when building
+     with SDK clock control driver disabled.

--- a/mcux/mcux-sdk/drivers/pit/fsl_pit.c
+++ b/mcux/mcux-sdk/drivers/pit/fsl_pit.c
@@ -23,15 +23,16 @@
  *
  * @return The PIT instance
  */
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t PIT_GetInstance(PIT_Type *base);
+#endif
 
 /*******************************************************************************
  * Variables
  ******************************************************************************/
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to PIT bases for each instance. */
 static PIT_Type *const s_pitBases[] = PIT_BASE_PTRS;
-
-#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to PIT clocks for each instance. */
 static const clock_ip_name_t s_pitClocks[] = PIT_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
@@ -39,6 +40,7 @@ static const clock_ip_name_t s_pitClocks[] = PIT_CLOCKS;
 /*******************************************************************************
  * Code
  ******************************************************************************/
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t PIT_GetInstance(PIT_Type *base)
 {
     uint32_t instance;
@@ -56,6 +58,7 @@ static uint32_t PIT_GetInstance(PIT_Type *base)
 
     return instance;
 }
+#endif
 
 /*!
  * brief Ungates the PIT clock, enables the PIT module, and configures the peripheral for basic operations.

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_PIT.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_PIT.h
@@ -83,7 +83,7 @@ typedef struct {
     __I  uint32_t CVAL;                              /**< Current Timer Value Register, array offset: 0x104, array step: 0x10 */
     __IO uint32_t TCTRL;                             /**< Timer Control Register, array offset: 0x108, array step: 0x10 */
     __IO uint32_t TFLG;                              /**< Timer Flag Register, array offset: 0x10C, array step: 0x10 */
-  } TIMER[PIT_TIMER_COUNT];
+  } CHANNEL[PIT_TIMER_COUNT];
 } PIT_Type, *PIT_MemMapPtr;
 
 /** Number of instances of the PIT module. */

--- a/s32/mcux/devices/S32Z27/S32Z27_features.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_features.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _S32Z27_FEATURES_H_
+#define _S32Z27_FEATURES_H_
+
+#endif /* _S32Z27_FEATURES_H_ */

--- a/s32/mcux/devices/S32Z27/S32Z27_features.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_features.h
@@ -7,4 +7,22 @@
 #ifndef _S32Z27_FEATURES_H_
 #define _S32Z27_FEATURES_H_
 
+/* SOC module features */
+
+/* @brief PIT availability on the SoC. */
+#define FSL_FEATURE_SOC_PIT_COUNT (2)
+
+/* PIT module features */
+
+/* @brief Number of channels (related to number of registers LDVALn, CVALn, TCTRLn, TFLGn). */
+#define FSL_FEATURE_PIT_TIMER_COUNT (4)
+/* @brief Has lifetime timer (related to existence of registers LTMR64L and LTMR64H). */
+#define FSL_FEATURE_PIT_HAS_LIFETIME_TIMER (1)
+/* @brief Has chain mode (related to existence of register bit field TCTRLn[CHN]). */
+#define FSL_FEATURE_PIT_HAS_CHAIN_MODE (1)
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_PIT_HAS_SHARED_IRQ_HANDLER (1)
+/* @brief Has timer enable control. */
+#define FSL_FEATURE_PIT_HAS_MDIS (1)
+
 #endif /* _S32Z27_FEATURES_H_ */

--- a/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _S32Z27_GLUE_MCUX_H_
+#define _S32Z27_GLUE_MCUX_H_
+
+#endif /* _S32Z27_GLUE_MCUX_H_ */

--- a/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
@@ -7,4 +7,16 @@
 #ifndef _S32Z27_GLUE_MCUX_H_
 #define _S32Z27_GLUE_MCUX_H_
 
+/* PIT - Peripheral instance base addresses */
+/** Peripheral PIT0 base address */
+#define PIT0_BASE                                IP_PIT_0_BASE
+/** Peripheral PIT0 base pointer */
+#define PIT0                                     IP_PIT_0
+/** Array initializer of PIT peripheral base addresses */
+#define PIT_BASE_ADDRS                           IP_PIT_BASE_ADDRS
+/** Array initializer of PIT peripheral base pointers */
+#define PIT_BASE_PTRS                            IP_PIT_BASE_PTRS
+/** Interrupt vectors for the PIT peripheral type */
+#define PIT_IRQS                                 { RTU_RTUn_PIT0_IRQn }
+
 #endif /* _S32Z27_GLUE_MCUX_H_ */

--- a/s32/mcux/devices/S32Z27/device_CMSIS.cmake
+++ b/s32/mcux/devices/S32Z27/device_CMSIS.cmake
@@ -1,0 +1,10 @@
+include_guard(GLOBAL)
+message("device_CMSIS component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    # nothing to build
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)

--- a/s32/mcux/devices/S32Z27/device_system.cmake
+++ b/s32/mcux/devices/S32Z27/device_system.cmake
@@ -1,0 +1,10 @@
+include_guard(GLOBAL)
+message("device_system component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    # nothing to build
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    # nothing to include
+)

--- a/s32/mcux/devices/S32Z27/drivers/driver_reset.cmake
+++ b/s32/mcux/devices/S32Z27/drivers/driver_reset.cmake
@@ -1,0 +1,10 @@
+include_guard(GLOBAL)
+message("driver_reset component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    # nothing to build
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)

--- a/s32/mcux/devices/S32Z27/drivers/fsl_clock.h
+++ b/s32/mcux/devices/S32Z27/drivers/fsl_clock.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _FSL_CLOCK_H_
+#define _FSL_CLOCK_H_
+
+#include "fsl_common.h"
+
+#endif /* _FSL_CLOCK_H_ */

--- a/s32/mcux/devices/S32Z27/fsl_device_registers.h
+++ b/s32/mcux/devices/S32Z27/fsl_device_registers.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __FSL_DEVICE_REGISTERS_H__
+#define __FSL_DEVICE_REGISTERS_H__
+
+/*
+ * Include the cpu specific register header files.
+ *
+ * The CPU macro should be declared in the project or makefile.
+ */
+
+#if defined(CPU_S32Z27)
+
+/* CMSIS-style register definitions */
+#include "S32Z2.h"
+/* CPU specific feature definitions */
+#include "S32Z27_features.h"
+
+/* Define the IRQ types for RTU sub-system */
+#define IRQn_Type       RTU_IRQn_Type
+#define NotAvail_IRQn   RTU_NotAvail_IRQn
+
+/*
+ * In order to reuse RTD CMSIS-based headers for the MCUX drivers, is needed
+ * to redefine the peripheral macros from IP_PERIPHERAL_n to PERIPHERALn.
+ */
+#include "S32Z27_glue_mcux.h"
+
+/* Dummy implementations just to build mcux/mcux-sdk/drivers/common/fsl_common_arm.h */
+#define __GIC_PRESENT   0
+#define __GIC_PRIO_BITS 0
+static inline void GIC_EnableIRQ(IRQn_Type IRQn) { }
+static inline void GIC_DisableIRQ(IRQn_Type IRQn) { }
+static inline void GIC_ClearPendingIRQ(IRQn_Type IRQn) { }
+static inline void GIC_SetPriority(IRQn_Type IRQn, uint32_t priority) { }
+
+#include "core_cr52.h"
+
+#else
+    #error "No valid CPU defined!"
+#endif
+
+#endif /* __FSL_DEVICE_REGISTERS_H__ */


### PR DESCRIPTION
Introduce necessary glue code and definitions to build MCUX with S32Z27 devices so that we can reuse existing shim drivers for common NXP hw blocks, same as it was done for S32K3. For now only PIT is supported.

A patch on MCUX is added for fixing compiler warnings, also fixed in https://github.com/nxp-mcuxpresso/mcux-sdk/pull/142 