### PR TITLE
imx93: port clock frequency initialization code

### DIFF
--- a/mcux/mcux-sdk/devices/MIMX9352/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MIMX9352/drivers/fsl_clock.c
@@ -16,7 +16,26 @@
 
 static CCM_Type *ccm_base = CCM_CTRL;
 
-volatile uint32_t g_clockSourceFreq[kCLOCK_Ext + 1];
+/* ROM initializes PLLs with default frequencies except audio/video/ext */
+volatile uint32_t g_clockSourceFreq[kCLOCK_Ext + 1] = {
+    24000000U,   /* kCLOCK_Osc24M          */
+    2000000000U, /* kCLOCK_ArmPll          */
+    2000000000U, /* kCLOCK_ArmPllOut       */
+    1000000000U, /* kCLOCK_DramPll         */
+    1000000000U, /* kCLOCK_DramPllOut      */
+    4000000000U, /* kCLOCK_SysPll1         */
+    1000000000U, /* kCLOCK_SysPll1Pfd0     */
+    500000000U,  /* kCLOCK_SysPll1Pfd0Div2 */
+    800000000U,  /* kCLOCK_SysPll1Pfd1     */
+    400000000U,  /* kCLOCK_SysPll1Pfd1Div2 */
+    625000000U,  /* kCLOCK_SysPll1Pfd2     */
+    312500000U,  /* kCLOCK_SysPll1Pfd2Div2 */
+    0U,          /* kCLOCK_AudioPll1       */
+    0U,          /* kCLOCK_AudioPll1Out    */
+    0U,          /* kCLOCK_VideoPll1       */
+    0U,          /* kCLOCK_VideoPll1Out    */
+    0U           /* kCLOCK_Ext             */
+};
 
 uint32_t CLOCK_GetIpFreq(clock_root_t name)
 {


### PR DESCRIPTION
clock source frequencies need to be initialized in mcux driver. we already have such fix, so port it here.

this is required by pr: https://github.com/zephyrproject-rtos/zephyr/pull/62755