### PR TITLE
s32ze: remove `u` prefix from instance count macro

### DIFF
--- a/s32/drivers/s32k3/BaseNXP/header/S32K344_QUADSPI.h
+++ b/s32/drivers/s32k3/BaseNXP/header/S32K344_QUADSPI.h
@@ -123,7 +123,7 @@ typedef struct {
 } QuadSPI_Type, *QuadSPI_MemMapPtr;
 
 /** Number of instances of the QuadSPI module. */
-#define QuadSPI_INSTANCE_COUNT                   (1u)
+#define QuadSPI_INSTANCE_COUNT                   (1)
 
 /* QuadSPI - Peripheral instance base addresses */
 /** Peripheral QUADSPI base address */

--- a/s32/drivers/s32k3/BaseNXP/header/S32K344_SIUL2.h
+++ b/s32/drivers/s32k3/BaseNXP/header/S32K344_SIUL2.h
@@ -576,7 +576,7 @@ typedef struct {
 } SIUL2_Type, *SIUL2_MemMapPtr;
 
 /** Number of instances of the SIUL2 module. */
-#define SIUL2_INSTANCE_COUNT                     (1u)
+#define SIUL2_INSTANCE_COUNT                     (1)
 
 /* SIUL2 - Peripheral instance base addresses */
 /** Peripheral SIUL2 base address */

--- a/s32/drivers/s32k3/BaseNXP/header/S32K344_WKPU.h
+++ b/s32/drivers/s32k3/BaseNXP/header/S32K344_WKPU.h
@@ -92,7 +92,7 @@ typedef struct {
 } WKPU_Type, *WKPU_MemMapPtr;
 
 /** Number of instances of the WKPU module. */
-#define WKPU_INSTANCE_COUNT                      (1u)
+#define WKPU_INSTANCE_COUNT                      (1)
 
 /* WKPU - Peripheral instance base addresses */
 /** Peripheral WKPU base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_CANXL_SIC.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_CANXL_SIC.h
@@ -91,7 +91,7 @@ typedef struct {
 } CANXL_SIC_Type, *CANXL_SIC_MemMapPtr;
 
 /** Number of instances of the CANXL_SIC module. */
-#define CANXL_SIC_INSTANCE_COUNT                 (2u)
+#define CANXL_SIC_INSTANCE_COUNT                 (2)
 
 /* CANXL_SIC - Peripheral instance base addresses */
 /** Peripheral CANXL_0__SIC base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_LINFLEXD.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_LINFLEXD.h
@@ -95,7 +95,7 @@ typedef struct {
 } LINFLEXD_Type, *LINFLEXD_MemMapPtr;
 
 /** Number of instances of the LINFLEXD module. */
-#define LINFLEXD_INSTANCE_COUNT                  (13u)
+#define LINFLEXD_INSTANCE_COUNT                  (13)
 
 /* LINFLEXD - Peripheral instance base addresses */
 /** Peripheral LINFLEX_0 base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_NETC_F1.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_NETC_F1.h
@@ -88,7 +88,7 @@ typedef struct {
 } NETC_F1_Type, *NETC_F1_MemMapPtr;
 
 /** Number of instances of the NETC_F1 module. */
-#define NETC_F1_INSTANCE_COUNT                   (1u)
+#define NETC_F1_INSTANCE_COUNT                   (1)
 
 /* NETC_F1 - Peripheral instance base addresses */
 /** Peripheral NETC__EMDIO_BASE base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_RTU_MRU.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_RTU_MRU.h
@@ -135,7 +135,7 @@ typedef struct {
 } RTU_MRU_Type, *RTU_MRU_MemMapPtr;
 
 /** Number of instances of the RTU_MRU module. */
-#define RTU_MRU_INSTANCE_COUNT                   (8u)
+#define RTU_MRU_INSTANCE_COUNT                   (8)
 
 /* RTU_MRU - Peripheral instance base addresses */
 /** Peripheral RTU0__MRU_0 base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_SIUL2.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_SIUL2.h
@@ -485,7 +485,7 @@ typedef struct {
 } SIUL2_Type, *SIUL2_MemMapPtr;
 
 /** Number of instances of the SIUL2 module. */
-#define SIUL2_INSTANCE_COUNT                     (5u)
+#define SIUL2_INSTANCE_COUNT                     (5)
 
 /* SIUL2 - Peripheral instance base addresses */
 /** Peripheral SIUL2_0 base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_SPI.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_SPI.h
@@ -106,7 +106,7 @@ typedef struct {
 } SPI_Type, *SPI_MemMapPtr;
 
 /** Number of instances of the SPI module. */
-#define SPI_INSTANCE_COUNT                       (10u)
+#define SPI_INSTANCE_COUNT                       (10)
 
 /* SPI - Peripheral instance base addresses */
 /** Peripheral SPI_0 base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_STM.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_STM.h
@@ -85,7 +85,7 @@ typedef struct {
 } STM_Type, *STM_MemMapPtr;
 
 /** Number of instances of the STM module. */
-#define STM_INSTANCE_COUNT                       (13u)
+#define STM_INSTANCE_COUNT                       (13)
 
 /* STM - Peripheral instance base addresses */
 /** Peripheral CE_STM_0 base address */

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_SWT.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_SWT.h
@@ -81,7 +81,7 @@ typedef struct {
 } SWT_Type, *SWT_MemMapPtr;
 
 /** Number of instances of the SWT module. */
-#define SWT_INSTANCE_COUNT                       (13u)
+#define SWT_INSTANCE_COUNT                       (13)
 
 /* SWT - Peripheral instance base addresses */
 /** Peripheral CE_SWT_0 base address */


### PR DESCRIPTION
At present, many of the NXP S32 shim drivers do not make use of devicetree instance-based macros because the NXP S32 HAL relies on an index-based approach, requiring knowledge of the peripheral instance index during both compilation and runtime, and this index might not align with the devicetree instance index.

As a prerequisite to refactor all those shim drivers to use the instance-based DT macros and to obtain the peripheral instance index at compile time as done in [f809614136](https://github.com/zephyrproject-rtos/zephyr/commit/f809614136c748707d365a1342128e0158145d55#diff-4bca4b738d2c995bd5b9a6e9bdf970d6c43fdfb33f2955e3093ac971228fec3aR404), remove the `u` prefix from the HAL instance count macros so that they can be used with `LISTIFY`.

> [!NOTE]
> There will be a separate PR in `zephyr` repo for each shim driver to be refactored, so to keep the dependencies between them as simple as possible, I pushed all updates needed for the HAL on this pr at once.