### PR TITLE
mcux: hal_nxp: remove CONFIG_IPM_IMX_REV2

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -112,7 +112,7 @@ include_driver_ifdef(CONFIG_UART_MCUX_FLEXCOMM		flexcomm/usart	driver_flexcomm_u
 include_driver_ifdef(CONFIG_WDT_MCUX_WWDT		wwdt		driver_wwdt)
 include_driver_ifdef(CONFIG_ADC_MCUX_ADC12		adc12		driver_adc12)
 include_driver_ifdef(CONFIG_ADC_MCUX_ADC16		adc16		driver_adc16)
-include_driver_ifdef(CONFIG_IPM_IMX_REV2		mu		driver_mu)
+include_driver_ifdef(CONFIG_IPM_IMX			mu		driver_mu)
 include_driver_ifdef(CONFIG_MBOX_NXP_IMX_MU		mu		driver_mu)
 include_driver_ifdef(CONFIG_CAN_MCUX_FLEXCAN		flexcan		driver_flexcan)
 include_driver_ifdef(CONFIG_CAN_MCUX_FLEXCAN_FD		flexcan		driver_flexcan)


### PR DESCRIPTION
Remove CONFIG_IPM_IMX_REV2, as this Kconfig has been removed from Zephyr in favor of CONFIG_IPM_IMX (since both Kconfigs handled the same IP block)