### PR TITLE
s32: mcux: use the SoC name to set the device name

### DIFF
--- a/s32/CMakeLists.txt
+++ b/s32/CMakeLists.txt
@@ -46,10 +46,8 @@ if(CONFIG_HAS_MCUX)
 
   set(MCUX_SDK_PROJECT_NAME ${ZEPHYR_CURRENT_LIBRARY})
 
-  # Translate the SoC name and part number into the MCUX device and CPU
-  # name respectively
+  # Translate the SoC name into the MCUX device
   string(TOUPPER ${CONFIG_SOC} MCUX_DEVICE)
-  set(MCUX_CPU CPU_${CONFIG_SOC_PART_NUMBER})
 
   # This is normally done in mcux/hal_nxp.cmake, but we need to point to the
   # path on this directory instead
@@ -59,7 +57,7 @@ if(CONFIG_HAS_MCUX)
   )
 
   # MCUX uses the CPU name to expose SoC-specific features of a given peripheral
-  zephyr_compile_definitions(${MCUX_CPU})
+  zephyr_compile_definitions(CPU_${MCUX_DEVICE})
 
   # Clock control is supported through RTD, so disable it in the MCUX drivers
   zephyr_compile_definitions(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL=1)


### PR DESCRIPTION
Switch to use `CONFIG_SOC` to define the device name and CPU name needed to build MCUX drivers and device sources.
The SoC part number for S32 now makes reference to the actual part number of device as defined in datasheets and should't be used to define the CPU name.