### PR TITLE
Support I3C for S32Z27

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -71,3 +71,5 @@ Patch List:
   8. MIMX8QM6: drivers: fsl_clock.c: Report NULL frequency for unsupported core
   9. devices: MIMX8QX6: Add header files for QXP's DSP core
   10. MIMX8QX6: scfw_api: Switch to including generic fsl_device_registers.h
+  11. mcux-sdk/drivers/i3c/fsl_i3c.c: add guards to avoid compilation warnings when building
+      with SDK clock control driver disabled for SoC has no reset driver.

--- a/mcux/mcux-sdk/drivers/i3c/fsl_i3c.c
+++ b/mcux/mcux-sdk/drivers/i3c/fsl_i3c.c
@@ -795,7 +795,11 @@ void I3C_GetDefaultConfig(i3c_config_t *config)
  */
 void I3C_Init(I3C_Type *base, const i3c_config_t *config, uint32_t sourceClock_Hz)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) || \
+    !(defined(FSL_FEATURE_I3C_HAS_NO_RESET) && FSL_FEATURE_I3C_HAS_NO_RESET)
     uint32_t instance = I3C_GetInstance(base);
+#endif
+
     uint32_t configValue;
 
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
@@ -928,7 +932,11 @@ void I3C_MasterGetDefaultConfig(i3c_master_config_t *masterConfig)
  */
 void I3C_MasterInit(I3C_Type *base, const i3c_master_config_t *masterConfig, uint32_t sourceClock_Hz)
 {
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) || \
+    !(defined(FSL_FEATURE_I3C_HAS_NO_RESET) && FSL_FEATURE_I3C_HAS_NO_RESET)
     uint32_t instance = I3C_GetInstance(base);
+#endif
+
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Ungate the clock. */
     CLOCK_EnableClock(kI3cClocks[instance]);
@@ -2601,7 +2609,12 @@ void I3C_SlaveInit(I3C_Type *base, const i3c_slave_config_t *slaveConfig, uint32
     assert(0UL != slowClock_Hz);
 
     uint32_t configValue;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) || \
+    !(defined(FSL_FEATURE_I3C_HAS_NO_RESET) && FSL_FEATURE_I3C_HAS_NO_RESET)
     uint32_t instance = I3C_GetInstance(base);
+#endif
+
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Ungate the clock. */
     CLOCK_EnableClock(kI3cClocks[instance]);

--- a/s32/mcux/devices/S32Z27/S32Z27_features.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_features.h
@@ -25,4 +25,20 @@
 /* @brief Has timer enable control. */
 #define FSL_FEATURE_PIT_HAS_MDIS (1)
 
+
+/* I3C module features */
+
+/* @brief Has TERM bitfile in MERRWARN register. */
+#define FSL_FEATURE_I3C_HAS_NO_MERRWARN_TERM (0)
+/* @brief SOC has no reset driver. */
+#define FSL_FEATURE_I3C_HAS_NO_RESET (1)
+/* @brief Use fixed BAMATCH count, do not provide editable BAMATCH. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_BAMATCH (0)
+/* @brief Register SCONFIG do not have IDRAND bitfield. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_IDRAND (1)
+/* @brief Register SCONFIG has HDROK bitfield. */
+#define FSL_FEATURE_I3C_HAS_HDROK (1)
+/* @brief Has ERRATA_051617. */
+#define FSL_FEATURE_I3C_HAS_ERRATA_051617 (1)
+
 #endif /* _S32Z27_FEATURES_H_ */

--- a/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
@@ -19,4 +19,33 @@
 /** Interrupt vectors for the PIT peripheral type */
 #define PIT_IRQS                                 { RTU_RTUn_PIT0_IRQn }
 
+/* I3C - Peripheral instance base addresses */
+/** Peripheral I3C0 base address */
+#define I3C0_BASE                                IP_I3C_0_BASE
+/** Peripheral I3C0 base pointer */
+#define I3C0                                     IP_I3C_0
+/** Peripheral I3C1 base address */
+#define I3C1_BASE                                IP_I3C_1_BASE
+/** Peripheral I3C1 base pointer */
+#define I3C1                                     IP_I3C_1
+/** Peripheral I3C2 base address */
+#define I3C2_BASE                                IP_I3C_2_BASE
+/** Peripheral I3C1 base pointer */
+#define I3C2                                     IP_I3C_2
+/** Array initializer of I3C peripheral base addresses */
+#define I3C_BASE_ADDRS                           IP_I3C_BASE_ADDRS
+/** Array initializer of I3C peripheral base pointers */
+#define I3C_BASE_PTRS                            IP_I3C_BASE_PTRS
+/** Interrupt vectors for the I3C peripheral type */
+#define I3C_IRQS                                 { RTU_I3C0_IRQn, RTU_I3C1_IRQn, RTU_I3C2_IRQn }
+
+/*
+ * These bit fields are not existed on this SoC, I3C slave request IBI will not be
+ * supported because I3C functionality is not stable in this SoC. Keep define these
+ * macros in order to build.
+ */
+#define I3C_IBIEXT2_EXT5(x)                     0
+#define I3C_IBIEXT2_EXT6(x)                     0
+#define I3C_IBIEXT2_EXT7(x)                     0
+
 #endif /* _S32Z27_GLUE_MCUX_H_ */


### PR DESCRIPTION
This adds glue code to reuse i3c mcux sdk for s32z27. Alsoa dd patch on the mcux driver for fixing compiler warnings
