### PR TITLE
Enabled support for the HiFi 4 DSP core in the MIMXRT685 microcontroller

### DIFF
--- a/mcux/CMakeLists.txt
+++ b/mcux/CMakeLists.txt
@@ -12,6 +12,10 @@ set(MCUX_SDK_PROJECT_NAME ${ZEPHYR_CURRENT_LIBRARY})
 if(NOT HWMv2)
   # Include HWMv1 logic for MCUX variables
   include(${CMAKE_CURRENT_LIST_DIR}/hwmv1.cmake)
+  
+  if((DEFINED CMAKE_C_COMPILER) AND (${CMAKE_C_COMPILER} MATCHES "xtensa"))
+    set(MCUX_IS_DSP true)
+  endif()
 else()
   string(TOUPPER ${CONFIG_SOC} MCUX_DEVICE_PATH)
   string(TOUPPER ${CONFIG_SOC} MCUX_DEVICE)
@@ -46,10 +50,21 @@ zephyr_compile_definitions(${MCUX_CPU})
 # Build mcux device-specific objects. Although it is not normal
 # practice, drilling down like this avoids the need for repetitive
 # build scripts for every mcux device.
+
 zephyr_library_sources(mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers/fsl_clock.c)
 if (${MCUX_DEVICE} MATCHES "LPC|MIMXRT6|MIMXRT5")
-  zephyr_library_sources(mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers/fsl_power.c)
+  # fsl_power.c does not build on DSPs because of missing symbols in fsl_device_registers.h
+  if(NOT MCUX_IS_DSP)
+    zephyr_library_sources(mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers/fsl_power.c)
+  endif()
   zephyr_library_sources(mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers/fsl_reset.c)
+endif()
+
+# i.MXRT500 and i.MXRT600 have DSPs - DSP support expected.
+# Don't include DSP support while building for DSP cores, as it 
+# doesn't serve any purpose and depends on fsl_power.c.
+if (${MCUX_DEVICE} MATCHES "MIMXRT6|MIMXRT5" AND NOT MCUX_IS_DSP)
+    zephyr_library_sources(mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers/fsl_dsp.c)
 endif()
 
 # RT11xx SOC initialization file requires additional drivers, import them

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -281,6 +281,7 @@ endif()
 endif()
 
 if(${MCUX_DEVICE} MATCHES "MIMXRT(5|6)")
+  set(CONFIG_USE_driver_pca9420 true)
   include(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/lpc_iopctl/driver_lpc_iopctl.cmake)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/lpc_iopctl)
 endif()


### PR DESCRIPTION
This PR resolves build errors encountered when porting the Zephyr RTOS to the Cadence HiFi 4 DSP core of the NXP MIMXRT685.