### PR TITLE
s32: soc: s32z27: netc: remove 'u' suffix from macro

### DIFF
--- a/s32/soc/s32z27/include/Netc_Eth_Ip_Features.h
+++ b/s32/soc/s32z27/include/Netc_Eth_Ip_Features.h
@@ -55,7 +55,7 @@ extern "C"
 #define NETC_ETH_IP_NUM_OF_PHYSICAL_CTRLS           (1U)
 
 /** @brief Total number of ethernet controllers supported on NETC(VSI + PSI). */
-#define FEATURE_NETC_ETH_NUMBER_OF_CTRLS            (8U)
+#define FEATURE_NETC_ETH_NUMBER_OF_CTRLS            (8)
 
 #define FEATURE_NETC_NUMBER_OF_FUNC            (4U)
 /** @brief Index of the physical SI. */


### PR DESCRIPTION
Netc shim driver uses the macro FEATURE_NETC_ETH_NUMBER_OF_CTRLS with LISTIFY.
Remove 'u' suffix from macro so that it can be used with LISTIFY.