### PR TITLE
Remove 'u' from Lcu and Trgmux instance count

### DIFF
--- a/s32/drivers/s32k3/BaseNXP/header/S32K344_LCU.h
+++ b/s32/drivers/s32k3/BaseNXP/header/S32K344_LCU.h
@@ -104,7 +104,7 @@ typedef struct {
 } LCU_Type, *LCU_MemMapPtr;
 
 /** Number of instances of the LCU module. */
-#define LCU_INSTANCE_COUNT                       (2u)
+#define LCU_INSTANCE_COUNT                       (2)
 
 /* LCU - Peripheral instance base addresses */
 /** Peripheral LCU_0 base address */

--- a/s32/drivers/s32k3/BaseNXP/header/S32K344_TRGMUX.h
+++ b/s32/drivers/s32k3/BaseNXP/header/S32K344_TRGMUX.h
@@ -77,7 +77,7 @@ typedef struct {
 } TRGMUX_Type, *TRGMUX_MemMapPtr;
 
 /** Number of instances of the TRGMUX module. */
-#define TRGMUX_INSTANCE_COUNT                    (1u)
+#define TRGMUX_INSTANCE_COUNT                    (1)
 
 /* TRGMUX - Peripheral instance base addresses */
 /** Peripheral TRGMUX base address */


### PR DESCRIPTION
Make LCU_INSTANCE_COUNT and TRGMUX_INSTANCE_COUNT usable by Zephyr