### PR TITLE
s32: mcux: s32k146: add LPI2C and LPSPI support

### DIFF
--- a/s32/mcux/devices/S32K146/S32K146_device.h
+++ b/s32/mcux/devices/S32K146/S32K146_device.h
@@ -550,4 +550,54 @@ typedef struct {
  * @}
  */ /* end of group LPUART_Peripheral_Access_Layer */
 
+/*!
+ * @addtogroup LPI2C_Peripheral_Access_Layer LPI2C Peripheral Access Layer
+ * @{
+ */
+
+/* LPI2C - Peripheral instance base addresses */
+/** Peripheral LPI2C0 base address */
+#define LPI2C0_BASE                              IP_LPI2C0_BASE
+/** Peripheral LPI2C0 base pointer */
+#define LPI2C0                                   IP_LPI2C0
+/** Array initializer of LPI2C peripheral base addresses */
+#define LPI2C_BASE_ADDRS                         IP_LPI2C_BASE_ADDRS
+/** Array initializer of LPI2C peripheral base pointers */
+#define LPI2C_BASE_PTRS                          IP_LPI2C_BASE_PTRS
+/** Interrupt vectors for the LPI2C peripheral type */
+#define LPI2C_IRQS                               { LPI2C0_Master_IRQn }
+
+/*!
+ * @}
+ */ /* end of group LPI2C_Peripheral_Access_Layer */
+
+/*!
+ * @addtogroup LPSPI_Peripheral_Access_Layer LPSPI Peripheral Access Layer
+ * @{
+ */
+
+/* LPSPI - Peripheral instance base addresses */
+/** Peripheral LPSPI0 base address */
+#define LPSPI0_BASE                              IP_LPSPI0_BASE
+/** Peripheral LPSPI0 base pointer */
+#define LPSPI0                                   IP_LPSPI0
+/** Peripheral LPSPI1 base address */
+#define LPSPI1_BASE                              IP_LPSPI1_BASE
+/** Peripheral LPSPI1 base pointer */
+#define LPSPI1                                   IP_LPSPI1
+/** Peripheral LPSPI2 base address */
+#define LPSPI2_BASE                              IP_LPSPI2_BASE
+/** Peripheral LPSPI2 base pointer */
+#define LPSPI2                                   IP_LPSPI2
+/** Array initializer of LPSPI peripheral base addresses */
+#define LPSPI_BASE_ADDRS                         IP_LPSPI_BASE_ADDRS
+/** Array initializer of LPSPI peripheral base pointers */
+#define LPSPI_BASE_PTRS                          IP_LPSPI_BASE_PTRS
+/** Interrupt vectors for the LPSPI peripheral type */
+#define LPSPI_IRQS                               { LPSPI0_IRQn, LPSPI1_IRQn, LPSPI2_IRQn }
+
+/*!
+ * @}
+ */ /* end of group LPSPI_Peripheral_Access_Layer */
+
 #endif /* _S32K146_DEVICE_H_ */

--- a/s32/mcux/devices/S32K146/S32K146_features.h
+++ b/s32/mcux/devices/S32K146/S32K146_features.h
@@ -17,6 +17,10 @@
 #define FSL_FEATURE_SOC_GPIO_COUNT (5)
 /* @brief LPUART availability on the SoC. */
 #define FSL_FEATURE_SOC_LPUART_COUNT (3)
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (1)
+/* @brief LPSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_LPSPI_COUNT (3)
 
 /* SYSMPU module features */
 
@@ -135,5 +139,21 @@
 #define FSL_FEATURE_LPUART_HAS_GLOBAL (1)
 /* @brief Has LPUART_PINCFG. */
 #define FSL_FEATURE_LPUART_HAS_PINCFG (1)
+
+/* LPI2C module features */
+
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (4)
+
+/* LPSPI module features */
+
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPSPI_FIFO_SIZEn(x) (4)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has CCR1 (related to existence of registers CCR1). */
+#define FSL_FEATURE_LPSPI_HAS_CCR1 (0)
 
 #endif /* _S32K146_FEATURES_H_ */


### PR DESCRIPTION
Add definitions for LPI2C and LPSPI of S32K146 devices.