### PR TITLE
s32: mcux: s32k146: add support for cache driver

### DIFF
--- a/s32/CMakeLists.txt
+++ b/s32/CMakeLists.txt
@@ -99,6 +99,8 @@ if(CONFIG_HAS_MCUX)
 
     zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/../mcux/mcux-sdk/drivers/sysmpu)
     include_mcux_driver_ifdef(CONFIG_ARM_MPU sysmpu driver_sysmpu)
+
+    include_mcux_driver_ifdef(CONFIG_HAS_MCUX_CACHE cache/lmem driver_cache_lmem)
   endif()
 
 endif()

--- a/s32/mcux/devices/S32K146/S32K146_device.h
+++ b/s32/mcux/devices/S32K146/S32K146_device.h
@@ -550,6 +550,11 @@ typedef struct {
  * @}
  */ /* end of group LPUART_Peripheral_Access_Layer */
 
+
+/* ----------------------------------------------------------------------------
+   -- LPI2C Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
 /*!
  * @addtogroup LPI2C_Peripheral_Access_Layer LPI2C Peripheral Access Layer
  * @{
@@ -570,6 +575,10 @@ typedef struct {
 /*!
  * @}
  */ /* end of group LPI2C_Peripheral_Access_Layer */
+
+/* ----------------------------------------------------------------------------
+   -- LPSPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
 
 /*!
  * @addtogroup LPSPI_Peripheral_Access_Layer LPSPI Peripheral Access Layer
@@ -599,5 +608,46 @@ typedef struct {
 /*!
  * @}
  */ /* end of group LPSPI_Peripheral_Access_Layer */
+
+/* ----------------------------------------------------------------------------
+   -- LMEM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup LMEM_Peripheral_Access_Layer LMEM Peripheral Access Layer
+ * @{
+ */
+
+/*!
+ * @addtogroup LMEM_Register_Masks LMEM Register Masks
+ * @{
+ */
+
+/*! @name PCCCR - Cache control register */
+/*! @{ */
+
+/* ENWRBUF - Enable Write Buffer is not available on this SoC */
+#define LMEM_PCCCR_ENWRBUF_MASK                  (0U)
+#define LMEM_PCCCR_ENWRBUF_SHIFT                 (0U)
+#define LMEM_PCCCR_ENWRBUF(x)                    (((uint32_t)(((uint32_t)(x)) << LMEM_PCCCR_ENWRBUF_SHIFT)) & LMEM_PCCCR_ENWRBUF_MASK)
+/*! @} */
+
+/*!
+ * @}
+ */ /* end of group LMEM_Register_Masks */
+
+/* LMEM - Peripheral instance base addresses */
+/** Peripheral LMEM base address */
+#define LMEM_BASE                                IP_LMEM_BASE
+/** Peripheral LMEM base pointer */
+#define LMEM                                     IP_LMEM
+/** Array initializer of LMEM peripheral base addresses */
+#define LMEM_BASE_ADDRS                          IP_LMEM_BASE_ADDRS
+/** Array initializer of LMEM peripheral base pointers */
+#define LMEM_BASE_PTRS                           IP_LMEM_BASE_PTRS
+
+/*!
+ * @}
+ */ /* end of group LMEM_Peripheral_Access_Layer */
 
 #endif /* _S32K146_DEVICE_H_ */

--- a/s32/mcux/devices/S32K146/S32K146_features.h
+++ b/s32/mcux/devices/S32K146/S32K146_features.h
@@ -21,6 +21,8 @@
 #define FSL_FEATURE_SOC_LPI2C_COUNT (1)
 /* @brief LPSPI availability on the SoC. */
 #define FSL_FEATURE_SOC_LPSPI_COUNT (3)
+/* @brief LMEM availability on the SoC. */
+#define FSL_FEATURE_SOC_LMEM_COUNT (1)
 
 /* SYSMPU module features */
 
@@ -155,5 +157,16 @@
 #define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
 /* @brief Has CCR1 (related to existence of registers CCR1). */
 #define FSL_FEATURE_LPSPI_HAS_CCR1 (0)
+
+/* LMEM module features */
+
+/* @brief Has process identifier support. */
+#define FSL_FEATURE_LMEM_HAS_SYSTEMBUS_CACHE (0)
+/* @brief Has L1 cache. */
+#define FSL_FEATURE_HAS_L1CACHE (1)
+/* @brief L1 ICACHE line size in byte. */
+#define FSL_FEATURE_L1ICACHE_LINESIZE_BYTE (16)
+/* @brief L1 DCACHE line size in byte. */
+#define FSL_FEATURE_L1DCACHE_LINESIZE_BYTE (16)
 
 #endif /* _S32K146_FEATURES_H_ */


### PR DESCRIPTION
Add definitions to use MCUX SDK cache driver for LMEM controller on S32K146 devices.

Note that `LMEM_PCCCR_ENWRBUF` is not present on S32K1xx devices so it is defined to have no effect if used in the cache driver.