### PR TITLE
s32: s32ze: patch I3C header in order to build with i3c mcux-sdk

### DIFF
--- a/s32/README
+++ b/s32/README
@@ -62,3 +62,4 @@ Patch List for S32Z/E:
      for S32Z/E.
    - Remove 'static inline' keywords from 'Netc_Eth_Ip_MSIX_Rx' function so that it can be
      used as an extern function outside of the file declaration.
+   - Use names from the HAL 0.9.0 for some reserved registers in order to build with I3C mcux-sdk

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_I3C.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_I3C.h
@@ -73,7 +73,7 @@ typedef struct {
   __IO uint32_t MCONFIG;                           /**< Controller Configuration, offset: 0x0 */
   __IO uint32_t SCONFIG;                           /**< Target Configuration, offset: 0x4 */
   __IO uint32_t SSTATUS;                           /**< Target Status, offset: 0x8 */
-  uint8_t RESERVED_0[4];
+  __IO uint32_t SCTRL;                             /**< Reserved, keep it in order to build, offset 0xC */
   __IO uint32_t SINTSET;                           /**< Target Interrupt Set, offset: 0x10 */
   __IO uint32_t SINTCLR;                           /**< Target Interrupt Clear, offset: 0x14 */
   __I  uint32_t SINTMASKED;                        /**< Target Interrupt Mask, offset: 0x18 */
@@ -87,50 +87,57 @@ typedef struct {
   __O  uint32_t SWDATAH;                           /**< Target Write Data Half-word, offset: 0x38 */
   __O  uint32_t SWDATAHE;                          /**< Target Write Data Half-word End, offset: 0x3C */
   __I  uint32_t SRDATAB;                           /**< Target Read Data Byte, offset: 0x40 */
-  uint8_t RESERVED_1[4];
+  uint8_t RESERVED_0[4];
   union {                                          /* offset: 0x48 */
     __I  uint32_t MRDATAH;                           /**< Controller Read Data Halfword, offset: 0x48 */
     __I  uint32_t SRDATAH;                           /**< Target Read Data Halfword, offset: 0x48 */
-  } SRDATAH_MRDATAH;
-  uint8_t RESERVED_2[8];
+  };
+  uint8_t RESERVED_1[8];
   union {                                          /* offset: 0x54 */
     __IO uint32_t SWDATAB1;                          /**< Target Write Data Byte, offset: 0x54 */
   } SWDATA_B_H;
-  uint8_t RESERVED_3[4];
+  uint8_t RESERVED_2[4];
   __I  uint32_t SCAPABILITIES2;                    /**< Target Capabilities 2, offset: 0x5C */
   __I  uint32_t SCAPABILITIES;                     /**< Target Capabilities, offset: 0x60 */
-  uint8_t RESERVED_4[12];
+  uint8_t RESERVED_3[4];
+  __IO uint32_t SMAXLIMITS;                        /**< Reserved, keep it in order to build, offset: 0x68 */
+  __IO uint32_t SIDPARTNO;                         /**< Reserved, keep it in order to build, offset: 0x6C */
        uint32_t SIDEXT;                            /**< Target ID Extension, offset: 0x70 */
-  uint8_t RESERVED_5[8];
+  __IO uint32_t SVENDORID;                         /**< Reserved, keep it in order to build, offset: 0x74 */
+  __IO uint32_t STCCLOCK;                          /**< Reserved, keep it in order to build, offset: 0x78 */
   __I  uint32_t SMSGLAST;                          /**< Target Message Last Matched, offset: 0x7C */
-  uint8_t RESERVED_6[4];
+  uint8_t RESERVED_4[4];
   __IO uint32_t MCTRL;                             /**< Controller Control, offset: 0x84 */
   __IO uint32_t MSTATUS;                           /**< Controller Status, offset: 0x88 */
-  uint8_t RESERVED_7[4];
+  __IO uint32_t MIBIRULES;                         /**< Reserved, keep it in order to build, offset: 0x8C */
   __IO uint32_t MINTSET;                           /**< Controller Interrupt Set, offset: 0x90 */
   __IO uint32_t MINTCLR;                           /**< Controller Interrupt Clear, offset: 0x94 */
   __I  uint32_t MINTMASKED;                        /**< Controller Interrupt Mask, offset: 0x98 */
   __IO uint32_t MERRWARN;                          /**< Controller Errors and Warnings, offset: 0x9C */
   __IO uint32_t MDMACTRL;                          /**< Controller DMA Control, offset: 0xA0 */
-  uint8_t RESERVED_8[8];
+  uint8_t RESERVED_5[8];
   __IO uint32_t MDATACTRL;                         /**< Controller Data Control, offset: 0xAC */
   __O  uint32_t MWDATAB;                           /**< Controller Write Data Byte, offset: 0xB0 */
   __O  uint32_t MWDATABE;                          /**< Controller Write Data Byte End, offset: 0xB4 */
   __O  uint32_t MWDATAH;                           /**< Controller Write Data Halfword, offset: 0xB8 */
   __O  uint32_t MWDATAHE;                          /**< Controller Write Data Halfword End, offset: 0xBC */
   __I  uint32_t MRDATAB;                           /**< Controller Read Data Byte, offset: 0xC0 */
-  uint8_t RESERVED_9[8];
+  uint8_t RESERVED_6[8];
   union {                                          /* offset: 0xCC */
     __O  uint32_t MWDATAB1;                          /**< Controller Write Byte Data 1(to bus), offset: 0xCC */
-  } MWDATA_B1_H1;
+  };
   union {                                          /* offset: 0xD0 */
     __O  uint32_t MWMSG_SDR_CONTROL;                 /**< Controller Write Message Control in SDR mode, offset: 0xD0 */
     __O  uint32_t MWMSG_SDR_DATA;                    /**< Controller Write Message Data in SDR mode, offset: 0xD0 */
-  } MWMSG_SDR;
+  };
   __I  uint32_t MRMSG_SDR;                         /**< Controller Read Message in SDR mode, offset: 0xD4 */
-  uint8_t RESERVED_10[72];
+  uint8_t RESERVED_10[4];
+  __I  uint32_t MRMSG_DDR;                         /**< Reserved, keep it in order to build, offset: 0xDC */
+  uint8_t RESERVED_11[4];
+  __IO uint32_t MDYNADDR;                          /**< Reserved, keep it in order to build, offset: 0xE4 */
+  uint8_t RESERVED_12[56];
   __IO uint32_t SMAPCTRL1;                         /**< Map Feature Control 1, offset: 0x120 */
-  uint8_t RESERVED_11[3788];
+  uint8_t RESERVED_13[3788];
   __IO uint32_t SELFRESET;                         /**< Self Reset, offset: 0xFF0 */
 } I3C_Type, *I3C_MemMapPtr;
 

--- a/s32/mcux/devices/S32Z27/S32Z27_device.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_device.h
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _S32Z27_DEVICE_H_
+#define _S32Z27_DEVICE_H_
+
+/*
+ * These bit fields are not existed on this SoC, I3C slave request IBI will not be
+ * supported because I3C functionality is not stable in this SoC. Keep define these
+ * macros in order to build.
+ */
+#define I3C_IBIEXT2_EXT5(x)                     0
+#define I3C_IBIEXT2_EXT6(x)                     0
+#define I3C_IBIEXT2_EXT7(x)                     0
+
+/*
+ * These macros not defined by the HAL because features provided by them is not used
+ * on the hardware, keep define them here in order to build
+ */
+
+/*! @name SCONFIG - Target Configuration */
+/*! @{ */
+
+#define I3C_SCONFIG_S0IGNORE_MASK                (0x8U)
+#define I3C_SCONFIG_S0IGNORE_SHIFT               (3U)
+#define I3C_SCONFIG_S0IGNORE_WIDTH               (1U)
+#define I3C_SCONFIG_S0IGNORE(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SCONFIG_S0IGNORE_SHIFT)) & I3C_SCONFIG_S0IGNORE_MASK)
+
+#define I3C_SCONFIG_HDROK_MASK                   (0x10U)
+#define I3C_SCONFIG_HDROK_SHIFT                  (4U)
+#define I3C_SCONFIG_HDROK_WIDTH                  (1U)
+#define I3C_SCONFIG_HDROK(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SCONFIG_HDROK_SHIFT)) & I3C_SCONFIG_HDROK_MASK)
+
+#define I3C_SCONFIG_OFFLINE_MASK                 (0x200U)
+#define I3C_SCONFIG_OFFLINE_SHIFT                (9U)
+#define I3C_SCONFIG_OFFLINE_WIDTH                (1U)
+#define I3C_SCONFIG_OFFLINE(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_SCONFIG_OFFLINE_SHIFT)) & I3C_SCONFIG_OFFLINE_MASK)
+/*! @} */
+
+/*! @name SSTATUS - Target Status */
+/*! @{ */
+
+#define I3C_SSTATUS_STHDR_MASK                   (0x40U)
+#define I3C_SSTATUS_STHDR_SHIFT                  (6U)
+#define I3C_SSTATUS_STHDR_WIDTH                  (1U)
+#define I3C_SSTATUS_STHDR(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_STHDR_SHIFT)) & I3C_SSTATUS_STHDR_MASK)
+
+#define I3C_SSTATUS_DACHG_MASK                   (0x2000U)
+#define I3C_SSTATUS_DACHG_SHIFT                  (13U)
+#define I3C_SSTATUS_DACHG_WIDTH                  (1U)
+#define I3C_SSTATUS_DACHG(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_DACHG_SHIFT)) & I3C_SSTATUS_DACHG_MASK)
+
+#define I3C_SSTATUS_CCC_MASK                     (0x4000U)
+#define I3C_SSTATUS_CCC_SHIFT                    (14U)
+#define I3C_SSTATUS_CCC_WIDTH                    (1U)
+#define I3C_SSTATUS_CCC(x)                       (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_CCC_SHIFT)) & I3C_SSTATUS_CCC_MASK)
+
+#define I3C_SSTATUS_HDRMATCH_MASK                (0x10000U)
+#define I3C_SSTATUS_HDRMATCH_SHIFT               (16U)
+#define I3C_SSTATUS_HDRMATCH_WIDTH               (1U)
+#define I3C_SSTATUS_HDRMATCH(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_HDRMATCH_SHIFT)) & I3C_SSTATUS_HDRMATCH_MASK)
+
+#define I3C_SSTATUS_CHANDLED_MASK                (0x20000U)
+#define I3C_SSTATUS_CHANDLED_SHIFT               (17U)
+#define I3C_SSTATUS_CHANDLED_WIDTH               (1U)
+#define I3C_SSTATUS_CHANDLED(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_CHANDLED_SHIFT)) & I3C_SSTATUS_CHANDLED_MASK)
+
+#define I3C_SSTATUS_EVENT_MASK                   (0x40000U)
+#define I3C_SSTATUS_EVENT_SHIFT                  (18U)
+#define I3C_SSTATUS_EVENT_WIDTH                  (1U)
+#define I3C_SSTATUS_EVENT(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_EVENT_SHIFT)) & I3C_SSTATUS_EVENT_MASK)
+
+#define I3C_SSTATUS_EVDET_MASK                   (0x300000U)
+#define I3C_SSTATUS_EVDET_SHIFT                  (20U)
+#define I3C_SSTATUS_EVDET_WIDTH                  (2U)
+#define I3C_SSTATUS_EVDET(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_EVDET_SHIFT)) & I3C_SSTATUS_EVDET_MASK)
+
+#define I3C_SSTATUS_IBIDIS_MASK                  (0x1000000U)
+#define I3C_SSTATUS_IBIDIS_SHIFT                 (24U)
+#define I3C_SSTATUS_IBIDIS_WIDTH                 (1U)
+#define I3C_SSTATUS_IBIDIS(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_IBIDIS_SHIFT)) & I3C_SSTATUS_IBIDIS_MASK)
+
+#define I3C_SSTATUS_MRDIS_MASK                   (0x2000000U)
+#define I3C_SSTATUS_MRDIS_SHIFT                  (25U)
+#define I3C_SSTATUS_MRDIS_WIDTH                  (1U)
+#define I3C_SSTATUS_MRDIS(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_MRDIS_SHIFT)) & I3C_SSTATUS_MRDIS_MASK)
+
+#define I3C_SSTATUS_HJDIS_MASK                   (0x8000000U)
+#define I3C_SSTATUS_HJDIS_SHIFT                  (27U)
+#define I3C_SSTATUS_HJDIS_WIDTH                  (1U)
+#define I3C_SSTATUS_HJDIS(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_HJDIS_SHIFT)) & I3C_SSTATUS_HJDIS_MASK)
+
+#define I3C_SSTATUS_ACTSTATE_MASK                (0x30000000U)
+#define I3C_SSTATUS_ACTSTATE_SHIFT               (28U)
+#define I3C_SSTATUS_ACTSTATE_WIDTH               (2U)
+#define I3C_SSTATUS_ACTSTATE(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_ACTSTATE_SHIFT)) & I3C_SSTATUS_ACTSTATE_MASK)
+
+#define I3C_SSTATUS_TIMECTRL_MASK                (0xC0000000U)
+#define I3C_SSTATUS_TIMECTRL_SHIFT               (30U)
+#define I3C_SSTATUS_TIMECTRL_WIDTH               (2U)
+#define I3C_SSTATUS_TIMECTRL(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SSTATUS_TIMECTRL_SHIFT)) & I3C_SSTATUS_TIMECTRL_MASK)
+/*! @} */
+
+/*! @name SINTSET - Target Interrupt Set */
+/*! @{ */
+#define I3C_SINTSET_DACHG_MASK                   (0x2000U)
+#define I3C_SINTSET_DACHG_SHIFT                  (13U)
+#define I3C_SINTSET_DACHG_WIDTH                  (1U)
+#define I3C_SINTSET_DACHG(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SINTSET_DACHG_SHIFT)) & I3C_SINTSET_DACHG_MASK)
+
+#define I3C_SINTSET_CCC_MASK                     (0x4000U)
+#define I3C_SINTSET_CCC_SHIFT                    (14U)
+#define I3C_SINTSET_CCC_WIDTH                    (1U)
+#define I3C_SINTSET_CCC(x)                       (((uint32_t)(((uint32_t)(x)) << I3C_SINTSET_CCC_SHIFT)) & I3C_SINTSET_CCC_MASK)
+
+#define I3C_SINTSET_DDRMATCHED_MASK              (0x10000U)
+#define I3C_SINTSET_DDRMATCHED_SHIFT             (16U)
+#define I3C_SINTSET_DDRMATCHED_WIDTH             (1U)
+#define I3C_SINTSET_DDRMATCHED(x)                (((uint32_t)(((uint32_t)(x)) << I3C_SINTSET_DDRMATCHED_SHIFT)) & I3C_SINTSET_DDRMATCHED_MASK)
+
+#define I3C_SINTSET_CHANDLED_MASK                (0x20000U)
+#define I3C_SINTSET_CHANDLED_SHIFT               (17U)
+#define I3C_SINTSET_CHANDLED_WIDTH               (1U)
+#define I3C_SINTSET_CHANDLED(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SINTSET_CHANDLED_SHIFT)) & I3C_SINTSET_CHANDLED_MASK)
+
+#define I3C_SINTSET_EVENT_MASK                   (0x40000U)
+#define I3C_SINTSET_EVENT_SHIFT                  (18U)
+#define I3C_SINTSET_EVENT_WIDTH                  (1U)
+#define I3C_SINTSET_EVENT(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SINTSET_EVENT_SHIFT)) & I3C_SINTSET_EVENT_MASK)
+
+/*! @} */
+
+/*! @name SINTCLR - Target Interrupt Clear */
+/*! @{ */
+
+#define I3C_SINTCLR_DACHG_MASK                   (0x2000U)
+#define I3C_SINTCLR_DACHG_SHIFT                  (13U)
+#define I3C_SINTCLR_DACHG_WIDTH                  (1U)
+#define I3C_SINTCLR_DACHG(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SINTCLR_DACHG_SHIFT)) & I3C_SINTCLR_DACHG_MASK)
+
+#define I3C_SINTCLR_CCC_MASK                     (0x4000U)
+#define I3C_SINTCLR_CCC_SHIFT                    (14U)
+#define I3C_SINTCLR_CCC_WIDTH                    (1U)
+#define I3C_SINTCLR_CCC(x)                       (((uint32_t)(((uint32_t)(x)) << I3C_SINTCLR_CCC_SHIFT)) & I3C_SINTCLR_CCC_MASK)
+
+#define I3C_SINTCLR_DDRMATCHED_MASK              (0x10000U)
+#define I3C_SINTCLR_DDRMATCHED_SHIFT             (16U)
+#define I3C_SINTCLR_DDRMATCHED_WIDTH             (1U)
+#define I3C_SINTCLR_DDRMATCHED(x)                (((uint32_t)(((uint32_t)(x)) << I3C_SINTCLR_DDRMATCHED_SHIFT)) & I3C_SINTCLR_DDRMATCHED_MASK)
+
+#define I3C_SINTCLR_CHANDLED_MASK                (0x20000U)
+#define I3C_SINTCLR_CHANDLED_SHIFT               (17U)
+#define I3C_SINTCLR_CHANDLED_WIDTH               (1U)
+#define I3C_SINTCLR_CHANDLED(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SINTCLR_CHANDLED_SHIFT)) & I3C_SINTCLR_CHANDLED_MASK)
+
+#define I3C_SINTCLR_EVENT_MASK                   (0x40000U)
+#define I3C_SINTCLR_EVENT_SHIFT                  (18U)
+#define I3C_SINTCLR_EVENT_WIDTH                  (1U)
+#define I3C_SINTCLR_EVENT(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SINTCLR_EVENT_SHIFT)) & I3C_SINTCLR_EVENT_MASK)
+
+/*! @} */
+
+/*! @name SINTMASKED - Target Interrupt Mask */
+/*! @{ */
+
+#define I3C_SINTMASKED_DACHG_MASK                (0x2000U)
+#define I3C_SINTMASKED_DACHG_SHIFT               (13U)
+#define I3C_SINTMASKED_DACHG_WIDTH               (1U)
+#define I3C_SINTMASKED_DACHG(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SINTMASKED_DACHG_SHIFT)) & I3C_SINTMASKED_DACHG_MASK)
+
+#define I3C_SINTMASKED_CCC_MASK                  (0x4000U)
+#define I3C_SINTMASKED_CCC_SHIFT                 (14U)
+#define I3C_SINTMASKED_CCC_WIDTH                 (1U)
+#define I3C_SINTMASKED_CCC(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_SINTMASKED_CCC_SHIFT)) & I3C_SINTMASKED_CCC_MASK)
+
+#define I3C_SINTMASKED_DDRMATCHED_MASK           (0x10000U)
+#define I3C_SINTMASKED_DDRMATCHED_SHIFT          (16U)
+#define I3C_SINTMASKED_DDRMATCHED_WIDTH          (1U)
+#define I3C_SINTMASKED_DDRMATCHED(x)             (((uint32_t)(((uint32_t)(x)) << I3C_SINTMASKED_DDRMATCHED_SHIFT)) & I3C_SINTMASKED_DDRMATCHED_MASK)
+
+#define I3C_SINTMASKED_CHANDLED_MASK             (0x20000U)
+#define I3C_SINTMASKED_CHANDLED_SHIFT            (17U)
+#define I3C_SINTMASKED_CHANDLED_WIDTH            (1U)
+#define I3C_SINTMASKED_CHANDLED(x)               (((uint32_t)(((uint32_t)(x)) << I3C_SINTMASKED_CHANDLED_SHIFT)) & I3C_SINTMASKED_CHANDLED_MASK)
+
+#define I3C_SINTMASKED_EVENT_MASK                (0x40000U)
+#define I3C_SINTMASKED_EVENT_SHIFT               (18U)
+#define I3C_SINTMASKED_EVENT_WIDTH               (1U)
+#define I3C_SINTMASKED_EVENT(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SINTMASKED_EVENT_SHIFT)) & I3C_SINTMASKED_EVENT_MASK)
+/*! @} */
+
+/*! @name SERRWARN - Target Errors and Warnings */
+/*! @{ */
+
+#define I3C_SERRWARN_HPAR_MASK                   (0x200U)
+#define I3C_SERRWARN_HPAR_SHIFT                  (9U)
+#define I3C_SERRWARN_HPAR_WIDTH                  (1U)
+#define I3C_SERRWARN_HPAR(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SERRWARN_HPAR_SHIFT)) & I3C_SERRWARN_HPAR_MASK)
+
+#define I3C_SERRWARN_HCRC_MASK                   (0x400U)
+#define I3C_SERRWARN_HCRC_SHIFT                  (10U)
+#define I3C_SERRWARN_HCRC_WIDTH                  (1U)
+#define I3C_SERRWARN_HCRC(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SERRWARN_HCRC_SHIFT)) & I3C_SERRWARN_HCRC_MASK)
+
+#define I3C_SERRWARN_S0S1_MASK                   (0x800U)
+#define I3C_SERRWARN_S0S1_SHIFT                  (11U)
+#define I3C_SERRWARN_S0S1_WIDTH                  (1U)
+#define I3C_SERRWARN_S0S1(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SERRWARN_S0S1_SHIFT)) & I3C_SERRWARN_S0S1_MASK)
+/*! @} */
+
+/*! @name SCTRL - Target Control */
+/*! @{ */
+
+#define I3C_SCTRL_EVENT_MASK                     (0x3U)
+#define I3C_SCTRL_EVENT_SHIFT                    (0U)
+#define I3C_SCTRL_EVENT_WIDTH                    (2U)
+#define I3C_SCTRL_EVENT(x)                       (((uint32_t)(((uint32_t)(x)) << I3C_SCTRL_EVENT_SHIFT)) & I3C_SCTRL_EVENT_MASK)
+
+#define I3C_SCTRL_IBIDATA_MASK                   (0xFF00U)
+#define I3C_SCTRL_IBIDATA_SHIFT                  (8U)
+#define I3C_SCTRL_IBIDATA_WIDTH                  (8U)
+#define I3C_SCTRL_IBIDATA(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SCTRL_IBIDATA_SHIFT)) & I3C_SCTRL_IBIDATA_MASK)
+
+#define I3C_SCTRL_PENDINT_MASK                   (0xF0000U)
+#define I3C_SCTRL_PENDINT_SHIFT                  (16U)
+#define I3C_SCTRL_PENDINT_WIDTH                  (4U)
+#define I3C_SCTRL_PENDINT(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SCTRL_PENDINT_SHIFT)) & I3C_SCTRL_PENDINT_MASK)
+
+#define I3C_SCTRL_ACTSTATE_MASK                  (0x300000U)
+#define I3C_SCTRL_ACTSTATE_SHIFT                 (20U)
+#define I3C_SCTRL_ACTSTATE_WIDTH                 (2U)
+#define I3C_SCTRL_ACTSTATE(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_SCTRL_ACTSTATE_SHIFT)) & I3C_SCTRL_ACTSTATE_MASK)
+
+#define I3C_SCTRL_VENDINFO_MASK                  (0xFF000000U)
+#define I3C_SCTRL_VENDINFO_SHIFT                 (24U)
+#define I3C_SCTRL_VENDINFO_WIDTH                 (8U)
+#define I3C_SCTRL_VENDINFO(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_SCTRL_VENDINFO_SHIFT)) & I3C_SCTRL_VENDINFO_MASK)
+/*! @} */
+
+/*! @name SMAXLIMITS - Target Maximum Limits */
+/*! @{ */
+
+#define I3C_SMAXLIMITS_MAXRD_MASK                (0xFFFU)
+#define I3C_SMAXLIMITS_MAXRD_SHIFT               (0U)
+#define I3C_SMAXLIMITS_MAXRD_WIDTH               (12U)
+#define I3C_SMAXLIMITS_MAXRD(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SMAXLIMITS_MAXRD_SHIFT)) & I3C_SMAXLIMITS_MAXRD_MASK)
+
+#define I3C_SMAXLIMITS_MAXWR_MASK                (0xFFF0000U)
+#define I3C_SMAXLIMITS_MAXWR_SHIFT               (16U)
+#define I3C_SMAXLIMITS_MAXWR_WIDTH               (12U)
+#define I3C_SMAXLIMITS_MAXWR(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SMAXLIMITS_MAXWR_SHIFT)) & I3C_SMAXLIMITS_MAXWR_MASK)
+/*! @} */
+
+/*! @name SIDPARTNO - Target ID Part Number */
+/*! @{ */
+
+#define I3C_SIDPARTNO_PARTNO_MASK                (0xFFFFFFFFU)
+#define I3C_SIDPARTNO_PARTNO_SHIFT               (0U)
+#define I3C_SIDPARTNO_PARTNO_WIDTH               (32U)
+#define I3C_SIDPARTNO_PARTNO(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_SIDPARTNO_PARTNO_SHIFT)) & I3C_SIDPARTNO_PARTNO_MASK)
+/*! @} */
+
+/*! @name MIBIRULES - Controller In-band Interrupt Registry and Rules */
+/*! @{ */
+
+#define I3C_MIBIRULES_ADDR0_MASK                 (0x3FU)
+#define I3C_MIBIRULES_ADDR0_SHIFT                (0U)
+#define I3C_MIBIRULES_ADDR0_WIDTH                (6U)
+#define I3C_MIBIRULES_ADDR0(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_ADDR0_SHIFT)) & I3C_MIBIRULES_ADDR0_MASK)
+
+#define I3C_MIBIRULES_ADDR1_MASK                 (0xFC0U)
+#define I3C_MIBIRULES_ADDR1_SHIFT                (6U)
+#define I3C_MIBIRULES_ADDR1_WIDTH                (6U)
+#define I3C_MIBIRULES_ADDR1(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_ADDR1_SHIFT)) & I3C_MIBIRULES_ADDR1_MASK)
+
+#define I3C_MIBIRULES_ADDR2_MASK                 (0x3F000U)
+#define I3C_MIBIRULES_ADDR2_SHIFT                (12U)
+#define I3C_MIBIRULES_ADDR2_WIDTH                (6U)
+#define I3C_MIBIRULES_ADDR2(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_ADDR2_SHIFT)) & I3C_MIBIRULES_ADDR2_MASK)
+
+#define I3C_MIBIRULES_ADDR3_MASK                 (0xFC0000U)
+#define I3C_MIBIRULES_ADDR3_SHIFT                (18U)
+#define I3C_MIBIRULES_ADDR3_WIDTH                (6U)
+#define I3C_MIBIRULES_ADDR3(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_ADDR3_SHIFT)) & I3C_MIBIRULES_ADDR3_MASK)
+
+#define I3C_MIBIRULES_ADDR4_MASK                 (0x3F000000U)
+#define I3C_MIBIRULES_ADDR4_SHIFT                (24U)
+#define I3C_MIBIRULES_ADDR4_WIDTH                (6U)
+#define I3C_MIBIRULES_ADDR4(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_ADDR4_SHIFT)) & I3C_MIBIRULES_ADDR4_MASK)
+
+#define I3C_MIBIRULES_MSB0_MASK                  (0x40000000U)
+#define I3C_MIBIRULES_MSB0_SHIFT                 (30U)
+#define I3C_MIBIRULES_MSB0_WIDTH                 (1U)
+#define I3C_MIBIRULES_MSB0(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_MSB0_SHIFT)) & I3C_MIBIRULES_MSB0_MASK)
+
+#define I3C_MIBIRULES_NOBYTE_MASK                (0x80000000U)
+#define I3C_MIBIRULES_NOBYTE_SHIFT               (31U)
+#define I3C_MIBIRULES_NOBYTE_WIDTH               (1U)
+#define I3C_MIBIRULES_NOBYTE(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MIBIRULES_NOBYTE_SHIFT)) & I3C_MIBIRULES_NOBYTE_MASK)
+/*! @} */
+
+/*! @name SIDEXT - Target ID Extension */
+/*! @{ */
+
+#define I3C_SIDEXT_DCR_MASK                      (0xFF00U)
+#define I3C_SIDEXT_DCR_SHIFT                     (8U)
+#define I3C_SIDEXT_DCR_WIDTH                     (8U)
+#define I3C_SIDEXT_DCR(x)                        (((uint32_t)(((uint32_t)(x)) << I3C_SIDEXT_DCR_SHIFT)) & I3C_SIDEXT_DCR_MASK)
+
+#define I3C_SIDEXT_BCR_MASK                      (0xFF0000U)
+#define I3C_SIDEXT_BCR_SHIFT                     (16U)
+#define I3C_SIDEXT_BCR_WIDTH                     (8U)
+#define I3C_SIDEXT_BCR(x)                        (((uint32_t)(((uint32_t)(x)) << I3C_SIDEXT_BCR_SHIFT)) & I3C_SIDEXT_BCR_MASK)
+/*! @} */
+
+/*! @name SVENDORID - Target Vendor ID */
+/*! @{ */
+
+#define I3C_SVENDORID_VID_MASK                   (0x7FFFU)
+#define I3C_SVENDORID_VID_SHIFT                  (0U)
+#define I3C_SVENDORID_VID_WIDTH                  (15U)
+#define I3C_SVENDORID_VID(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_SVENDORID_VID_SHIFT)) & I3C_SVENDORID_VID_MASK)
+/*! @} */
+
+/*! @name STCCLOCK - Target Time Control Clock */
+/*! @{ */
+
+#define I3C_STCCLOCK_ACCURACY_MASK               (0xFFU)
+#define I3C_STCCLOCK_ACCURACY_SHIFT              (0U)
+#define I3C_STCCLOCK_ACCURACY_WIDTH              (8U)
+#define I3C_STCCLOCK_ACCURACY(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_STCCLOCK_ACCURACY_SHIFT)) & I3C_STCCLOCK_ACCURACY_MASK)
+
+#define I3C_STCCLOCK_FREQ_MASK                   (0xFF00U)
+#define I3C_STCCLOCK_FREQ_SHIFT                  (8U)
+#define I3C_STCCLOCK_FREQ_WIDTH                  (8U)
+#define I3C_STCCLOCK_FREQ(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_STCCLOCK_FREQ_SHIFT)) & I3C_STCCLOCK_FREQ_MASK)
+/*! @} */
+
+/*! @name MCTRL - Controller Control */
+/*! @{ */
+
+#define I3C_MCTRL_IBIRESP_MASK                   (0xC0U)
+#define I3C_MCTRL_IBIRESP_SHIFT                  (6U)
+#define I3C_MCTRL_IBIRESP_WIDTH                  (2U)
+#define I3C_MCTRL_IBIRESP(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_MCTRL_IBIRESP_SHIFT)) & I3C_MCTRL_IBIRESP_MASK)
+/*! @} */
+
+/*! @name MSTATUS - Controller Status */
+/*! @{ */
+
+#define I3C_MSTATUS_IBITYPE_MASK                 (0xC0U)
+#define I3C_MSTATUS_IBITYPE_SHIFT                (6U)
+#define I3C_MSTATUS_IBITYPE_WIDTH                (2U)
+#define I3C_MSTATUS_IBITYPE(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MSTATUS_IBITYPE_SHIFT)) & I3C_MSTATUS_IBITYPE_MASK)
+
+#define I3C_MSTATUS_SLVSTART_MASK                (0x100U)
+#define I3C_MSTATUS_SLVSTART_SHIFT               (8U)
+#define I3C_MSTATUS_SLVSTART_WIDTH               (1U)
+#define I3C_MSTATUS_SLVSTART(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MSTATUS_SLVSTART_SHIFT)) & I3C_MSTATUS_SLVSTART_MASK)
+
+#define I3C_MSTATUS_IBIWON_MASK                  (0x2000U)
+#define I3C_MSTATUS_IBIWON_SHIFT                 (13U)
+#define I3C_MSTATUS_IBIWON_WIDTH                 (1U)
+#define I3C_MSTATUS_IBIWON(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MSTATUS_IBIWON_SHIFT)) & I3C_MSTATUS_IBIWON_MASK)
+
+#define I3C_MSTATUS_NOWMASTER_MASK               (0x80000U)
+#define I3C_MSTATUS_NOWMASTER_SHIFT              (19U)
+#define I3C_MSTATUS_NOWMASTER_WIDTH              (1U)
+#define I3C_MSTATUS_NOWMASTER(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_MSTATUS_NOWMASTER_SHIFT)) & I3C_MSTATUS_NOWMASTER_MASK)
+
+#define I3C_MSTATUS_IBIADDR_MASK                 (0x7F000000U)
+#define I3C_MSTATUS_IBIADDR_SHIFT                (24U)
+#define I3C_MSTATUS_IBIADDR_WIDTH                (7U)
+#define I3C_MSTATUS_IBIADDR(x)                   (((uint32_t)(((uint32_t)(x)) << I3C_MSTATUS_IBIADDR_SHIFT)) & I3C_MSTATUS_IBIADDR_MASK)
+/*! @} */
+
+/*! @name MINTSET - Controller Interrupt Set */
+/*! @{ */
+
+#define I3C_MINTSET_SLVSTART_MASK                (0x100U)
+#define I3C_MINTSET_SLVSTART_SHIFT               (8U)
+#define I3C_MINTSET_SLVSTART_WIDTH               (1U)
+#define I3C_MINTSET_SLVSTART(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MINTSET_SLVSTART_SHIFT)) & I3C_MINTSET_SLVSTART_MASK)
+
+#define I3C_MINTSET_IBIWON_MASK                  (0x2000U)
+#define I3C_MINTSET_IBIWON_SHIFT                 (13U)
+#define I3C_MINTSET_IBIWON_WIDTH                 (1U)
+#define I3C_MINTSET_IBIWON(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MINTSET_IBIWON_SHIFT)) & I3C_MINTSET_IBIWON_MASK)
+
+#define I3C_MINTSET_NOWMASTER_MASK               (0x80000U)
+#define I3C_MINTSET_NOWMASTER_SHIFT              (19U)
+#define I3C_MINTSET_NOWMASTER_WIDTH              (1U)
+#define I3C_MINTSET_NOWMASTER(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_MINTSET_NOWMASTER_SHIFT)) & I3C_MINTSET_NOWMASTER_MASK)
+/*! @} */
+
+/*! @name MINTCLR - Controller Interrupt Clear */
+/*! @{ */
+
+#define I3C_MINTCLR_SLVSTART_MASK                (0x100U)
+#define I3C_MINTCLR_SLVSTART_SHIFT               (8U)
+#define I3C_MINTCLR_SLVSTART_WIDTH               (1U)
+#define I3C_MINTCLR_SLVSTART(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MINTCLR_SLVSTART_SHIFT)) & I3C_MINTCLR_SLVSTART_MASK)
+
+#define I3C_MINTCLR_IBIWON_MASK                  (0x2000U)
+#define I3C_MINTCLR_IBIWON_SHIFT                 (13U)
+#define I3C_MINTCLR_IBIWON_WIDTH                 (1U)
+#define I3C_MINTCLR_IBIWON(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MINTCLR_IBIWON_SHIFT)) & I3C_MINTCLR_IBIWON_MASK)
+
+#define I3C_MINTCLR_NOWMASTER_MASK               (0x80000U)
+#define I3C_MINTCLR_NOWMASTER_SHIFT              (19U)
+#define I3C_MINTCLR_NOWMASTER_WIDTH              (1U)
+#define I3C_MINTCLR_NOWMASTER(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_MINTCLR_NOWMASTER_SHIFT)) & I3C_MINTCLR_NOWMASTER_MASK)
+/*! @} */
+
+/*! @name MINTMASKED - Controller Interrupt Mask */
+/*! @{ */
+
+#define I3C_MINTMASKED_SLVSTART_MASK             (0x100U)
+#define I3C_MINTMASKED_SLVSTART_SHIFT            (8U)
+#define I3C_MINTMASKED_SLVSTART_WIDTH            (1U)
+#define I3C_MINTMASKED_SLVSTART(x)               (((uint32_t)(((uint32_t)(x)) << I3C_MINTMASKED_SLVSTART_SHIFT)) & I3C_MINTMASKED_SLVSTART_MASK)
+
+#define I3C_MINTMASKED_IBIWON_MASK               (0x2000U)
+#define I3C_MINTMASKED_IBIWON_SHIFT              (13U)
+#define I3C_MINTMASKED_IBIWON_WIDTH              (1U)
+#define I3C_MINTMASKED_IBIWON(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_MINTMASKED_IBIWON_SHIFT)) & I3C_MINTMASKED_IBIWON_MASK)
+
+#define I3C_MINTMASKED_NOWMASTER_MASK            (0x80000U)
+#define I3C_MINTMASKED_NOWMASTER_SHIFT           (19U)
+#define I3C_MINTMASKED_NOWMASTER_WIDTH           (1U)
+#define I3C_MINTMASKED_NOWMASTER(x)              (((uint32_t)(((uint32_t)(x)) << I3C_MINTMASKED_NOWMASTER_SHIFT)) & I3C_MINTMASKED_NOWMASTER_MASK)
+/*! @} */
+
+/*! @name MERRWARN - Controller Errors and Warnings */
+/*! @{ */
+
+#define I3C_MERRWARN_TERM_MASK                   (0x10U)
+#define I3C_MERRWARN_TERM_SHIFT                  (4U)
+#define I3C_MERRWARN_TERM_WIDTH                  (1U)
+#define I3C_MERRWARN_TERM(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_MERRWARN_TERM_SHIFT)) & I3C_MERRWARN_TERM_MASK)
+
+#define I3C_MERRWARN_HPAR_MASK                   (0x200U)
+#define I3C_MERRWARN_HPAR_SHIFT                  (9U)
+#define I3C_MERRWARN_HPAR_WIDTH                  (1U)
+#define I3C_MERRWARN_HPAR(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_MERRWARN_HPAR_SHIFT)) & I3C_MERRWARN_HPAR_MASK)
+
+#define I3C_MERRWARN_HCRC_MASK                   (0x400U)
+#define I3C_MERRWARN_HCRC_SHIFT                  (10U)
+#define I3C_MERRWARN_HCRC_WIDTH                  (1U)
+#define I3C_MERRWARN_HCRC(x)                     (((uint32_t)(((uint32_t)(x)) << I3C_MERRWARN_HCRC_SHIFT)) & I3C_MERRWARN_HCRC_MASK)
+
+/*! @} */
+
+/*! @name MRMSG_DDR - Controller Read Message in DDR mode */
+/*! @{ */
+
+#define I3C_MRMSG_DDR_DATA_MASK                  (0xFFFFU)
+#define I3C_MRMSG_DDR_DATA_SHIFT                 (0U)
+/*! DATA - Data */
+#define I3C_MRMSG_DDR_DATA(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MRMSG_DDR_DATA_SHIFT)) & I3C_MRMSG_DDR_DATA_MASK)
+
+#define I3C_MRMSG_DDR_CLEN_MASK                  (0x3FF0000U)
+#define I3C_MRMSG_DDR_CLEN_SHIFT                 (16U)
+/*! CLEN - Current length */
+#define I3C_MRMSG_DDR_CLEN(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MRMSG_DDR_CLEN_SHIFT)) & I3C_MRMSG_DDR_CLEN_MASK)
+/*! @} */
+
+/*! @name MDYNADDR - Controller Dynamic Address */
+/*! @{ */
+
+#define I3C_MDYNADDR_DAVALID_MASK                (0x1U)
+#define I3C_MDYNADDR_DAVALID_SHIFT               (0U)
+#define I3C_MDYNADDR_DAVALID_WIDTH               (1U)
+#define I3C_MDYNADDR_DAVALID(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MDYNADDR_DAVALID_SHIFT)) & I3C_MDYNADDR_DAVALID_MASK)
+
+#define I3C_MDYNADDR_DADDR_MASK                  (0xFEU)
+#define I3C_MDYNADDR_DADDR_SHIFT                 (1U)
+#define I3C_MDYNADDR_DADDR_WIDTH                 (7U)
+#define I3C_MDYNADDR_DADDR(x)                    (((uint32_t)(((uint32_t)(x)) << I3C_MDYNADDR_DADDR_SHIFT)) & I3C_MDYNADDR_DADDR_MASK)
+/*! @} */
+
+#endif /* _S32Z27_DEVICE_H_ */

--- a/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
+++ b/s32/mcux/devices/S32Z27/S32Z27_glue_mcux.h
@@ -7,6 +7,8 @@
 #ifndef _S32Z27_GLUE_MCUX_H_
 #define _S32Z27_GLUE_MCUX_H_
 
+#include "S32Z27_device.h"
+
 /* PIT - Peripheral instance base addresses */
 /** Peripheral PIT0 base address */
 #define PIT0_BASE                                IP_PIT_0_BASE
@@ -38,14 +40,5 @@
 #define I3C_BASE_PTRS                            IP_I3C_BASE_PTRS
 /** Interrupt vectors for the I3C peripheral type */
 #define I3C_IRQS                                 { RTU_I3C0_IRQn, RTU_I3C1_IRQn, RTU_I3C2_IRQn }
-
-/*
- * These bit fields are not existed on this SoC, I3C slave request IBI will not be
- * supported because I3C functionality is not stable in this SoC. Keep define these
- * macros in order to build.
- */
-#define I3C_IBIEXT2_EXT5(x)                     0
-#define I3C_IBIEXT2_EXT6(x)                     0
-#define I3C_IBIEXT2_EXT7(x)                     0
 
 #endif /* _S32Z27_GLUE_MCUX_H_ */


### PR DESCRIPTION
There are some registers marked as reserved from the HAL 1.0.0, the features provided by these registers are not supported by I3C hw on this device, so rename them in order to build with i3c driver from mcux-sdk