### PR TITLE
s32k344: devices: Fix lpspi by removing errata.

### DIFF
--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -169,7 +169,7 @@
 /* @brief Has CCR1 (related to existence of registers CCR1). */
 #define FSL_FEATURE_LPSPI_HAS_CCR1 (1)
 /* @brief Is affected by errata S32K3X4-0P55A-1P55A-ERRATA / ERR050456 (LPSPI: Reset to fifo does not work as expected). */
-#define FSL_FEATURE_LPSPI_HAS_ERRATA_050456 (1)
+#define FSL_FEATURE_LPSPI_HAS_ERRATA_050456 (0)
 
 /* EDMA module features */
 


### PR DESCRIPTION
Removes the S32K3X4-0P55A-1P55A-ERRATA by disabling FSL_FEATURE_LPSPI_HAS_ERRATA_050456. This allows for lpspi to work correctly on mr_canhubk3.