### PR TITLE
mcux-sdk-middleware-usb: fix ip control return value for ip3511

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -83,3 +83,4 @@ Patch List:
   19. drivers: fsl_sai: Allow NULL FIFO watermark
   20. drivers: fsl_sai: Fix compilation warnings when asserts are disabled
   21. mcux-sdk/drivers/ftm/fsl_ftm.c: make public FTM_GetInstance() function (mcux-sdk#155)
+  22. mcux-sdk-middleware-usb: fix ip control return value for ip3511

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
@@ -2299,11 +2299,13 @@ usb_status_t USB_DeviceLpc3511IpControl(usb_device_controller_handle controllerH
         case kUSB_DeviceControlRun:
             lpc3511IpState->registerBase->DEVCMDSTAT |= (USB_LPC3511IP_DEVCMDSTAT_DCON_MASK);
             lpc3511IpState->registerBase->DEVCMDSTAT &= ~(USB_LPC3511IP_DEVCMDSTAT_FORCE_NEEDCLK_MASK);
+            error = kStatus_USB_Success;
             break;
 
         case kUSB_DeviceControlStop:
             lpc3511IpState->registerBase->DEVCMDSTAT |= USB_LPC3511IP_DEVCMDSTAT_FORCE_NEEDCLK_MASK;
             lpc3511IpState->registerBase->DEVCMDSTAT &= (~USB_LPC3511IP_DEVCMDSTAT_DCON_MASK);
+            error = kStatus_USB_Success;
             break;
 
         case kUSB_DeviceControlEndpointInit:


### PR DESCRIPTION
without this kStatus_USB_Error was always returned for kUSB_DeviceControlRun and kUSB_DeviceControlStop control types. let's do it as for ehci/khci.

this change fixes the tests/subsys/usb/device/usb.device test for lpcxpresso55s69_cpu0.

this is from https://github.com/nxp-mcuxpresso/mcux-sdk-middleware-usb/pull/6