### PR TITLE
s32: drivers: s32ze: patch the function Canexcel_Ip_ConfigFdTx

### DIFF
--- a/s32/README
+++ b/s32/README
@@ -64,3 +64,5 @@ Patch List for S32Z/E:
      for S32Z/E.
    - Remove 'static inline' keywords from 'Netc_Eth_Ip_MSIX_Rx' function so that it can be
      used as an extern function outside of the file declaration.
+   - Update the function 'Canexcel_Ip_ConfigFdTx' so that it allows to configure
+     Remote Transmission Request (RTR) frames.

--- a/s32/drivers/s32ze/Can_CANEXCEL/src/CanEXCEL_Ip.c
+++ b/s32/drivers/s32ze/Can_CANEXCEL/src/CanEXCEL_Ip.c
@@ -677,6 +677,12 @@ static void Canexcel_Ip_ConfigFdTx(uint8 instance, uint8 mbIdx, uint32 id,const 
     }
 
     dlcValue = (uint16)CAN_ComputeDLCValue((uint8)(info->dataLength));
+
+    if(dlcValue == 0)
+    {
+        TxMsg->Header.word3 |= CANXL_TX_HEADER_RTR_MASK;
+    }
+
     if(info->frame == CANEXCEL_FD_FRAME)
     {
         if (info->enable_brs == TRUE)


### PR DESCRIPTION
Patch the function Canexcel_Ip_ConfigFdTx allows to configure Remote Transmission Request (RTR) frames. So that NXP S32 CANXL zephyr shimdriver supports to send RTR frames.