### PR TITLE
s32: mcux: s32k146: enable watchdog driver

### DIFF
--- a/s32/mcux/devices/S32K146/S32K146_device.h
+++ b/s32/mcux/devices/S32K146/S32K146_device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -732,5 +732,32 @@ typedef struct {
 /*!
  * @}
  */ /* end of group CAN_Peripheral_Access_Layer */
+
+/* ----------------------------------------------------------------------------
+   -- WDOG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup WDOG_Peripheral_Access_Layer WDOG Peripheral Access Layer
+ * @{
+ */
+
+ /* WDOG - Peripheral instance base addresses */
+/** Peripheral WDOG base address */
+#define WDOG_BASE                                IP_WDOG_BASE
+/** Peripheral WDOG base pointer */
+#define WDOG                                     IP_WDOG
+/** Array initializer of WDOG peripheral base addresses */
+#define WDOG_BASE_ADDRS                          IP_WDOG_BASE_ADDRS
+/** Array initializer of WDOG peripheral base pointers */
+#define WDOG_BASE_PTRS                           IP_WDOG_BASE_PTRS
+/** Interrupt vectors for the WDOG peripheral type */
+#define WDOG_IRQS                                { WDOG_EWM_IRQn }
+#define WDOG_UPDATE_KEY                          (0xD928C520U)
+#define WDOG_REFRESH_KEY                         (0xB480A602U)
+
+/*!
+ * @}
+ */ /* end of group WDOG_Peripheral_Access_Layer */
 
 #endif /* _S32K146_DEVICE_H_ */

--- a/s32/mcux/devices/S32K146/S32K146_features.h
+++ b/s32/mcux/devices/S32K146/S32K146_features.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,6 +27,8 @@
 #define FSL_FEATURE_SOC_FTM_COUNT (6)
 /* @brief FLEXCAN availability on the SoC. */
 #define FSL_FEATURE_SOC_FLEXCAN_COUNT (3)
+/* @brief WDOG availability on the SoC. */
+#define FSL_FEATURE_SOC_WDOG_COUNT (1)
 
 /* SYSMPU module features */
 
@@ -242,5 +244,12 @@
 #define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO (0)
 /* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
 #define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (0)
+
+/* WDOG module features */
+
+/* @brief Watchdog is available. */
+#define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
+/* @brief WDOG_CNT can be 32-bit written. */
+#define FSL_FEATURE_WDOG_HAS_32BIT_ACCESS (1)
 
 #endif /* _S32K146_FEATURES_H_ */


### PR DESCRIPTION
Enable fsl_wdog32 driver on S32K146 devices.