### PR TITLE
s32: mcux: s32k146: enable RTC driver

### DIFF
--- a/s32/mcux/devices/S32K146/S32K146_device.h
+++ b/s32/mcux/devices/S32K146/S32K146_device.h
@@ -760,4 +760,30 @@ typedef struct {
  * @}
  */ /* end of group WDOG_Peripheral_Access_Layer */
 
+/* ----------------------------------------------------------------------------
+   -- RTC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup RTC_Peripheral_Access_Layer RTC Peripheral Access Layer
+ * @{
+ */
+
+/* RTC - Peripheral instance base addresses */
+/** Peripheral RTC base address */
+#define RTC_BASE                                 IP_RTC_BASE
+/** Peripheral RTC base pointer */
+#define RTC                                      IP_RTC
+/** Array initializer of RTC peripheral base addresses */
+#define RTC_BASE_ADDRS                           IP_RTC_BASE_ADDRS
+/** Array initializer of RTC peripheral base pointers */
+#define RTC_BASE_PTRS                            IP_RTC_BASE_PTRS
+/** Interrupt vectors for the RTC peripheral type */
+#define RTC_IRQS                                 { RTC_IRQn }
+#define RTC_SECONDS_IRQS                         { RTC_Seconds_IRQn }
+
+/*!
+ * @}
+ */ /* end of group RTC_Peripheral_Access_Layer */
+
 #endif /* _S32K146_DEVICE_H_ */

--- a/s32/mcux/devices/S32K146/S32K146_features.h
+++ b/s32/mcux/devices/S32K146/S32K146_features.h
@@ -29,6 +29,8 @@
 #define FSL_FEATURE_SOC_FLEXCAN_COUNT (3)
 /* @brief WDOG availability on the SoC. */
 #define FSL_FEATURE_SOC_WDOG_COUNT (1)
+/* @brief RTC availability on the SoC. */
+#define FSL_FEATURE_SOC_RTC_COUNT (1)
 
 /* SYSMPU module features */
 
@@ -251,5 +253,52 @@
 #define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
 /* @brief WDOG_CNT can be 32-bit written. */
 #define FSL_FEATURE_WDOG_HAS_32BIT_ACCESS (1)
+
+/* RTC module features */
+
+/* @brief Has wakeup pin. */
+#define FSL_FEATURE_RTC_HAS_WAKEUP_PIN (0)
+/* @brief Has wakeup pin selection (bit field CR[WPS]). */
+#define FSL_FEATURE_RTC_HAS_WAKEUP_PIN_SELECTION (0)
+/* @brief Has low power features (registers MER, MCLR and MCHR). */
+#define FSL_FEATURE_RTC_HAS_MONOTONIC (0)
+/* @brief Has read/write access control (registers WAR and RAR). */
+#define FSL_FEATURE_RTC_HAS_ACCESS_CONTROL (0)
+/* @brief Has security features (registers TTSR, MER, MCLR and MCHR). */
+#define FSL_FEATURE_RTC_HAS_SECURITY (0)
+/* @brief Has RTC_CLKIN available. */
+#define FSL_FEATURE_RTC_HAS_RTC_CLKIN (1)
+/* @brief Has prescaler adjust for LPO. */
+#define FSL_FEATURE_RTC_HAS_LPO_ADJUST (1)
+/* @brief Has Clock Pin Enable field. */
+#define FSL_FEATURE_RTC_HAS_CPE (1)
+/* @brief Has Timer Seconds Interrupt Configuration field. */
+#define FSL_FEATURE_RTC_HAS_TSIC (1)
+/* @brief Has OSC capacitor setting RTC_CR[SC2P ~ SC16P] */
+#define FSL_FEATURE_RTC_HAS_OSC_SCXP (0)
+/* @brief Has Tamper Interrupt Register (register TIR). */
+#define FSL_FEATURE_RTC_HAS_TIR (0)
+/* @brief Has Tamper Pin Interrupt Enable (bitfield TIR[TPIE]). */
+#define FSL_FEATURE_RTC_HAS_TIR_TPIE (0)
+/* @brief Has Security Interrupt Enable (bitfield TIR[SIE]). */
+#define FSL_FEATURE_RTC_HAS_TIR_SIE (0)
+/* @brief Has Loss of Clock Interrupt Enable (bitfield TIR[LCIE]). */
+#define FSL_FEATURE_RTC_HAS_TIR_LCIE (0)
+/* @brief Has Tamper Interrupt Detect Flag (bitfield SR[TIDF]). */
+#define FSL_FEATURE_RTC_HAS_SR_TIDF (0)
+/* @brief Has Tamper Detect Register (register TDR). */
+#define FSL_FEATURE_RTC_HAS_TDR (0)
+/* @brief Has Tamper Pin Flag (bitfield TDR[TPF]). */
+#define FSL_FEATURE_RTC_HAS_TDR_TPF (0)
+/* @brief Has Security Tamper Flag (bitfield TDR[STF]). */
+#define FSL_FEATURE_RTC_HAS_TDR_STF (0)
+/* @brief Has Loss of Clock Tamper Flag (bitfield TDR[LCTF]). */
+#define FSL_FEATURE_RTC_HAS_TDR_LCTF (0)
+/* @brief Has Tamper Time Seconds Register (register TTSR). */
+#define FSL_FEATURE_RTC_HAS_TTSR (0)
+/* @brief Has Pin Configuration Register (register PCR). */
+#define FSL_FEATURE_RTC_HAS_PCR (0)
+/* @brief Has Oscillator Enable(bitfield CR[OSCE]). */
+#define FSL_FEATURE_RTC_HAS_NO_CR_OSCE (1)
 
 #endif /* _S32K146_FEATURES_H_ */

--- a/s32/soc/s32k146/src/Clock_Ip_Cfg.c
+++ b/s32/soc/s32k146/src/Clock_Ip_Cfg.c
@@ -239,7 +239,7 @@ const Clock_Ip_ClockConfigType Clock_Ip_aClockConfig[1U] = {
             #if CLOCK_IP_SELECTORS_NO > 4U
             {
                 RTC_CLK,                    /* Clock name associated to selector */
-                SOSCDIV1_CLK,                    /* Name of the selected input source */
+                RTC_CLKIN,                    /* Name of the selected input source */
             },
             #endif
 


### PR DESCRIPTION
Enable fsl_rtc.c driver on S32K146 devices.