### PR TITLE
Enable NXP USB Host controllers in Zephyr

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -108,3 +108,9 @@ Patch List:
   - Add missing CMAKE files device_system.cmake device_CMSIS.cmake and drivers/driver_reset.cmake to MCXW716C.
   - Add missing CMAKE file to ccm32k driver driver_ccm32k.cmake.
   - Add missing CMAKE file to flash_k4 driver driver_flash_k4.cmake.
+  - Add usb_host_mcux_drv_port.h file for using MCUX SDK USB host controller driver easily in Zephyr.
+      - usb_host_mcux_drv_port.h contains the simplified structs, enums and APIs that MCUX SDK USB host controller drivers need.
+      - Update usb_host_ehci.c, usb_host_khci.c, usb_host_ohci.c and usb_host_ip3516hs.c if in Zephyr environment.
+        - Add include of usb_host_mcux_drv_port.h.
+        - Remove include of usb_host.h, usb_host_hci.h, usb_host_devices.h and usb_host_framework.h.
+      - Update usb_host_ehci.c and usb_host_ip3516hs.c to not depend on usb_host_device_instance_t struct.

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -417,6 +417,28 @@ if (CONFIG_UDC_DRIVER)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/include)
 endif()
 
+if (CONFIG_UHC_DRIVER)
+  set(CONFIG_USE_component_osa_zephyr true)
+
+  list(APPEND CMAKE_MODULE_PATH
+    ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/osa
+  )
+  list(APPEND CMAKE_MODULE_PATH
+    ${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb
+  )
+  include_ifdef(CONFIG_DT_HAS_NXP_USBPHY_ENABLED  middleware_usb_phy)
+  include_ifdef(CONFIG_UHC_NXP_EHCI               middleware_usb_host_ehci)
+  include_ifdef(CONFIG_UHC_NXP_KHCI               middleware_usb_host_khci)
+  include_ifdef(CONFIG_UHC_NXP_OHCI               middleware_usb_host_ohci)
+  include_ifdef(CONFIG_UHC_NXP_IP3516HS           middleware_usb_host_ip3516hs)
+  include(set_component_osa)
+
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/host)
+  zephyr_include_directories_ifdef(CONFIG_DT_HAS_NXP_USBPHY_ENABLED, ${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/phy)
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/include)
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/osa)
+endif()
+
 if(${MCUX_DEVICE} MATCHES "RW61")
   set(CONFIG_USE_component_osa_zephyr true)
   if(CONFIG_NXP_FW_LOADER)

--- a/mcux/mcux-sdk/devices/LPC55S28/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/LPC55S28/drivers/fsl_clock.c
@@ -1984,6 +1984,32 @@ bool CLOCK_EnableUsbfs0HostClock(clock_usbfs_src_t src, uint32_t freq)
         /* Select FRO 96 MHz */
         CLOCK_AttachClk(kFRO_HF_to_USB0_CLK);
     }
+    else if (kCLOCK_UsbfsSrcPll0 == src)
+    {
+        /*!< Configure XTAL32M */
+        POWER_DisablePD(kPDRUNCFG_PD_XTAL32M);                                /* Ensure XTAL32M is powered */
+        POWER_DisablePD(kPDRUNCFG_PD_LDOXO32M);                               /* Ensure XTAL32M is powered */
+        (void)CLOCK_SetupExtClocking(16000000U);                              /* Enable clk_in clock */
+        SYSCON->CLOCK_CTRL |= SYSCON_CLOCK_CTRL_CLKIN_ENA_MASK;               /* Enable clk_in from XTAL32M clock  */
+        ANACTRL->XO32M_CTRL |= ANACTRL_XO32M_CTRL_ENABLE_SYSTEM_CLK_OUT_MASK; /* Enable clk_in to system  */
+
+        /*!< Set up PLL0 */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0);
+        CLOCK_AttachClk(kEXT_CLK_to_PLL0); /*!< Switch PLL0CLKSEL to EXT_CLK */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0_SSCG);
+        const pll_setup_t pll1Setup = {
+            .pllctrl = SYSCON_PLL0CTRL_CLKEN_MASK | SYSCON_PLL0CTRL_SELI(19U) | SYSCON_PLL0CTRL_SELP(9U),
+            .pllndec = SYSCON_PLL0NDEC_NDIV(1U),
+            .pllpdec = SYSCON_PLL0PDEC_PDIV(5U),
+            .pllsscg = {0x0U,(SYSCON_PLL0SSCG1_MDIV_EXT(30U) | SYSCON_PLL0SSCG1_SEL_EXT_MASK)},
+            .pllRate = 48000000U,
+            .flags   = PLL_SETUPFLAG_WAITLOCK};
+        (void)CLOCK_SetPLL0Freq(&pll1Setup);
+
+        CLOCK_SetClkDiv(kCLOCK_DivUsb0Clk, 1U, false);
+        CLOCK_AttachClk(kPLL0_to_USB0_CLK);
+        SDK_DelayAtLeastUs(50U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
     else
     {
         /*!< Configure XTAL32M */

--- a/mcux/mcux-sdk/devices/LPC55S69/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/LPC55S69/drivers/fsl_clock.c
@@ -1984,6 +1984,32 @@ bool CLOCK_EnableUsbfs0HostClock(clock_usbfs_src_t src, uint32_t freq)
         /* Select FRO 96 MHz */
         CLOCK_AttachClk(kFRO_HF_to_USB0_CLK);
     }
+    else if (kCLOCK_UsbfsSrcPll0 == src)
+    {
+        /*!< Configure XTAL32M */
+        POWER_DisablePD(kPDRUNCFG_PD_XTAL32M);                                /* Ensure XTAL32M is powered */
+        POWER_DisablePD(kPDRUNCFG_PD_LDOXO32M);                               /* Ensure XTAL32M is powered */
+        (void)CLOCK_SetupExtClocking(16000000U);                              /* Enable clk_in clock */
+        SYSCON->CLOCK_CTRL |= SYSCON_CLOCK_CTRL_CLKIN_ENA_MASK;               /* Enable clk_in from XTAL32M clock  */
+        ANACTRL->XO32M_CTRL |= ANACTRL_XO32M_CTRL_ENABLE_SYSTEM_CLK_OUT_MASK; /* Enable clk_in to system  */
+
+        /*!< Set up PLL0 */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0);
+        CLOCK_AttachClk(kEXT_CLK_to_PLL0); /*!< Switch PLL0CLKSEL to EXT_CLK */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0_SSCG);
+        const pll_setup_t pll1Setup = {
+            .pllctrl = SYSCON_PLL0CTRL_CLKEN_MASK | SYSCON_PLL0CTRL_SELI(19U) | SYSCON_PLL0CTRL_SELP(9U),
+            .pllndec = SYSCON_PLL0NDEC_NDIV(1U),
+            .pllpdec = SYSCON_PLL0PDEC_PDIV(5U),
+            .pllsscg = {0x0U,(SYSCON_PLL0SSCG1_MDIV_EXT(30U) | SYSCON_PLL0SSCG1_SEL_EXT_MASK)},
+            .pllRate = 48000000U,
+            .flags   = PLL_SETUPFLAG_WAITLOCK};
+        (void)CLOCK_SetPLL0Freq(&pll1Setup);
+
+        CLOCK_SetClkDiv(kCLOCK_DivUsb0Clk, 1U, false);
+        CLOCK_AttachClk(kPLL0_to_USB0_CLK);
+        SDK_DelayAtLeastUs(50U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
     else
     {
         /*!< Configure XTAL32M */

--- a/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_ehci.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_ehci.c
@@ -7,6 +7,15 @@
  */
 #include "usb_host_config.h"
 #if ((defined USB_HOST_CONFIG_EHCI) && (USB_HOST_CONFIG_EHCI > 0U))
+/* CONFIG_UHC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ehci.h"
+#if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT))
+#include "usb_phy.h"
+#endif
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "usb_host_devices.h"
@@ -20,6 +29,7 @@
 #endif
 #if ((defined USB_HOST_CONFIG_COMPLIANCE_TEST) && (USB_HOST_CONFIG_COMPLIANCE_TEST))
 #include "usb_host.h"
+#endif
 #endif
 #if (defined(FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET) && (FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET > 0U))
 #include "fsl_memory.h"
@@ -3849,6 +3859,7 @@ static usb_status_t USB_HostEhciControlBus(usb_host_ehci_instance_t *ehciInstanc
         case kUSB_HostBusL1Sleep:
             if (0U != (ehciInstance->ehciIpBase->PORTSC1 & USBHS_PORTSC1_CCS_MASK))
             {
+                uint32_t info_val;
                 volatile uint32_t lpm_count = 200000U;
                 OSA_SR_ALLOC();
                  /* set timer1 */
@@ -3874,11 +3885,9 @@ static usb_status_t USB_HostEhciControlBus(usb_host_ehci_instance_t *ehciInstanc
                     ((uint32_t)ehciInstance->hirdValue << USBNC_LPM_CSR2_LPM_HST_BESL_SHIFT) |
                     ((uint32_t)ehciInstance->L1remoteWakeupEnable << USBNC_LPM_CSR2_LPM_HST_RWKEN_SHIFT));
                 ehciInstance->registerNcBase->LPM_CSR2 = portScRegister;
-                
-                usb_host_device_instance_t *deviceInstance;
 
                 ehciInstance->busSuspendStatus = kBus_EhciL1StartSleep;
-                deviceInstance = (usb_host_device_instance_t *)hostPointer->suspendedDevice;
+                USB_HostHelperGetPeripheralInformation(hostPointer->suspendedDevice, kUSB_HostGetDeviceAddress, &info_val);
                  OSA_ENTER_CRITICAL();
                 /* Workaroud for TKT0634948: begin */
                 ehciInstance->ehciIpBase->USBSTS |= USB_USBSTS_SRI_MASK;
@@ -3888,7 +3897,7 @@ static usb_status_t USB_HostEhciControlBus(usb_host_ehci_instance_t *ehciInstanc
                     lpm_count--;
                 }
                 ehciInstance->registerNcBase->LPM_CSR2 |= ((uint32_t)USBNC_LPM_CSR2_LPM_HST_SEND_MASK |
-                  (((uint32_t)deviceInstance->setAddress << USBNC_LPM_CSR2_LPM_HST_DEVADD_SHIFT) &
+                  (((uint32_t)info_val << USBNC_LPM_CSR2_LPM_HST_DEVADD_SHIFT) &
                   (uint32_t)USBNC_LPM_CSR2_LPM_HST_DEVADD_MASK));
                 /* Workaroud for TKT0634948: end */
                 OSA_EXIT_CRITICAL();

--- a/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_khci.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_khci.c
@@ -8,12 +8,19 @@
 
 #include "usb_host_config.h"
 #if ((defined USB_HOST_CONFIG_KHCI) && (USB_HOST_CONFIG_KHCI))
+/* CONFIG_UHC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_khci.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_khci.h"
 #include "usb_host_devices.h"
 #include "usb_host_framework.h"
+#endif
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -1703,7 +1710,7 @@ usb_status_t USB_HostKhciOpenPipe(usb_host_controller_handle controllerHandle,
 {
     usb_khci_host_state_struct_t *usbHostPointer = (usb_khci_host_state_struct_t *)controllerHandle;
     usb_host_pipe_t *pipePointer;
-    usb_host_pipe_t *prePipePointer;
+    usb_host_pipe_t *prePipePointer = NULL;
     usb_host_pipe_t *tempPipePointer;
 
     OSA_SR_ALLOC();

--- a/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_mcux_drv_port.h
+++ b/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_mcux_drv_port.h
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* This file is used in Zephyr */
+
+#ifndef _USB_HOST_MCUX_DRV_PORT_H_
+#define _USB_HOST_MCUX_DRV_PORT_H_
+
+#include "usb.h"
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief USB host controller handle type define */
+typedef void *usb_host_controller_handle;
+
+/*! @brief USB host pipe handle type define */
+typedef void *usb_host_pipe_handle;
+
+/*! @brief USB host configuration handle type define */
+typedef void *usb_host_configuration_handle;
+
+/*! @brief USB host controller control code */
+typedef enum _usb_host_controller_control {
+	kUSB_HostCancelTransfer = 1U,          /*!< Cancel transfer code */
+	kUSB_HostBusControl,                   /*!< Bus control code */
+	kUSB_HostGetFrameNumber,               /*!< Get frame number code */
+	kUSB_HostUpdateControlEndpointAddress, /*!< Update control endpoint address */
+	kUSB_HostUpdateControlPacketSize,      /*!< Update control endpoint maximum  packet size */
+	kUSB_HostPortAttachDisable,            /*!< Disable the port attach event */
+	kUSB_HostPortAttachEnable,             /*!< Enable the port attach event */
+	kUSB_HostL1Config,                     /*!< L1 suspend Bus control code */
+	kUSB_HostSetChargerType,               /*!< set charger type */
+#if ((defined USB_HOST_CONFIG_COMPLIANCE_TEST) && (USB_HOST_CONFIG_COMPLIANCE_TEST))
+	kUSB_HostTestModeInit,                 /*!< initialize charger type */
+#endif
+} usb_host_controller_control_t;
+
+/*! @brief USB host controller bus control code */
+typedef enum _usb_host_bus_control {
+	kUSB_HostBusReset = 1U,    /*!< Reset bus */
+	kUSB_HostBusRestart,       /*!< Restart bus */
+	kUSB_HostBusEnableAttach,  /*!< Enable attach */
+	kUSB_HostBusDisableAttach, /*!< Disable attach */
+	kUSB_HostBusSuspend,       /*!< Suspend BUS */
+	kUSB_HostBusResume,        /*!< Resume BUS */
+	kUSB_HostBusL1SuspendInit, /*!< L1 Suspend BUS */
+	kUSB_HostBusL1Sleep,       /*!< L1 Suspend BUS */
+	kUSB_HostBusL1Resume,      /*!< L1 Resume BUS */
+} usb_host_bus_control_t;
+
+/*! @brief USB host device information code */
+typedef enum _usb_host_dev_info {
+	kUSB_HostGetDeviceAddress = 1U, /*!< Device's address */
+	kUSB_HostGetDeviceHubNumber,    /*!< Device's first hub address */
+	kUSB_HostGetDevicePortNumber,   /*!< Device's first hub port number */
+	kUSB_HostGetDeviceSpeed,        /*!< Device's speed */
+	kUSB_HostGetDeviceHSHubNumber,  /*!< Device's first high-speed hub address */
+	kUSB_HostGetDeviceHSHubPort,    /*!< Device's first high-speed hub number */
+	kUSB_HostGetDeviceLevel,        /*!< Device's hub level */
+	kUSB_HostGetHostHandle,         /*!< Device's host handle */
+	kUSB_HostGetDeviceControlPipe,  /*!< Device's control pipe handle */
+	kUSB_HostGetDevicePID,          /*!< Device's PID */
+	kUSB_HostGetDeviceVID,          /*!< Device's VID */
+	kUSB_HostGetHubThinkTime,       /*!< Device's hub total think time */
+	kUSB_HostGetDeviceConfigIndex,  /*!< Device's running zero-based config index */
+	kUSB_HostGetConfigurationDes,   /*!< Device's configuration descriptor pointer */
+	kUSB_HostGetConfigurationLength,/*!< Device's configuration descriptor pointer */
+} usb_host_dev_info_t;
+
+struct _usb_host_transfer;
+/*!
+ * @brief Host stack inner transfer callback function typedef.
+ *
+ * This callback function is used to notify the upper layer the result of a transfer.
+ * This callback pointer is passed when initializing the structure usb_host_transfer_t.
+ *
+ * @param param	 The parameter pointer, which is passed when calling the send/receive APIs.
+ * @param transfer  The transfer information; See the structure usb_host_transfer_t.
+ * @param status	A USB error code or kStatus_USB_Success.
+ */
+typedef void (*host_inner_transfer_callback_t)(void *param,
+		struct _usb_host_transfer *transfer, usb_status_t status);
+
+/*!
+ * @brief Controller driver callback function typedef.
+ *
+ * This callback function is used to notify upper layer suspend related event.
+ * This callback pointer is passed when initializing the host.
+ *
+ * @param deviceHandle		   The device handle, which indicates the attached device.
+ * @param configurationHandle	The configuration handle contains the attached device's
+ *				configuration information. It is not used in Zephyr environment.
+ * @param event_code		   The callback event code; See the enumeration host_event_t.
+ *
+ * @return A USB error code or kStatus_USB_Success.
+ * @retval kStatus_USB_Success	   Application handles the attached device successfully.
+ * @retval kStatus_USB_NotSupported  Application don't support the attached device.
+ * @retval kStatus_USB_Error		 Application handles the attached device falsely.
+ */
+typedef usb_status_t (*host_callback_t)(usb_device_handle deviceHandle,
+				usb_host_configuration_handle configurationHandle,
+				uint32_t eventCode);
+
+/*! @brief USB host pipe information structure for opening pipe */
+typedef struct _usb_host_pipe_init {
+	void *devInstance;	/*!< Device instance handle*/
+	uint16_t nakCount;	/*!< Maximum NAK retry count. MUST be zero for interrupt*/
+	uint16_t maxPacketSize;	/*!< Pipe's maximum packet size*/
+	uint8_t interval;	/*!< Pipe's interval*/
+	uint8_t endpointAddress;/*!< Endpoint address*/
+	uint8_t direction;	/*!< Endpoint direction*/
+	uint8_t pipeType;	/*!< Endpoint type, the value is USB_ENDPOINT_INTERRUPT,
+				 * USB_ENDPOINT_CONTROL, USB_ENDPOINT_ISOCHRONOUS,
+				 * USB_ENDPOINT_BULK
+				 */
+	uint8_t numberPerUframe;/*!< Transaction number for each micro-frame*/
+} usb_host_pipe_init_t;
+
+/*! @brief USB host pipe common structure */
+typedef struct _usb_host_pipe {
+	struct _usb_host_pipe *next;	/*!< Link the idle pipes*/
+	usb_device_handle deviceHandle; /*!< This pipe's device's handle*/
+	uint16_t currentCount;		/*!< For KHCI transfer*/
+	uint16_t nakCount;		/*!< Maximum NAK count*/
+	uint16_t maxPacketSize;		/*!< Maximum packet size*/
+	uint16_t interval;		/*!< FS/LS: frame unit; HS: micro-frame unit*/
+	uint8_t open;			/*!< 0 - closed, 1 - open*/
+	uint8_t nextdata01;		/*!< Data toggle*/
+	uint8_t endpointAddress;	/*!< Endpoint address*/
+	uint8_t direction;		/*!< Pipe direction*/
+	uint8_t pipeType;		/*!< Pipe type, for example USB_ENDPOINT_BULK*/
+	uint8_t numberPerUframe;	/*!< Transaction number per micro-frame*/
+} usb_host_pipe_t;
+
+/*! @brief USB host transfer structure */
+typedef struct _usb_host_transfer {
+	struct _usb_host_transfer *next;		/*!< The next transfer structure*/
+	uint8_t *transferBuffer;			/*!< Transfer data buffer*/
+	uint32_t transferLength;			/*!< Transfer data length*/
+	uint32_t transferSofar;	/*!< Length transferred so far*/
+	host_inner_transfer_callback_t callbackFn; /*!< Transfer callback function*/
+	void *callbackParam;				/*!< Transfer callback parameter*/
+	usb_host_pipe_t *transferPipe;			/*!< Transfer pipe pointer*/
+	usb_setup_struct_t *setupPacket;		/*!< Set up packet buffer*/
+	/*! Transfer direction; it's values are USB_OUT or USB_IN */
+	uint8_t direction;
+	uint8_t setupStatus;				/*!< Set up the transfer status*/
+	union {
+		uint32_t unitHead;			/*!< xTD head for this transfer*/
+		int32_t transferResult;			/*!< KHCI transfer result */
+	} union1;
+
+	union {
+		uint32_t unitTail;			/*!<xTD tail for this transfer*/
+		uint32_t frame;				/*!< KHCI transfer frame number */
+	} union2;
+
+#if USB_HOST_CONFIG_KHCI
+	uint16_t nakTimeout;				/*!< KHCI transfer NAK timeout */
+	uint16_t retry;					/*!< KHCI transfer retry */
+#endif
+	void *uhc_xfer;
+} usb_host_transfer_t;
+
+/*! @brief Cancel transfer parameter structure */
+typedef struct _usb_host_cancel_param {
+	usb_host_pipe_handle pipeHandle;	/*!< Canceling pipe handle*/
+	usb_host_transfer_t *transfer;		/*!< Canceling transfer*/
+} usb_host_cancel_param_t;
+
+/*! @brief USB host controller interface structure */
+typedef struct _usb_host_controller_interface {
+	/*! Create a controller instance function prototype*/
+	usb_status_t (*controllerCreate)(
+		uint8_t controllerId,
+		usb_host_handle upperLayerHandle,
+		usb_host_controller_handle *controllerHandle);
+	/*! Destroy a controller instance function prototype*/
+	usb_status_t (*controllerDestory)(
+		usb_host_controller_handle controllerHandle);
+	/*! Open a controller pipe function prototype*/
+	usb_status_t (*controllerOpenPipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle *pipeHandle,
+				usb_host_pipe_init_t *pipeInit);
+	/*! Close a controller pipe function prototype*/
+	usb_status_t (*controllerClosePipe)(
+		usb_host_controller_handle controllerHandle,
+		usb_host_pipe_handle pipeHandle);
+	/*! Write data to a pipe function prototype*/
+	usb_status_t (*controllerWritePipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle pipeHandle,
+				usb_host_transfer_t *transfer);
+	/*! Read data from a pipe function prototype*/
+	usb_status_t (*controllerReadPipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle pipeHandle,
+				usb_host_transfer_t *transfer);
+	/*! Control a controller function prototype*/
+	usb_status_t (*controllerIoctl)(usb_host_controller_handle controllerHandle,
+				uint32_t ioctlEvent,
+				void *ioctlParam);
+} usb_host_controller_interface_t;
+
+/*! @brief USB host instance structure */
+typedef struct _usb_host_instance {
+	void *controllerHandle;		/*!< The low level controller handle*/
+	host_callback_t deviceCallback;	/*!< Device attach/detach callback*/
+} usb_host_instance_t;
+
+/*!
+ * @brief Controller driver calls this function when device detaches.
+ *
+ * @param hostHandle   Host instance handle.
+ * @param hubNumber    Device hub no. root device's hub no. is 0.
+ * @param portNumber   Device port no. root device's port no. is 0.
+ *
+ * @return kStatus_USB_Success or error codes.
+ */
+usb_status_t USB_HostDetachDevice(usb_host_handle hostHandle, uint8_t hubNumber,
+					uint8_t portNumber);
+
+/*!
+ * @brief Controller driver calls this function when device attach.
+ *
+ * @param hostHandle    Host instance handle.
+ * @param speed         Device speed.
+ * @param hubNumber     Device hub no. root device's hub no. is 0.
+ * @param portNumber    Device port no. root device's port no. is 0.
+ * @param level         Device level. root device's level is 1.
+ * @param deviceHandle  Return device handle.
+ *
+ * @return kStatus_USB_Success or error codes.
+ */
+usb_status_t USB_HostAttachDevice(usb_host_handle hostHandle,
+				uint8_t speed,
+				uint8_t hubNumber,
+				uint8_t portNumber,
+				uint8_t level,
+				usb_device_handle *deviceHandle);
+
+/*!
+ * @brief Controller driver calls this function to get the device information.
+ *
+ * This function gets the device information.
+ *
+ * @param[in] deviceHandle   Removing device handle.
+ * @param[in] infoCode       See the enumeration host_dev_info_t.
+ * @param[out] infoValue     Return the information value.
+ *
+ * @retval kStatus_USB_Success           Close successfully.
+ * @retval kStatus_USB_InvalidParameter  The deviceHandle or info_value is a NULL pointer.
+ * @retval kStatus_USB_Error             The info_code is not the host_dev_info_t value.
+ */
+usb_status_t USB_HostHelperGetPeripheralInformation(usb_device_handle deviceHandle,
+				uint32_t infoCode,
+				uint32_t *infoValue);
+
+#if (defined(USB_HOST_CONFIG_EHCI) && (USB_HOST_CONFIG_EHCI > 0U))
+/*!
+ * @brief Device EHCI ISR function.
+ *
+ * The function is the EHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostEhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief EHCI task function.
+ *
+ * The function is used to handle the EHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostEhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_KHCI) && (USB_HOST_CONFIG_KHCI > 0U))
+/*!
+ * @brief Device KHCI ISR function.
+ *
+ * The function is the KHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostKhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief KHCI task function.
+ *
+ * The function is used to handle the KHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostKhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_OHCI) && (USB_HOST_CONFIG_OHCI > 0U))
+/*!
+ * @brief Device OHCI ISR function.
+ *
+ * The function is the OHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostOhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief OHCI task function.
+ *
+ * The function is used to handle the OHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostOhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_IP3516HS) && (USB_HOST_CONFIG_IP3516HS > 0U))
+/*!
+ * @brief Device IP3516HS ISR function.
+ *
+ * The function is the IP3516HS interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostIp3516HsIsrFunction(void *hostHandle);
+
+/*!
+ * @brief IP3516HS task function.
+ *
+ * The function is used to handle the IP3516HS controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostIp3516HsTaskFunction(void *hostHandle);
+#endif
+
+#endif /* _USB_HOST_MCUX_DRV_PORT_H_ */

--- a/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_ohci.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/host/usb_host_ohci.c
@@ -8,11 +8,17 @@
 
 #include "usb_host_config.h"
 #if (defined(USB_HOST_CONFIG_OHCI) && (USB_HOST_CONFIG_OHCI > 0U))
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ohci.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_ohci.h"
 #include "usb_host_devices.h"
+#endif
 
 /*******************************************************************************
  * Definitions
@@ -836,6 +842,14 @@ static usb_status_t USB_HostOhciOpenControlBulkPipe(usb_host_ohci_state_struct_t
     return kStatus_USB_Success;
 }
 
+static uint8_t USB_HostOhciGetDeviceInfo(usb_device_handle deviceHandle, uint32_t infoCode)
+{
+    uint32_t info_val;
+
+    (void)USB_HostHelperGetPeripheralInformation(deviceHandle, (uint32_t)infoCode, &info_val);
+    return (uint8_t)info_val;
+}
+
 #if (defined(USB_HOST_CONFIG_OHCI_MAX_ITD) && (USB_HOST_CONFIG_OHCI_MAX_ITD > 0U))
 static usb_status_t USB_HostOhciOpenIsoPipe(usb_host_ohci_state_struct_t *usbHostState,
                                             usb_host_ohci_pipe_struct_t *pipe)
@@ -847,7 +861,7 @@ static usb_status_t USB_HostOhciOpenIsoPipe(usb_host_ohci_state_struct_t *usbHos
     OSA_SR_ALLOC();
 
     pipe->busTime = (uint16_t)USB_HostOhciBusTime(
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed, pipe->pipeCommon.pipeType,
+        USB_HostOhciGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed), pipe->pipeCommon.pipeType,
         pipe->pipeCommon.direction,
         ((uint32_t)pipe->pipeCommon.maxPacketSize) * ((uint32_t)pipe->pipeCommon.numberPerUframe));
 
@@ -894,7 +908,7 @@ static usb_status_t USB_HostOhciOpenInterruptPipe(usb_host_ohci_state_struct_t *
     OSA_SR_ALLOC();
 
     pipe->busTime = (uint16_t)USB_HostOhciBusTime(
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed, pipe->pipeCommon.pipeType,
+        USB_HostOhciGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed), pipe->pipeCommon.pipeType,
         pipe->pipeCommon.direction,
         ((uint32_t)pipe->pipeCommon.maxPacketSize) * ((uint32_t)pipe->pipeCommon.numberPerUframe));
 
@@ -2350,9 +2364,9 @@ usb_status_t USB_HostOhciOpenPipe(usb_host_controller_handle controllerHandle,
     pipe->pipeCommon.open                 = 1U;
     pipe->ed->stateUnion.stateBitField.EN = pipeInit->endpointAddress;
     pipe->ed->stateUnion.stateBitField.D  = (USB_OUT == pipeInit->direction) ? 1U : 2U;
-    pipe->ed->stateUnion.stateBitField.FA = ((usb_host_device_instance_t *)pipeInit->devInstance)->setAddress;
+    pipe->ed->stateUnion.stateBitField.FA = USB_HostOhciGetDeviceInfo(pipeInit->devInstance, kUSB_HostGetDeviceAddress);
     pipe->ed->stateUnion.stateBitField.S =
-        (USB_SPEED_FULL == ((usb_host_device_instance_t *)pipeInit->devInstance)->speed) ? 0U : 1U;
+        (USB_SPEED_FULL == USB_HostOhciGetDeviceInfo(pipeInit->devInstance, kUSB_HostGetDeviceSpeed)) ? 0U : 1U;
     pipe->ed->stateUnion.stateBitField.F   = 0U;
     pipe->ed->stateUnion.stateBitField.MPS = pipeInit->maxPacketSize;
     pipe->ed->stateUnion.stateBitField.K   = 0U;


### PR DESCRIPTION
Add the NXP USB Host controllers support in Zephyr.
Support EHCI, KHCI, OHCI and IP3516HS NXP controllers.

The Zephyr PR is: https://github.com/zephyrproject-rtos/zephyr/pull/77973