### PR TITLE
License: summary of contents

### DIFF
--- a/scr-hal.txt
+++ b/scr-hal.txt
@@ -1,0 +1,9 @@
+NXP Software Content Register
+--------------------------------------------
+Package:                     hal_nxp
+Outgoing License:            BSD-3-Clause
+License File:                LICENSE.BSD-3
+Type of Content:             source
+Description and comments:    Hardware Abstraction Layer for NXP MCU's
+Release Location:            https://github.com/nxp-zephyr/hal_nxp
+Origin:                      NXP (BSD-3)


### PR DESCRIPTION
The software content register file (scr-hal.txt) provides information about the NXP HAL. e.g. origin, license, location.

It is added for clarity.