### PR TITLE
devices: MIMX8QM6 / MIMX8QX6: add support for IRQ_STEER driver

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -92,3 +92,7 @@ Patch List:
      - mcux-sdk\docs
   26. mcux: mcux-sdk: Fix "loop" labels in inline assembly to use unique identifiers.
   27. mcux-sdk-middleware-usb: Fix build issues with the code from github
+  28. devices: MIMX8QX6: change IRQ_START_INDEX to 0
+  29. devices: MIMX8QM6: fsl_clock: Add missing definition for AUDIO IRQSTEER
+  30. devices: MIMX8QM6: Fix naming inconsistency
+  31. devices: MIMX8QM6: Add missing FSL_FEATURE_* macros

--- a/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_dsp_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_dsp_features.h
@@ -665,5 +665,12 @@
 /* @brief Offset between MIPI DSI controller and CSR in the MIPI DSI subsystem. */
 #define FSL_FEATURE_DSI_CSR_OFFSET (0x7000)
 
+/* IRQSTEER module features */
+
+/* @brief Number of IRQSTEER CHn_MASK registers */
+#define FSL_FEATURE_IRQSTEER_CHn_MASK_COUNT (16)
+/* @brief The start IRQ index of first IRQSTEER source IRQ */
+#define FSL_FEATURE_IRQSTEER_IRQ_START_INDEX (0)
+
 #endif /* _MIMX8QM6_dsp_FEATURES_H_ */
 

--- a/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/drivers/fsl_clock.h
@@ -165,6 +165,11 @@
     {                         \
         kCLOCK_M4_1_Irqsteer, \
     }
+#else
+#define IRQSTEER_CLOCKS        \
+    {                          \
+        kCLOCK_AUDIO_Irqsteer, \
+    }
 #endif
 
 /*! @brief Clock ip name array for EDMA. */
@@ -261,6 +266,7 @@ typedef enum _clock_ip_name
 {
     kCLOCK_M4_0_Irqsteer      = LPCG_TUPLE(SC_R_IRQSTR_M4_0, NV),
     kCLOCK_M4_1_Irqsteer      = LPCG_TUPLE(SC_R_IRQSTR_M4_1, NV),
+    kCLOCK_AUDIO_Irqsteer     = LPCG_TUPLE(SC_R_IRQSTR_DSP, NV),
     kCLOCK_DMA_Lpspi0         = LPCG_TUPLE(SC_R_SPI_0, DMA__LPCG_LPSPI0_BASE),
     kCLOCK_DMA_Lpspi1         = LPCG_TUPLE(SC_R_SPI_1, DMA__LPCG_LPSPI1_BASE),
     kCLOCK_DMA_Lpspi2         = LPCG_TUPLE(SC_R_SPI_2, DMA__LPCG_LPSPI2_BASE),

--- a/mcux/mcux-sdk/devices/MIMX8QX6/MIMX8QX6_dsp_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QX6/MIMX8QX6_dsp_features.h
@@ -672,7 +672,7 @@
 /* @brief Number of IRQSTEER CHn_MASK register. */
 #define FSL_FEATURE_IRQSTEER_CHn_MASK_COUNT (16)
 /* @brief The start IRQ index of first IRQSTEER source IRQ. */
-#define FSL_FEATURE_IRQSTEER_IRQ_START_INDEX (51)
+#define FSL_FEATURE_IRQSTEER_IRQ_START_INDEX (0)
 /* @brief Number of IRQSTEER master. */
 #define FSL_FEATURE_IRQSTEER_MASTER_COUNT (8)
 


### PR DESCRIPTION
Depends on: https://github.com/nxp-mcuxpresso/mcux-sdk/pull/169