### PR TITLE
devices: MIMX8QM6/MIMX8QX6: add SAI FSL_FEATURE_* macros

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -92,3 +92,5 @@ Patch List:
      - mcux-sdk\docs
   26. mcux: mcux-sdk: Fix "loop" labels in inline assembly to use unique identifiers.
   27. mcux-sdk-middleware-usb: Fix build issues with the code from github
+  28. devices: MIMX8QX6: add new SAI-related FSL_FEATURE_* macros
+  29. devices: MIMX8QM6: add new SAI-related FSL_FEATURE_* macros

--- a/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_dsp_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QM6/MIMX8QM6_dsp_features.h
@@ -193,6 +193,28 @@
 #define FSL_FEATURE_SAI_HAS_CHANNEL_MODE (0)
 /* @brief Support synchronous with another SAI. */
 #define FSL_FEATURE_SAI_HAS_SYNC_WITH_ANOTHER_SAI (0)
+/* @brief Used to retrieve the physical base address of a transmit FIFO.
+ * The index of the transmit FIFO is specified through the fifo_index argument.
+ * The sai_base argument needs to be the physical base address of the SAI.
+ * If there's any SAI instances with only 1 channel then the fifo_index argument
+ * will be ignored and the macro will return the address of the only transmit
+ * FIFO.
+ */
+#define FSL_FEATURE_SAI_TX_FIFO_BASEn(sai_base, fifo_index)\
+    (((sai_base) == AUDIO__SAI0) ? ((uintptr_t)AUDIO__SAI0 + 0x20) :\
+    (((sai_base) == AUDIO__SAI1) ? ((uintptr_t)AUDIO__SAI1 + 0x20) :\
+    (((sai_base) == AUDIO__SAI2) ? ((uintptr_t)AUDIO__SAI2 + 0x20) : (0))))
+/* @brief Used to retrieve the physical base address of a receive FIFO.
+ * The index of the receive FIFO is specified through the fifo_index argument.
+ * The sai_base argument needs to be the physical base address of the SAI.
+ * If there's any SAI instances with only 1 channel then the fifo_index argument
+ * will be ignored and the macro will return the address of the only receive
+ * FIFO.
+ */
+#define FSL_FEATURE_SAI_RX_FIFO_BASEn(sai_base, fifo_index)\
+    (((sai_base) == AUDIO__SAI0) ? ((uintptr_t)AUDIO__SAI0 + 0xa0) :\
+    (((sai_base) == AUDIO__SAI1) ? ((uintptr_t)AUDIO__SAI1 + 0xa0) :\
+    (((sai_base) == AUDIO__SAI2) ? ((uintptr_t)AUDIO__SAI2 + 0xa0) : (0))))
 
 /* ASMC module features */
 

--- a/mcux/mcux-sdk/devices/MIMX8QX6/MIMX8QX6_dsp_features.h
+++ b/mcux/mcux-sdk/devices/MIMX8QX6/MIMX8QX6_dsp_features.h
@@ -457,6 +457,31 @@
 /* @brief Support synchronous with another SAI. */
 #define FSL_FEATURE_SAI_HAS_SYNC_WITH_ANOTHER_SAI (0)
 
+/* @brief Used to retrieve the physical base address of a transmit FIFO.
+ * The index of the transmit FIFO is specified through the fifo_index argument.
+ * The sai_base argument needs to be the physical base address of the SAI.
+ * If there's any SAI instances with only 1 channel then the fifo_index argument
+ * will be ignored and the macro will return the address of the only transmit
+ * FIFO.
+ */
+#define FSL_FEATURE_SAI_TX_FIFO_BASEn(sai_base, fifo_index)\
+    (((sai_base) == ADMA__SAI0) ? ((uintptr_t)ADMA__SAI0 + 0x20) :\
+    (((sai_base) == ADMA__SAI1) ? ((uintptr_t)ADMA__SAI1 + 0x20) :\
+    (((sai_base) == ADMA__SAI2) ? ((uintptr_t)ADMA__SAI2 + 0x20) : (0))))
+
+/* @brief Used to retrieve the physical base address of a receive FIFO.
+ * The index of the receive FIFO is specified through the fifo_index argument.
+ * The sai_base argument needs to be the physical base address of the SAI.
+ * If there's any SAI instances with only 1 channel then the fifo_index argument
+ * will be ignored and the macro will return the address of the only receive
+ * FIFO.
+ */
+#define FSL_FEATURE_SAI_RX_FIFO_BASEn(sai_base, fifo_index)\
+    (((sai_base) == ADMA__SAI0) ? ((uintptr_t)ADMA__SAI0 + 0xa0) :\
+    (((sai_base) == ADMA__SAI1) ? ((uintptr_t)ADMA__SAI1 + 0xa0) :\
+    (((sai_base) == ADMA__SAI2) ? ((uintptr_t)ADMA__SAI2 + 0xa0) : (0))))
+
+
 /* ASMC module features */
 
 /* @brief Has high speed run mode. */


### PR DESCRIPTION
Depends on: https://github.com/nxp-mcuxpresso/mcux-sdk/pull/171