### PR TITLE
mcux: hal_nxp: update path for scfw_api

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -81,9 +81,9 @@ zephyr_library_compile_definitions_ifdef(
 # Required by all SCFW-based SoCs
 if (CONFIG_SOC_MIMX8QM_A53 OR CONFIG_SOC_MIMX8QM_ADSP OR CONFIG_SOC_MIMX8QXP_ADSP)
     list(APPEND CMAKE_MODULE_PATH
-        ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}/scfw_api
+        ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE_PATH}/scfw_api
     )
-    zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE}/scfw_api)
+    zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE_PATH}/scfw_api)
     include(driver_scfw_api)
 endif()
 


### PR DESCRIPTION
With HWMv2, when trying to load the scfw_api for 8QM or 8QXP I get:
```
include could not find requested file:
    driver_scfw_api
```
So update the path for scfw_api based on MCUX_DEVICE_PATH.

For ADSP we don't have separate devices (i.e. MIMX8QX6_dsp or MIMX8QM6_dsp), because will duplicate a lot of code. For these we use the core devices (i.e. MIMX8QX6 or MIMX8QM6).