### PR TITLE
mcux: hal_nxp: update configs for ADSP

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -80,7 +80,7 @@ zephyr_library_compile_definitions_ifdef(
 )
 
 # Required by all SCFW-based SoCs
-if (CONFIG_SOC_MIMX8QM_A53 OR CONFIG_SOC_MIMX8QM_ADSP OR CONFIG_SOC_MIMX8QXP_ADSP)
+if (CONFIG_SOC_MIMX8QM6_ADSP OR CONFIG_SOC_MIMX8QX6_ADSP)
     list(APPEND CMAKE_MODULE_PATH
         ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/devices/${MCUX_DEVICE_PATH}/scfw_api
     )


### PR DESCRIPTION
CONFIG_SOC_MIMX8QM_ADSP and CONFIG_SOC_MIMX8QXP_ADSP were renamed to match the soc name, so update here also.

While here, remove CONFIG_SOC_MIMX8QM_A53 since is not defined and used anywhere.