### PR TITLE
Fix MCXN947 WDT1 Clock Select Bug

### DIFF
--- a/mcux/mcux-sdk/devices/MCXN947/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MCXN947/drivers/fsl_clock.c
@@ -1732,6 +1732,7 @@ uint32_t CLOCK_GetWdtClkFreq(uint32_t id)
                 freq = CLOCK_GetFroHfFreq() / ((SYSCON->FROHFDIV & 0xffU) + 1U);
                 break;
             case 2U:
+            case 3U:
                 freq = CLOCK_GetClk1MFreq();
                 break;
             default:


### PR DESCRIPTION
The case statement for selecting the WDT1
clock sel is missing a possible case
that selects 1MHZ.