### PR TITLE
drivers: lpi2c: Fix the interaction with LPFlexcomm driver

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -73,3 +73,4 @@ Patch List:
   6. devices: MIMX8UD7: add header and source files for HIFI4 DSP core
   7. devices: MIMX8UD7: fsl_device_registers.h: add support for HIFI4 DSP
   8. devices: MIMX8UD7: add cmake file for reset driver
+  9. drivers: lpflexcomm: lpi2c: Fixed an error in the driver when interacting with the lpflexcomm driver

--- a/mcux/mcux-sdk/drivers/lpflexcomm/lpi2c/fsl_lpi2c.c
+++ b/mcux/mcux-sdk/drivers/lpflexcomm/lpi2c/fsl_lpi2c.c
@@ -483,13 +483,15 @@ void LPI2C_MasterInit(LPI2C_Type *base, const lpi2c_master_config_t *masterConfi
  */
 void LPI2C_MasterDeinit(LPI2C_Type *base)
 {
-    uint32_t instance = LPI2C_GetInstance(base); 
-    
+    uint32_t instance = LPI2C_GetInstance(base);
+
     /* Restore to reset state. */
     LPI2C_MasterReset(base);
     if(LP_FLEXCOMM_GetBaseAddress(instance) != 0U)
     {
+#if !(defined(LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER) && LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER)
         LP_FLEXCOMM_Deinit(instance);
+#endif /* LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER */
     }
     else
     {
@@ -503,9 +505,6 @@ void LPI2C_MasterDeinit(LPI2C_Type *base)
 
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     }
-#if !(defined(LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER) && LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER)
-    LP_FLEXCOMM_Deinit(LPI2C_GetInstance(base));
-#endif
 }
 
 /*!
@@ -1776,7 +1775,9 @@ void LPI2C_SlaveDeinit(LPI2C_Type *base)
     LPI2C_SlaveReset(base);
     if(LP_FLEXCOMM_GetBaseAddress(instance) != 0U)
     {
+#if !(defined(LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER) && LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER)
         LP_FLEXCOMM_Deinit(instance);
+#endif /* LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER */
     }
     else
     {
@@ -1790,9 +1791,6 @@ void LPI2C_SlaveDeinit(LPI2C_Type *base)
 
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     }
-#if !(defined(LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER) && LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER)
-    LP_FLEXCOMM_Deinit(LPI2C_GetInstance(base));
-#endif
 }
 
 /*!


### PR DESCRIPTION
There was an error in the init and deinit functions where the LPFlexcomm registers was getting modified even if the flag LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER was set.

PR submitted to internal mcux-sdk-github repo as well 