### PR TITLE
devices: LPC55XXX: Removed incorrect pwm defs

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -74,3 +74,6 @@ Patch List:
   7. devices: MIMX8UD7: fsl_device_registers.h: add support for HIFI4 DSP
   8. devices: MIMX8UD7: add cmake file for reset driver
   9. drivers: lpflexcomm: lpi2c: Fixed an error in the driver when interacting with the lpflexcomm driver
+  10. devices: LPC5534: Changed FSL_FEATURE_PWM_HAS_NO_WAITEN from 1 to 0 to solve pwm issue.
+  11. devices: LPC5536: Changed FSL_FEATURE_PWM_HAS_NO_WAITEN from 1 to 0 to solve pwm issue.
+  12. devices: LPC55S36: Changed FSL_FEATURE_PWM_HAS_NO_WAITEN from 1 to 0 to solve pwm issue.

--- a/mcux/mcux-sdk/devices/LPC5534/LPC5534_features.h
+++ b/mcux/mcux-sdk/devices/LPC5534/LPC5534_features.h
@@ -610,7 +610,7 @@
 /* @brief Number of fault channel in each (e)FlexPWM module. */
 #define FSL_FEATURE_PWM_FAULT_CH_COUNT (1)
 /* @brief (e)FlexPWM has no WAITEN Bitfield In CTRL2 Register. */
-#define FSL_FEATURE_PWM_HAS_NO_WAITEN (1)
+#define FSL_FEATURE_PWM_HAS_NO_WAITEN (0)
 /* @brief If (e)FlexPWM has phase delay feature. */
 #define FSL_FEATURE_PWM_HAS_PHASE_DELAY (1)
 /* @brief If (e)FlexPWM has input filter capture feature. */

--- a/mcux/mcux-sdk/devices/LPC5536/LPC5536_features.h
+++ b/mcux/mcux-sdk/devices/LPC5536/LPC5536_features.h
@@ -610,7 +610,7 @@
 /* @brief Number of fault channel in each (e)FlexPWM module. */
 #define FSL_FEATURE_PWM_FAULT_CH_COUNT (1)
 /* @brief (e)FlexPWM has no WAITEN Bitfield In CTRL2 Register. */
-#define FSL_FEATURE_PWM_HAS_NO_WAITEN (1)
+#define FSL_FEATURE_PWM_HAS_NO_WAITEN (0)
 /* @brief If (e)FlexPWM has phase delay feature. */
 #define FSL_FEATURE_PWM_HAS_PHASE_DELAY (1)
 /* @brief If (e)FlexPWM has input filter capture feature. */

--- a/mcux/mcux-sdk/devices/LPC55S36/LPC55S36_features.h
+++ b/mcux/mcux-sdk/devices/LPC55S36/LPC55S36_features.h
@@ -639,7 +639,7 @@
 /* @brief Number of fault channel in each (e)FlexPWM module. */
 #define FSL_FEATURE_PWM_FAULT_CH_COUNT (1)
 /* @brief (e)FlexPWM has no WAITEN Bitfield In CTRL2 Register. */
-#define FSL_FEATURE_PWM_HAS_NO_WAITEN (1)
+#define FSL_FEATURE_PWM_HAS_NO_WAITEN (0)
 /* @brief If (e)FlexPWM has phase delay feature. */
 #define FSL_FEATURE_PWM_HAS_PHASE_DELAY (1)
 /* @brief If (e)FlexPWM has input filter capture feature. */


### PR DESCRIPTION
Three LPC devices were using the HAS_NO_WAITEN
macro definition when the devices had the WAIT
ENABLE BIT for PWM on their individual device
header file.

PR submitted to internal mcux-sdk-github repo as well.