### PR TITLE
mcux: Enable flexio hal driver to support flexio IP on S32 SoCs

### DIFF
--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
@@ -114,13 +114,19 @@ void FLEXIO_Init(FLEXIO_Type *base, const flexio_config_t *userConfig)
     FLEXIO_Reset(base);
 
     ctrlReg = base->CTRL;
+#ifdef FSL_FEATURE_FLEXIO_HAS_NO_DOZE_MODE_SUPPORT
+    ctrlReg &= ~(FLEXIO_CTRL_DBGE_MASK | FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+#else
     ctrlReg &= ~(FLEXIO_CTRL_DOZEN_MASK | FLEXIO_CTRL_DBGE_MASK | FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+#endif
     ctrlReg |= (FLEXIO_CTRL_DBGE(userConfig->enableInDebug) | FLEXIO_CTRL_FASTACC(userConfig->enableFastAccess) |
                 FLEXIO_CTRL_FLEXEN(userConfig->enableFlexio));
+#ifndef FSL_FEATURE_FLEXIO_HAS_NO_DOZE_MODE_SUPPORT
     if (!userConfig->enableInDoze)
     {
         ctrlReg |= FLEXIO_CTRL_DOZEN_MASK;
     }
+#endif
 
     base->CTRL = ctrlReg;
 }

--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio.h
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio.h
@@ -67,6 +67,7 @@ typedef enum _flexio_timer_mode
     kFLEXIO_TimerModeDual8BitBaudBit = 0x1U, /*!< Dual 8-bit counters baud/bit mode. */
     kFLEXIO_TimerModeDual8BitPWM     = 0x2U, /*!< Dual 8-bit counters PWM mode. */
     kFLEXIO_TimerModeSingle16Bit     = 0x3U, /*!< Single 16-bit counter mode. */
+    kFLEXIO_TimerModeDual8BitPWMLow  = 0x6U, /*!< Dual 8-bit counters PWM Low mode. */
 } flexio_timer_mode_t;
 
 /*! @brief Define type of timer initial output or timer reset condition.*/
@@ -893,6 +894,50 @@ static inline uint32_t FLEXIO_PinRead(FLEXIO_Type *base, uint32_t pin)
 static inline uint32_t FLEXIO_GetPinStatus(FLEXIO_Type *base, uint32_t pin)
 {
     return (((base->PINSTAT) >> pin) & 0x01U);
+}
+
+/*!
+ * @brief Sets the FLEXIO output pin level.
+ *
+ * @param base   FlexIO peripheral base address
+ * @param pin    FlexIO pin number.
+ * @param level  FlexIO output pin level to set, can be either 0 or 1.
+ */
+static inline void FLEXIO_SetPinLevel(FLEXIO_Type *base, uint8_t pin, bool level)
+{
+	base->PINOUTD =
+		(base->PINOUTD & ~((uint32_t)((uint32_t)1U << pin))) |
+		(FLEXIO_PINOUTD_OUTD((uint32_t)((true == level)
+		? (uint32_t)0x1U : (uint32_t)0x0U) << pin));
+}
+
+/*!
+ * @brief Gets the enabled status of a FLEXIO output pin.
+ *
+ * @param base   FlexIO peripheral base address
+ * @param pin    FlexIO pin number.
+ * @retval       FlexIO port enabled status
+ *        - 0: corresponding output pin is in disabled state.
+ *        - 1: corresponding output pin is in enabled state.
+ */
+static inline bool FLEXIO_GetPinOverride(const FLEXIO_Type *const base, uint8_t pin)
+{
+	return ((base->PINOUTE & (uint32_t)((uint32_t)1U << pin)) != 0UL);
+}
+
+/*!
+ * @brief Enables or disables a FLEXIO output pin.
+ *
+ * @param base     FlexIO peripheral base address
+ * @param pin      Flexio pin number.
+ * @param enabled  Enable or disable the FlexIO pin.
+ */
+static inline void FLEXIO_ConfigPinOverride(FLEXIO_Type *base, uint8_t pin, bool enabled)
+{
+	base->PINOUTE =
+		(base->PINOUTE & ~((uint32_t)((uint32_t)1U << pin))) |
+		FLEXIO_PINOUTE_OUTE((uint32_t)((true == enabled)
+		? (uint32_t)0x1U : (uint32_t)0x0U) << pin);
 }
 
 /*!

--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -21,6 +21,8 @@
 #define FSL_FEATURE_SOC_LPSPI_COUNT (6)
 /* @brief EDMA availability on the SoC. */
 #define FSL_FEATURE_SOC_EDMA_COUNT (1)
+/* @brief FLEXIO availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXIO_COUNT (1)
 
 /* LPUART module features */
 
@@ -199,6 +201,13 @@
 #define FSL_FEATURE_DMAMUX_HAS_TRIG (1)
 /* @brief Register CHCFGn width. */
 #define FSL_FEATURE_DMAMUX_CHCFG_REGISTER_WIDTH (8)
+
+/* FLEXIO module features */
+
+/* @brief Has pin input output related registers */
+#define FSL_FEATURE_FLEXIO_HAS_PIN_REGISTER (1)
+/* @brief Has doze mode in Flexio */
+#define FSL_FEATURE_FLEXIO_HAS_NO_DOZE_MODE_SUPPORT (1)
 
 /* @brief Memory map has offset between subsystems. */
 #define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)

--- a/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
+++ b/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
@@ -197,4 +197,15 @@
 /** Array initializer of DMAMUX peripheral base pointers */
 #define DMAMUX_BASE_PTRS                        IP_DMAMUX_BASE_PTRS
 
+/* FLEXIO - Peripheral instance base addresses */
+/** Peripheral FLEXIO base address */
+#define FLEXIO_BASE                             IP_FLEXIO_BASE
+/** Peripheral FLEXIO base pointer */
+#define FLEXIO                                  IP_FLEXIO
+/** Array initializer of FLEXIO peripheral base addresses */
+#define FLEXIO_BASE_ADDRS                       IP_FLEXIO_BASE_ADDRS
+/** Array initializer of FLEXIO peripheral base pointers */
+#define FLEXIO_BASE_PTRS                        IP_FLEXIO_BASE_PTRS
+/** Interrupt vectors for the FLEXIO peripheral type */
+#define FLEXIO_IRQS                              { FLEXIO_IRQn }
 #endif  /* _S32K344_GLUE_MCUX_H_ */


### PR DESCRIPTION
Flexio IP in mcux and S32 SoCs are quite similar.
These changes enable the existing Flexio driver to use memory mapping of S32K344 and adds a NO DOZE mode for using Flexio driver on S32K344.