### PR TITLE
drivers: csi: Rework to fix the low framerate issue

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -75,3 +75,4 @@ Patch List:
       - Update usb_device_ehci.c and usb_device_lpcip3511.c if in Zephyr environment.
         - Add include of usb_device_mcux_drv_port.h.
         - Remove include of usb_device.h and usb_device_dci.h.
+  7. drivers: csi: Rework to fix the low framerate issue


### PR DESCRIPTION
Currently, the camera framerate is divided by two. This is because the driver only puts the full buffer to the queue and calls the callback at half of the interrupt rate (when there are at least 2 active framebuffers).

This issue is not really visible when using more than two buffers and the application does not hold the full buffer for too long before submitting it again to the empty buffers queue. But if we use only two buffers, the framerate is clearly reduced (by a factor of two).

Especially, when CSI_TransferGetFullBuffer() get called inside the callback function (as in Zephyr RTOS), framerate is always reduced by a factor of two despite of the number of buffers used.

Rework the driver to fix these issues as well as to clean up the logics.

The corresponding SDK PR is here https://github.com/nxp-mcuxpresso/mcux-sdk/pull/188

- I already updated this PR with the **latest code from the SDK PR** which addressed the comments from the reviewer.
- As the patch list in the README is changed nearly everyday, this PR may have a merge conflict (on the patch number in README). I suggest to solve this merge conflict when the PR is on the point to be merged.