### PR TITLE
s32: s32k146: set RTC clock source to internal oscillator

### DIFF
--- a/s32/soc/s32k146/src/Clock_Ip_Cfg.c
+++ b/s32/soc/s32k146/src/Clock_Ip_Cfg.c
@@ -239,7 +239,7 @@ const Clock_Ip_ClockConfigType Clock_Ip_aClockConfig[1U] = {
             #if CLOCK_IP_SELECTORS_NO > 4U
             {
                 RTC_CLK,                    /* Clock name associated to selector */
-                RTC_CLKIN,                    /* Name of the selected input source */
+                LPO_32K_CLK,                    /* Name of the selected input source */
             },
             #endif
 


### PR DESCRIPTION
Set the RTC clock source to the 32KHz internal oscillator.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/71289