### PR TITLE
drivers: elcdif: Fix register writting issue in SetPixelFormat

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -77,3 +77,4 @@ Patch List:
         - Remove include of usb_device.h and usb_device_dci.h.
   7. drivers: csi: Rework to fix the low framerate issue
   8. drivers: flexio: Enable flexio hal driver to support flexio IP on S32 SoCs
+  9. drivers: elcdif: Fix register writting issue in SetPixelFormat

--- a/mcux/mcux-sdk/drivers/elcdif/fsl_elcdif.c
+++ b/mcux/mcux-sdk/drivers/elcdif/fsl_elcdif.c
@@ -210,7 +210,8 @@ void ELCDIF_RgbModeSetPixelFormat(LCDIF_Type *base, elcdif_pixel_format_t pixelF
                                  LCDIF_CTRL_DATA_FORMAT_18_BIT_MASK | LCDIF_CTRL_DATA_FORMAT_16_BIT_MASK)) |
                  s_pixelFormatReg[(uint32_t)pixelFormat].regCtrl;
 
-    base->CTRL1 = s_pixelFormatReg[(uint32_t)pixelFormat].regCtrl1;
+    base->CTRL1 = (base->CTRL1 & ~(LCDIF_CTRL1_BYTE_PACKING_FORMAT_MASK)) |
+                  s_pixelFormatReg[(uint32_t)pixelFormat].regCtrl1;
 }
 
 /*!


### PR DESCRIPTION
Currently, when setting pixel format, all the previous values of the CTRL1 register, even not related to pixel format, are unwantedly cleared. This leads to some erroneous behaviors, for example, the interrupts will be disabled.

Fix it by modifying only the related bits of the CTRL1 register.

This was also merged to github mcux-sdk: https://github.com/nxp-mcuxpresso/mcux-sdk/commit/84cd68607886ca810c239e7b95b8b7d497096c9b
