### PR TITLE
mcux: Enable flexio hal driver to support flexio IP on S32 SoCs

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -76,3 +76,4 @@ Patch List:
         - Add include of usb_device_mcux_drv_port.h.
         - Remove include of usb_device.h and usb_device_dci.h.
   7. drivers: csi: Rework to fix the low framerate issue
+  8. drivers: flexio: Enable flexio hal driver to support flexio IP on S32 SoCs

--- a/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
+++ b/mcux/mcux-sdk/drivers/flexio/fsl_flexio.c
@@ -114,13 +114,19 @@ void FLEXIO_Init(FLEXIO_Type *base, const flexio_config_t *userConfig)
     FLEXIO_Reset(base);
 
     ctrlReg = base->CTRL;
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && (FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
     ctrlReg &= ~(FLEXIO_CTRL_DOZEN_MASK | FLEXIO_CTRL_DBGE_MASK | FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+#else
+    ctrlReg &= ~(FLEXIO_CTRL_DBGE_MASK | FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+#endif
     ctrlReg |= (FLEXIO_CTRL_DBGE(userConfig->enableInDebug) | FLEXIO_CTRL_FASTACC(userConfig->enableFastAccess) |
                 FLEXIO_CTRL_FLEXEN(userConfig->enableFlexio));
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && (FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
     if (!userConfig->enableInDoze)
     {
         ctrlReg |= FLEXIO_CTRL_DOZEN_MASK;
     }
+#endif
 
     base->CTRL = ctrlReg;
 }
@@ -160,7 +166,9 @@ void FLEXIO_GetDefaultConfig(flexio_config_t *userConfig)
     (void)memset(userConfig, 0, sizeof(*userConfig));
 
     userConfig->enableFlexio     = true;
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && (FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
     userConfig->enableInDoze     = false;
+#endif
     userConfig->enableInDebug    = true;
     userConfig->enableFastAccess = false;
 }

--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -21,6 +21,8 @@
 #define FSL_FEATURE_SOC_LPSPI_COUNT (6)
 /* @brief EDMA availability on the SoC. */
 #define FSL_FEATURE_SOC_EDMA_COUNT (1)
+/* @brief FLEXIO availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXIO_COUNT (1)
 
 /* LPUART module features */
 
@@ -199,6 +201,35 @@
 #define FSL_FEATURE_DMAMUX_HAS_TRIG (1)
 /* @brief Register CHCFGn width. */
 #define FSL_FEATURE_DMAMUX_CHCFG_REGISTER_WIDTH (8)
+
+/* FLEXIO module features */
+
+/* @brief Has pin input output related registers */
+#define FSL_FEATURE_FLEXIO_HAS_PIN_REGISTER (1)
+/* @brief Has doze mode in Flexio */
+#define FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT (0)
+/* @brief Has Shifter Status Register (FLEXIO_SHIFTSTAT) */
+#define FSL_FEATURE_FLEXIO_HAS_SHIFTER_STATUS (1)
+/* @brief Has Pin Data Input Register (FLEXIO_PIN) */
+#define FSL_FEATURE_FLEXIO_HAS_PIN_STATUS (1)
+/* @brief Has Shifter Buffer N Nibble Byte Swapped Register (FLEXIO_SHIFTBUFNBSn) */
+#define FSL_FEATURE_FLEXIO_HAS_SHFT_BUFFER_NIBBLE_BYTE_SWAP (1)
+/* @brief Has Shifter Buffer N Half Word Swapped Register (FLEXIO_SHIFTBUFHWSn) */
+#define FSL_FEATURE_FLEXIO_HAS_SHFT_BUFFER_HALF_WORD_SWAP (1)
+/* @brief Has Shifter Buffer N Nibble Swapped Register (FLEXIO_SHIFTBUFNISn) */
+#define FSL_FEATURE_FLEXIO_HAS_SHFT_BUFFER_NIBBLE_SWAP (1)
+/* @brief Supports Shifter State Mode (FLEXIO_SHIFTCTLn[SMOD]) */
+#define FSL_FEATURE_FLEXIO_HAS_STATE_MODE (1)
+/* @brief Supports Shifter Logic Mode (FLEXIO_SHIFTCTLn[SMOD]) */
+#define FSL_FEATURE_FLEXIO_HAS_LOGIC_MODE (1)
+/* @brief Supports paralle width (FLEXIO_SHIFTCFGn[PWIDTH]) */
+#define FSL_FEATURE_FLEXIO_HAS_PARALLEL_WIDTH (1)
+/* @brief Reset value of the FLEXIO_VERID register */
+#define FSL_FEATURE_FLEXIO_VERID_RESET_VALUE (0x02010003)
+/* @brief Reset value of the FLEXIO_PARAM register */
+#define FSL_FEATURE_FLEXIO_PARAM_RESET_VALUE (0x04200808)
+/* @brief Flexio DMA request base channel */
+#define FSL_FEATURE_FLEXIO_DMA_REQUEST_BASE_CHANNEL (0)
 
 /* @brief Memory map has offset between subsystems. */
 #define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)

--- a/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
+++ b/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
@@ -197,4 +197,15 @@
 /** Array initializer of DMAMUX peripheral base pointers */
 #define DMAMUX_BASE_PTRS                        IP_DMAMUX_BASE_PTRS
 
+/* FLEXIO - Peripheral instance base addresses */
+/** Peripheral FLEXIO base address */
+#define FLEXIO_BASE                             IP_FLEXIO_BASE
+/** Peripheral FLEXIO base pointer */
+#define FLEXIO                                  IP_FLEXIO
+/** Array initializer of FLEXIO peripheral base addresses */
+#define FLEXIO_BASE_ADDRS                       IP_FLEXIO_BASE_ADDRS
+/** Array initializer of FLEXIO peripheral base pointers */
+#define FLEXIO_BASE_PTRS                        IP_FLEXIO_BASE_PTRS
+/** Interrupt vectors for the FLEXIO peripheral type */
+#define FLEXIO_IRQS                              { FLEXIO_IRQn }
 #endif  /* _S32K344_GLUE_MCUX_H_ */


### PR DESCRIPTION
This commit enables the existing mcux flexio driver to support Flexio IP on S32 SoCs as well.