### PR TITLE
Support monolithic app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,5 @@ else()
     imx
     )
 endif()
+
+add_subdirectory(zephyr/src)

--- a/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
+++ b/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
@@ -19,16 +19,16 @@ if(CONFIG_SOC_SERIES_RW6XX)
 
     zephyr_compile_definitions(gPlatformDisableVendorSpecificInit=1U)
 
-    if (CONFIG_MONOLITHIC_WIFI OR CONFIG_MONOLITHIC_BT OR CONFIG_MONOLITHIC_IEEE802154)
+    if (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_BT OR CONFIG_NXP_MONOLITHIC_IEEE802154)
         zephyr_compile_definitions(gPlatformMonolithicApp_d=1U)
 
-        zephyr_compile_definitions_ifndef(CONFIG_MONOLITHIC_BT
+        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_BT
                                           BLE_FW_ADDRESS=0U)
 
-        zephyr_compile_definitions_ifndef(CONFIG_MONOLITHIC_WIFI
+        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_WIFI
                                           WIFI_FW_ADDRESS=0U)
 
-        zephyr_compile_definitions_ifndef(CONFIG_MONOLITHIC_IEEE802154
+        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_IEEE802154
                                           COMBO_FW_ADDRESS=0U)
     endif()
 endif()

--- a/zephyr/src/CMakeLists.txt
+++ b/zephyr/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory_ifdef(CONFIG_SOC_SERIES_RW6XX rw61x)

--- a/zephyr/src/rw61x/CMakeLists.txt
+++ b/zephyr/src/rw61x/CMakeLists.txt
@@ -1,0 +1,56 @@
+if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_BT OR CONFIG_NXP_MONOLITHIC_IEEE802154)
+	set(hal_blobs_dir ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/rw61x)
+
+	set(signed_binary_blobs_list)
+	set(binary_blobs_list)
+	set(output_includes_list)
+
+	if(CONFIG_NXP_MONOLITHIC_WIFI)
+		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_wifi_fw.bin.inc)
+
+		set(signed_binary_blob_name rw61x_sb_wifi_a2.bin)
+
+		list(APPEND signed_binary_blobs_list ${hal_blobs_dir}/${signed_binary_blob_name})
+
+		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu1.c)
+	endif()
+	if(CONFIG_NXP_MONOLITHIC_IEEE802154)
+		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_combo_fw.bin.inc)
+
+		set(signed_binary_blob_name rw61x_sb_combo_a2.bin)
+
+		list(APPEND signed_binary_blobs_list ${hal_blobs_dir}/${signed_binary_blob_name})
+
+		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu2.c)
+	elseif(CONFIG_NXP_MONOLITHIC_BT)
+		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_ble_fw.bin.inc)
+
+		set(signed_binary_blob_name rw61x_sb_ble_a2.bin)
+
+		list(APPEND signed_binary_blobs_list ${hal_blobs_dir}/${signed_binary_blob_name})
+
+		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu2.c)
+	endif()
+
+	list(LENGTH signed_binary_blobs_list count)
+	math(EXPR count "${count}-1")
+	foreach(i RANGE ${count})
+		list(GET signed_binary_blobs_list ${i} signed_binary_blob)
+		if(EXISTS ${signed_binary_blob})
+			set(binary_blob ${signed_binary_blob})
+		else()
+			message(FATAL_ERROR "Couldn't find signed firmware ! ${signed_binary_blob}")
+		endif()
+
+		list(APPEND binary_blobs_list ${binary_blob})
+	endforeach()
+
+	list(LENGTH binary_blobs_list count)
+	math(EXPR count "${count}-1")
+	foreach(i RANGE ${count})
+		list(GET binary_blobs_list ${i} binary_blob)
+		list(GET output_includes_list ${i} output_include)
+		message(STATUS " generate include of binary blob: ${binary_blob}")
+		generate_inc_file_for_target(${ZEPHYR_CURRENT_LIBRARY} ${binary_blob} ${output_include})
+	endforeach()
+endif()

--- a/zephyr/src/rw61x/rw61x_cpu1.c
+++ b/zephyr/src/rw61x/rw61x_cpu1.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+
+#include <stdint.h>
+
+#if defined(CONFIG_NXP_MONOLITHIC_WIFI)
+__attribute__ ((__section__(".fw_cpu1"), used))
+const uint8_t fw_cpu1[] = {
+    #include <rw61x_wifi_fw.bin.inc>
+};
+
+const unsigned char *wlan_fw_bin = (const unsigned char *)(void *)&fw_cpu1[0];
+const unsigned int wlan_fw_bin_len = sizeof(fw_cpu1);
+#endif

--- a/zephyr/src/rw61x/rw61x_cpu2.c
+++ b/zephyr/src/rw61x/rw61x_cpu2.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+
+#include <stdint.h>
+
+#if defined(CONFIG_NXP_MONOLITHIC_IEEE802154)
+__attribute__ ((__section__(".fw_cpu2_combo"), used))
+const uint8_t fw_cpu2_combo[] = {
+    #include <rw61x_combo_fw.bin.inc>
+};
+#elif defined(CONFIG_NXP_MONOLITHIC_BT)
+__attribute__ ((__section__(".fw_cpu2_ble"), used))
+const uint8_t fw_cpu2_ble[] = {
+    #include <rw61x_ble_fw.bin.inc>
+};
+#endif


### PR DESCRIPTION
Make use of generate_inc_file_for_target() to convert the firmware binaries into C arrays which will be linked by the application and sourced when loading the CPU1 and CPU2 firmwares.

Put the firmwares into sections to allow for more control on placement.