### PR TITLE
middleware: usb: the MCUX udc Kconfig macro is changed.

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -372,9 +372,9 @@ if (CONFIG_UDC_DRIVER)
   list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb
   )
-  include_ifdef(CONFIG_USB_UDC_NXP_PHY          middleware_usb_phy)
-  include_ifdef(CONFIG_USB_UDC_NXP_EHCI         middleware_usb_device_ehci)
-  include_ifdef(CONFIG_USB_UDC_NXP_IP3511       middleware_usb_device_ip3511fs)
+  include_ifdef(CONFIG_DT_HAS_NXP_USBPHY_ENABLED  middleware_usb_phy)
+  include_ifdef(CONFIG_UDC_NXP_EHCI               middleware_usb_device_ehci)
+  include_ifdef(CONFIG_UDC_NXP_IP3511             middleware_usb_device_ip3511fs)
 
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/device)
   zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/middleware/mcux-sdk-middleware-usb/phy)

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_ehci.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_ehci.c
@@ -23,6 +23,7 @@
 #include "usb_device_dci.h"
 
 #include "usb_device_ehci.h"
+#endif
 #if (defined(USB_DEVICE_CONFIG_LOW_POWER_MODE) && (USB_DEVICE_CONFIG_LOW_POWER_MODE > 0U))
 #if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT > 0U))
 #include "usb_phy.h"
@@ -37,7 +38,6 @@
 #endif
 #if defined FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET && FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET
 #include "fsl_memory.h"
-#endif
 #endif
 /*******************************************************************************
  * Definitions

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
@@ -15,6 +15,7 @@
 #else
 #include "usb_device.h"
 #include "fsl_device_registers.h"
+#endif
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U)) && \
     ((defined(FSL_FEATURE_SOC_USBHSDCD_COUNT) && (FSL_FEATURE_SOC_USBHSDCD_COUNT > 0U)))
 #include "usb_hsdcd.h"
@@ -22,7 +23,6 @@
 #if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT > 0U))
 #if ((defined FSL_FEATURE_USBHSD_HAS_EXIT_HS_ISSUE) && (FSL_FEATURE_USBHSD_HAS_EXIT_HS_ISSUE > 0U))
 #include "usb_phy.h"
-#endif
 #endif
 #endif
 #if (((defined(USB_DEVICE_CONFIG_LPCIP3511FS)) && (USB_DEVICE_CONFIG_LPCIP3511FS > 0U)) || \

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_mcux_drv_port.h
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_mcux_drv_port.h
@@ -157,7 +157,7 @@ typedef enum _usb_endpoint_status
  */
 usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg);
 
-#ifdef CONFIG_USB_UDC_NXP_EHCI
+#if ((defined USB_DEVICE_CONFIG_EHCI) && (USB_DEVICE_CONFIG_EHCI))
 /*!
  * @brief Device EHCI ISR function.
  *
@@ -168,7 +168,8 @@ usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg);
 extern void USB_DeviceEhciIsrFunction(void *deviceHandle);
 #endif
 
-#ifdef CONFIG_USB_UDC_NXP_IP3511
+#if ((defined USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS)) ||\
+    ((defined USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS))
 /*!
  * @brief Device LPC USB ISR function.
  *


### PR DESCRIPTION
Remove the 'USB' prefix in the Kconfig macro.
Update controller drivers to still include some head files that can be controlled by MCUX USB stack macro.
Replace Zephyr Kconfig marco with MCUX USB macro in usb_device_mcux_drv_port.h