### PR TITLE
s32: drivers: dio: optimize bit reversal function using `__RBIT` intrinsic

### DIFF
--- a/s32/drivers/s32k3/Dio/src/Siul2_Dio_Ip.c
+++ b/s32/drivers/s32k3/Dio/src/Siul2_Dio_Ip.c
@@ -28,6 +28,7 @@ extern "C"{
 #if (STD_ON == SIUL2_DIO_IP_DEV_ERROR_DETECT)
     #include "Devassert.h"
 #endif /* (STD_ON == SIUL2_DIO_IP_DEV_ERROR_DETECT) */
+#include "cmsis_compiler.h"
 
 /*==================================================================================================
 *                                 SOURCE FILE VERSION INFORMATION
@@ -146,15 +147,11 @@ static inline uint16 Siul2_Dio_Ip_Rev_Bit_16(uint16 value);
 /* Reverse bit order in each halfword independently */
 static inline uint16 Siul2_Dio_Ip_Rev_Bit_16(uint16 value)
 {
-    uint8 i;
-    uint16 ret = 0U;
+    uint32 ret;
 
-    for (i = 0U; i < 8U; i++)
-    {
-        ret |= (uint16)((((value >> i) & 1U) << (15U - i)) | (((value << i) & 0x8000U) >> (15U - i)));
-    }
+    ret = __RBIT((uint32)value) >> 16U;
 
-    return ret;
+    return (uint16)ret;
 }
 
 /*==================================================================================================

--- a/s32/drivers/s32ze/Dio/src/Siul2_Dio_Ip.c
+++ b/s32/drivers/s32ze/Dio/src/Siul2_Dio_Ip.c
@@ -31,6 +31,7 @@ extern "C"{
 #if (defined(MCAL_ENABLE_USER_MODE_SUPPORT) && defined(DIO_ENABLE_USER_MODE_SUPPORT) && (STD_ON == DIO_ENABLE_USER_MODE_SUPPORT))
     #include "OsIf_Internal.h"
 #endif /* (defined(MCAL_ENABLE_USER_MODE_SUPPORT) && defined(DIO_ENABLE_USER_MODE_SUPPORT) && (STD_ON == DIO_ENABLE_USER_MODE_SUPPORT)) */
+#include "cmsis_compiler.h"
 
 /*==================================================================================================
 *                                 SOURCE FILE VERSION INFORMATION
@@ -223,15 +224,11 @@ Siul2_Dio_Ip_PinsChannelType Siul2_Dio_Ip_ReadPinsRunTime(const Siul2_Dio_Ip_Gpi
 /* Reverse bit order in each halfword independently */
 static inline uint16 Siul2_Dio_Ip_Rev_Bit_16(uint16 value)
 {
-    uint8 i;
-    uint16 ret = 0U;
+    uint32 ret;
 
-    for (i = 0U; i < 8U; i++)
-    {
-        ret |= (uint16)((((value >> i) & 1U) << (15U - i)) | (((value << i) & 0x8000U) >> (15U - i)));
-    }
+    ret = __RBIT((uint32)value) >> 16U;
 
-    return ret;
+    return (uint16)ret;
 }
 
 /*==================================================================================================


### PR DESCRIPTION
Optimized the `Siul2_Dio_Ip_Rev_Bit_16` function by replacing the loop-based bit reversal implementation with the `__RBIT` intrinsic. This change enhances performance and reduces code footprint.