### PR TITLE
s32: mcux: s32k146: enable ADC driver

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -97,3 +97,5 @@ Patch List:
       - MCXA15x family
       - MCXN23x family
   - add kUSB_DeviceNotifySOF to usb_device_mcux_drv_port.h SDK USB stack already supports it in SDK 2.16.0
+  - mcux-sdk/drivers/adc12/fsl_adc12.c: add guards to avoid compilation warnings when building
+      with SDK clock control driver disabled.

--- a/mcux/mcux-sdk/drivers/adc12/fsl_adc12.c
+++ b/mcux/mcux-sdk/drivers/adc12/fsl_adc12.c
@@ -30,7 +30,9 @@
  *
  * @param base ADC12 peripheral base address
  */
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t ADC12_GetInstance(ADC_Type *base);
+#endif
 
 /*!
  * @brief Check calibration failed status.
@@ -62,8 +64,8 @@ static status_t ADC12_GetCalibrationStatus(ADC_Type *base);
  * Variables
  ******************************************************************************/
 /*! @brief Pointers to ADC12 bases for each instance. */
-static ADC_Type *const s_adc12Bases[] = ADC_BASE_PTRS;
 #if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+static ADC_Type *const s_adc12Bases[] = ADC_BASE_PTRS;
 /*! @brief Pointers to ADC12 clocks for each instance. */
 static const clock_ip_name_t s_adc12Clocks[] = ADC12_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
@@ -71,6 +73,7 @@ static const clock_ip_name_t s_adc12Clocks[] = ADC12_CLOCKS;
 /*******************************************************************************
  * Code
  ******************************************************************************/
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t ADC12_GetInstance(ADC_Type *base)
 {
     uint32_t instance;
@@ -88,6 +91,7 @@ static uint32_t ADC12_GetInstance(ADC_Type *base)
 
     return instance;
 }
+#endif
 
 static status_t ADC12_GetCalibrationStatus(ADC_Type *base)
 {

--- a/s32/drivers/s32k1/BaseNXP/header/S32K146_ADC.h
+++ b/s32/drivers/s32k1/BaseNXP/header/S32K146_ADC.h
@@ -69,9 +69,8 @@
  */
 
 /** ADC - Size of Registers Arrays */
-#define ADC_CV_COUNT                              2u
-#define ADC_SC1ZZ_COUNT                           8u
-#define ADC_RZZ_COUNT                             8u
+#define ADC_SC1_COUNT                             24u
+#define ADC_R_COUNT                               24u
 
 /** ADC - Register Layout Typedef */
 typedef struct {
@@ -109,7 +108,8 @@ typedef struct {
   __I  uint32_t RN;                                /**< ADC Data Result Registers, offset: 0x7C */
   __I  uint32_t RO;                                /**< ADC Data Result Registers, offset: 0x80 */
   __I  uint32_t RP;                                /**< ADC Data Result Registers, offset: 0x84 */
-  __IO uint32_t CV[ADC_CV_COUNT];                  /**< Compare Value Registers, array offset: 0x88, array step: 0x4 */
+  __IO uint32_t CV1;                               /**< Compare Value Registers, offset: 0x88 */
+  __IO uint32_t CV2;                               /**< Compare Value Registers, offset: 0x8C */
   __IO uint32_t SC2;                               /**< Status and Control Register 2, offset: 0x90 */
   __IO uint32_t SC3;                               /**< Status and Control Register 3, offset: 0x94 */
   __IO uint32_t BASE_OFS;                          /**< BASE Offset Register, offset: 0x98 */
@@ -134,41 +134,9 @@ typedef struct {
   __IO uint32_t CLPX_OFS;                          /**< ADC Plus-Side General Calibration Offset Value Register X, offset: 0xE4 */
   __IO uint32_t CLP9_OFS;                          /**< ADC Plus-Side General Calibration Offset Value Register 9, offset: 0xE8 */
   uint8_t RESERVED_0[28];
-  __IO uint32_t ASC1A;                             /**< ADC Status and Control Register 1, offset: 0x108 */
-  __IO uint32_t ASC1B;                             /**< ADC Status and Control Register 1, offset: 0x10C */
-  __IO uint32_t ASC1C;                             /**< ADC Status and Control Register 1, offset: 0x110 */
-  __IO uint32_t ASC1D;                             /**< ADC Status and Control Register 1, offset: 0x114 */
-  __IO uint32_t ASC1E;                             /**< ADC Status and Control Register 1, offset: 0x118 */
-  __IO uint32_t ASC1F;                             /**< ADC Status and Control Register 1, offset: 0x11C */
-  __IO uint32_t ASC1G;                             /**< ADC Status and Control Register 1, offset: 0x120 */
-  __IO uint32_t ASC1H;                             /**< ADC Status and Control Register 1, offset: 0x124 */
-  __IO uint32_t ASC1I;                             /**< ADC Status and Control Register 1, offset: 0x128 */
-  __IO uint32_t ASC1J;                             /**< ADC Status and Control Register 1, offset: 0x12C */
-  __IO uint32_t ASC1K;                             /**< ADC Status and Control Register 1, offset: 0x130 */
-  __IO uint32_t ASC1L;                             /**< ADC Status and Control Register 1, offset: 0x134 */
-  __IO uint32_t ASC1M;                             /**< ADC Status and Control Register 1, offset: 0x138 */
-  __IO uint32_t ASC1N;                             /**< ADC Status and Control Register 1, offset: 0x13C */
-  __IO uint32_t ASC1O;                             /**< ADC Status and Control Register 1, offset: 0x140 */
-  __IO uint32_t ASC1P;                             /**< ADC Status and Control Register 1, offset: 0x144 */
-  __IO uint32_t SC1[ADC_SC1ZZ_COUNT];              /**< ADC Status and Control Register 1, array offset: 0x148, array step: 0x4 */
+  __IO uint32_t SC1[ADC_SC1_COUNT];                /**< ADC Status and Control Register 1, array offset: 0x108, array step: 0x4 */
   uint8_t RESERVED_1[32];
-  __I  uint32_t ARA;                               /**< ADC Data Result Registers, offset: 0x188 */
-  __I  uint32_t ARB;                               /**< ADC Data Result Registers, offset: 0x18C */
-  __I  uint32_t ARC;                               /**< ADC Data Result Registers, offset: 0x190 */
-  __I  uint32_t ARD;                               /**< ADC Data Result Registers, offset: 0x194 */
-  __I  uint32_t ARE;                               /**< ADC Data Result Registers, offset: 0x198 */
-  __I  uint32_t ARF;                               /**< ADC Data Result Registers, offset: 0x19C */
-  __I  uint32_t ARG;                               /**< ADC Data Result Registers, offset: 0x1A0 */
-  __I  uint32_t ARH;                               /**< ADC Data Result Registers, offset: 0x1A4 */
-  __I  uint32_t ARI;                               /**< ADC Data Result Registers, offset: 0x1A8 */
-  __I  uint32_t ARJ;                               /**< ADC Data Result Registers, offset: 0x1AC */
-  __I  uint32_t ARK;                               /**< ADC Data Result Registers, offset: 0x1B0 */
-  __I  uint32_t ARL;                               /**< ADC Data Result Registers, offset: 0x1B4 */
-  __I  uint32_t ARM;                               /**< ADC Data Result Registers, offset: 0x1B8 */
-  __I  uint32_t ARN;                               /**< ADC Data Result Registers, offset: 0x1BC */
-  __I  uint32_t ARO;                               /**< ADC Data Result Registers, offset: 0x1C0 */
-  __I  uint32_t ARP;                               /**< ADC Data Result Registers, offset: 0x1C4 */
-  __I  uint32_t R[ADC_RZZ_COUNT];                  /**< ADC Data Result Registers, array offset: 0x1C8, array step: 0x4 */
+  __I  uint32_t R[ADC_R_COUNT];                    /**< ADC Data Result Registers, array offset: 0x188, array step: 0x4 */
 } ADC_Type, *ADC_MemMapPtr;
 
 /** Number of instances of the ADC module. */
@@ -678,13 +646,24 @@ typedef struct {
 #define ADC_RP_D(x)                              (((uint32_t)(((uint32_t)(x)) << ADC_RP_D_SHIFT)) & ADC_RP_D_MASK)
 /*! @} */
 
-/*! @name CV - Compare Value Registers */
+/*! @name CV1 - Compare Value Registers */
 /*! @{ */
 
-#define ADC_CV_CV_MASK                           (0xFFFFU)
-#define ADC_CV_CV_SHIFT                          (0U)
-#define ADC_CV_CV_WIDTH                          (16U)
-#define ADC_CV_CV(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_CV_CV_SHIFT)) & ADC_CV_CV_MASK)
+#define ADC_CV1_CV_MASK                          (0xFFFFU)
+#define ADC_CV1_CV_SHIFT                         (0U)
+/*! CV - Compare Value.
+ */
+#define ADC_CV1_CV(x)                            (((uint32_t)(((uint32_t)(x)) << ADC_CV1_CV_SHIFT)) & ADC_CV1_CV_MASK)
+/*! @} */
+
+/*! @name CV2 - Compare Value Registers */
+/*! @{ */
+
+#define ADC_CV2_CV_MASK                          (0xFFFFU)
+#define ADC_CV2_CV_SHIFT                         (0U)
+/*! CV - Compare Value.
+ */
+#define ADC_CV2_CV(x)                            (((uint32_t)(((uint32_t)(x)) << ADC_CV2_CV_SHIFT)) & ADC_CV2_CV_MASK)
 /*! @} */
 
 /*! @name SC2 - Status and Control Register 2 */
@@ -954,310 +933,6 @@ typedef struct {
 #define ADC_CLP9_OFS_CLP9_OFS(x)                 (((uint32_t)(((uint32_t)(x)) << ADC_CLP9_OFS_CLP9_OFS_SHIFT)) & ADC_CLP9_OFS_CLP9_OFS_MASK)
 /*! @} */
 
-/*! @name ASC1A - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1A_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1A_ADCH_SHIFT                     (0U)
-#define ADC_ASC1A_ADCH_WIDTH                     (6U)
-#define ADC_ASC1A_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1A_ADCH_SHIFT)) & ADC_ASC1A_ADCH_MASK)
-
-#define ADC_ASC1A_AIEN_MASK                      (0x40U)
-#define ADC_ASC1A_AIEN_SHIFT                     (6U)
-#define ADC_ASC1A_AIEN_WIDTH                     (1U)
-#define ADC_ASC1A_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1A_AIEN_SHIFT)) & ADC_ASC1A_AIEN_MASK)
-
-#define ADC_ASC1A_COCO_MASK                      (0x80U)
-#define ADC_ASC1A_COCO_SHIFT                     (7U)
-#define ADC_ASC1A_COCO_WIDTH                     (1U)
-#define ADC_ASC1A_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1A_COCO_SHIFT)) & ADC_ASC1A_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1B - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1B_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1B_ADCH_SHIFT                     (0U)
-#define ADC_ASC1B_ADCH_WIDTH                     (6U)
-#define ADC_ASC1B_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1B_ADCH_SHIFT)) & ADC_ASC1B_ADCH_MASK)
-
-#define ADC_ASC1B_AIEN_MASK                      (0x40U)
-#define ADC_ASC1B_AIEN_SHIFT                     (6U)
-#define ADC_ASC1B_AIEN_WIDTH                     (1U)
-#define ADC_ASC1B_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1B_AIEN_SHIFT)) & ADC_ASC1B_AIEN_MASK)
-
-#define ADC_ASC1B_COCO_MASK                      (0x80U)
-#define ADC_ASC1B_COCO_SHIFT                     (7U)
-#define ADC_ASC1B_COCO_WIDTH                     (1U)
-#define ADC_ASC1B_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1B_COCO_SHIFT)) & ADC_ASC1B_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1C - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1C_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1C_ADCH_SHIFT                     (0U)
-#define ADC_ASC1C_ADCH_WIDTH                     (6U)
-#define ADC_ASC1C_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1C_ADCH_SHIFT)) & ADC_ASC1C_ADCH_MASK)
-
-#define ADC_ASC1C_AIEN_MASK                      (0x40U)
-#define ADC_ASC1C_AIEN_SHIFT                     (6U)
-#define ADC_ASC1C_AIEN_WIDTH                     (1U)
-#define ADC_ASC1C_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1C_AIEN_SHIFT)) & ADC_ASC1C_AIEN_MASK)
-
-#define ADC_ASC1C_COCO_MASK                      (0x80U)
-#define ADC_ASC1C_COCO_SHIFT                     (7U)
-#define ADC_ASC1C_COCO_WIDTH                     (1U)
-#define ADC_ASC1C_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1C_COCO_SHIFT)) & ADC_ASC1C_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1D - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1D_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1D_ADCH_SHIFT                     (0U)
-#define ADC_ASC1D_ADCH_WIDTH                     (6U)
-#define ADC_ASC1D_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1D_ADCH_SHIFT)) & ADC_ASC1D_ADCH_MASK)
-
-#define ADC_ASC1D_AIEN_MASK                      (0x40U)
-#define ADC_ASC1D_AIEN_SHIFT                     (6U)
-#define ADC_ASC1D_AIEN_WIDTH                     (1U)
-#define ADC_ASC1D_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1D_AIEN_SHIFT)) & ADC_ASC1D_AIEN_MASK)
-
-#define ADC_ASC1D_COCO_MASK                      (0x80U)
-#define ADC_ASC1D_COCO_SHIFT                     (7U)
-#define ADC_ASC1D_COCO_WIDTH                     (1U)
-#define ADC_ASC1D_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1D_COCO_SHIFT)) & ADC_ASC1D_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1E - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1E_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1E_ADCH_SHIFT                     (0U)
-#define ADC_ASC1E_ADCH_WIDTH                     (6U)
-#define ADC_ASC1E_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1E_ADCH_SHIFT)) & ADC_ASC1E_ADCH_MASK)
-
-#define ADC_ASC1E_AIEN_MASK                      (0x40U)
-#define ADC_ASC1E_AIEN_SHIFT                     (6U)
-#define ADC_ASC1E_AIEN_WIDTH                     (1U)
-#define ADC_ASC1E_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1E_AIEN_SHIFT)) & ADC_ASC1E_AIEN_MASK)
-
-#define ADC_ASC1E_COCO_MASK                      (0x80U)
-#define ADC_ASC1E_COCO_SHIFT                     (7U)
-#define ADC_ASC1E_COCO_WIDTH                     (1U)
-#define ADC_ASC1E_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1E_COCO_SHIFT)) & ADC_ASC1E_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1F - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1F_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1F_ADCH_SHIFT                     (0U)
-#define ADC_ASC1F_ADCH_WIDTH                     (6U)
-#define ADC_ASC1F_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1F_ADCH_SHIFT)) & ADC_ASC1F_ADCH_MASK)
-
-#define ADC_ASC1F_AIEN_MASK                      (0x40U)
-#define ADC_ASC1F_AIEN_SHIFT                     (6U)
-#define ADC_ASC1F_AIEN_WIDTH                     (1U)
-#define ADC_ASC1F_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1F_AIEN_SHIFT)) & ADC_ASC1F_AIEN_MASK)
-
-#define ADC_ASC1F_COCO_MASK                      (0x80U)
-#define ADC_ASC1F_COCO_SHIFT                     (7U)
-#define ADC_ASC1F_COCO_WIDTH                     (1U)
-#define ADC_ASC1F_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1F_COCO_SHIFT)) & ADC_ASC1F_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1G - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1G_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1G_ADCH_SHIFT                     (0U)
-#define ADC_ASC1G_ADCH_WIDTH                     (6U)
-#define ADC_ASC1G_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1G_ADCH_SHIFT)) & ADC_ASC1G_ADCH_MASK)
-
-#define ADC_ASC1G_AIEN_MASK                      (0x40U)
-#define ADC_ASC1G_AIEN_SHIFT                     (6U)
-#define ADC_ASC1G_AIEN_WIDTH                     (1U)
-#define ADC_ASC1G_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1G_AIEN_SHIFT)) & ADC_ASC1G_AIEN_MASK)
-
-#define ADC_ASC1G_COCO_MASK                      (0x80U)
-#define ADC_ASC1G_COCO_SHIFT                     (7U)
-#define ADC_ASC1G_COCO_WIDTH                     (1U)
-#define ADC_ASC1G_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1G_COCO_SHIFT)) & ADC_ASC1G_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1H - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1H_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1H_ADCH_SHIFT                     (0U)
-#define ADC_ASC1H_ADCH_WIDTH                     (6U)
-#define ADC_ASC1H_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1H_ADCH_SHIFT)) & ADC_ASC1H_ADCH_MASK)
-
-#define ADC_ASC1H_AIEN_MASK                      (0x40U)
-#define ADC_ASC1H_AIEN_SHIFT                     (6U)
-#define ADC_ASC1H_AIEN_WIDTH                     (1U)
-#define ADC_ASC1H_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1H_AIEN_SHIFT)) & ADC_ASC1H_AIEN_MASK)
-
-#define ADC_ASC1H_COCO_MASK                      (0x80U)
-#define ADC_ASC1H_COCO_SHIFT                     (7U)
-#define ADC_ASC1H_COCO_WIDTH                     (1U)
-#define ADC_ASC1H_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1H_COCO_SHIFT)) & ADC_ASC1H_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1I - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1I_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1I_ADCH_SHIFT                     (0U)
-#define ADC_ASC1I_ADCH_WIDTH                     (6U)
-#define ADC_ASC1I_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1I_ADCH_SHIFT)) & ADC_ASC1I_ADCH_MASK)
-
-#define ADC_ASC1I_AIEN_MASK                      (0x40U)
-#define ADC_ASC1I_AIEN_SHIFT                     (6U)
-#define ADC_ASC1I_AIEN_WIDTH                     (1U)
-#define ADC_ASC1I_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1I_AIEN_SHIFT)) & ADC_ASC1I_AIEN_MASK)
-
-#define ADC_ASC1I_COCO_MASK                      (0x80U)
-#define ADC_ASC1I_COCO_SHIFT                     (7U)
-#define ADC_ASC1I_COCO_WIDTH                     (1U)
-#define ADC_ASC1I_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1I_COCO_SHIFT)) & ADC_ASC1I_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1J - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1J_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1J_ADCH_SHIFT                     (0U)
-#define ADC_ASC1J_ADCH_WIDTH                     (6U)
-#define ADC_ASC1J_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1J_ADCH_SHIFT)) & ADC_ASC1J_ADCH_MASK)
-
-#define ADC_ASC1J_AIEN_MASK                      (0x40U)
-#define ADC_ASC1J_AIEN_SHIFT                     (6U)
-#define ADC_ASC1J_AIEN_WIDTH                     (1U)
-#define ADC_ASC1J_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1J_AIEN_SHIFT)) & ADC_ASC1J_AIEN_MASK)
-
-#define ADC_ASC1J_COCO_MASK                      (0x80U)
-#define ADC_ASC1J_COCO_SHIFT                     (7U)
-#define ADC_ASC1J_COCO_WIDTH                     (1U)
-#define ADC_ASC1J_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1J_COCO_SHIFT)) & ADC_ASC1J_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1K - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1K_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1K_ADCH_SHIFT                     (0U)
-#define ADC_ASC1K_ADCH_WIDTH                     (6U)
-#define ADC_ASC1K_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1K_ADCH_SHIFT)) & ADC_ASC1K_ADCH_MASK)
-
-#define ADC_ASC1K_AIEN_MASK                      (0x40U)
-#define ADC_ASC1K_AIEN_SHIFT                     (6U)
-#define ADC_ASC1K_AIEN_WIDTH                     (1U)
-#define ADC_ASC1K_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1K_AIEN_SHIFT)) & ADC_ASC1K_AIEN_MASK)
-
-#define ADC_ASC1K_COCO_MASK                      (0x80U)
-#define ADC_ASC1K_COCO_SHIFT                     (7U)
-#define ADC_ASC1K_COCO_WIDTH                     (1U)
-#define ADC_ASC1K_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1K_COCO_SHIFT)) & ADC_ASC1K_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1L - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1L_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1L_ADCH_SHIFT                     (0U)
-#define ADC_ASC1L_ADCH_WIDTH                     (6U)
-#define ADC_ASC1L_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1L_ADCH_SHIFT)) & ADC_ASC1L_ADCH_MASK)
-
-#define ADC_ASC1L_AIEN_MASK                      (0x40U)
-#define ADC_ASC1L_AIEN_SHIFT                     (6U)
-#define ADC_ASC1L_AIEN_WIDTH                     (1U)
-#define ADC_ASC1L_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1L_AIEN_SHIFT)) & ADC_ASC1L_AIEN_MASK)
-
-#define ADC_ASC1L_COCO_MASK                      (0x80U)
-#define ADC_ASC1L_COCO_SHIFT                     (7U)
-#define ADC_ASC1L_COCO_WIDTH                     (1U)
-#define ADC_ASC1L_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1L_COCO_SHIFT)) & ADC_ASC1L_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1M - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1M_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1M_ADCH_SHIFT                     (0U)
-#define ADC_ASC1M_ADCH_WIDTH                     (6U)
-#define ADC_ASC1M_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1M_ADCH_SHIFT)) & ADC_ASC1M_ADCH_MASK)
-
-#define ADC_ASC1M_AIEN_MASK                      (0x40U)
-#define ADC_ASC1M_AIEN_SHIFT                     (6U)
-#define ADC_ASC1M_AIEN_WIDTH                     (1U)
-#define ADC_ASC1M_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1M_AIEN_SHIFT)) & ADC_ASC1M_AIEN_MASK)
-
-#define ADC_ASC1M_COCO_MASK                      (0x80U)
-#define ADC_ASC1M_COCO_SHIFT                     (7U)
-#define ADC_ASC1M_COCO_WIDTH                     (1U)
-#define ADC_ASC1M_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1M_COCO_SHIFT)) & ADC_ASC1M_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1N - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1N_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1N_ADCH_SHIFT                     (0U)
-#define ADC_ASC1N_ADCH_WIDTH                     (6U)
-#define ADC_ASC1N_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1N_ADCH_SHIFT)) & ADC_ASC1N_ADCH_MASK)
-
-#define ADC_ASC1N_AIEN_MASK                      (0x40U)
-#define ADC_ASC1N_AIEN_SHIFT                     (6U)
-#define ADC_ASC1N_AIEN_WIDTH                     (1U)
-#define ADC_ASC1N_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1N_AIEN_SHIFT)) & ADC_ASC1N_AIEN_MASK)
-
-#define ADC_ASC1N_COCO_MASK                      (0x80U)
-#define ADC_ASC1N_COCO_SHIFT                     (7U)
-#define ADC_ASC1N_COCO_WIDTH                     (1U)
-#define ADC_ASC1N_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1N_COCO_SHIFT)) & ADC_ASC1N_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1O - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1O_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1O_ADCH_SHIFT                     (0U)
-#define ADC_ASC1O_ADCH_WIDTH                     (6U)
-#define ADC_ASC1O_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1O_ADCH_SHIFT)) & ADC_ASC1O_ADCH_MASK)
-
-#define ADC_ASC1O_AIEN_MASK                      (0x40U)
-#define ADC_ASC1O_AIEN_SHIFT                     (6U)
-#define ADC_ASC1O_AIEN_WIDTH                     (1U)
-#define ADC_ASC1O_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1O_AIEN_SHIFT)) & ADC_ASC1O_AIEN_MASK)
-
-#define ADC_ASC1O_COCO_MASK                      (0x80U)
-#define ADC_ASC1O_COCO_SHIFT                     (7U)
-#define ADC_ASC1O_COCO_WIDTH                     (1U)
-#define ADC_ASC1O_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1O_COCO_SHIFT)) & ADC_ASC1O_COCO_MASK)
-/*! @} */
-
-/*! @name ASC1P - ADC Status and Control Register 1 */
-/*! @{ */
-
-#define ADC_ASC1P_ADCH_MASK                      (0x3FU)
-#define ADC_ASC1P_ADCH_SHIFT                     (0U)
-#define ADC_ASC1P_ADCH_WIDTH                     (6U)
-#define ADC_ASC1P_ADCH(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1P_ADCH_SHIFT)) & ADC_ASC1P_ADCH_MASK)
-
-#define ADC_ASC1P_AIEN_MASK                      (0x40U)
-#define ADC_ASC1P_AIEN_SHIFT                     (6U)
-#define ADC_ASC1P_AIEN_WIDTH                     (1U)
-#define ADC_ASC1P_AIEN(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1P_AIEN_SHIFT)) & ADC_ASC1P_AIEN_MASK)
-
-#define ADC_ASC1P_COCO_MASK                      (0x80U)
-#define ADC_ASC1P_COCO_SHIFT                     (7U)
-#define ADC_ASC1P_COCO_WIDTH                     (1U)
-#define ADC_ASC1P_COCO(x)                        (((uint32_t)(((uint32_t)(x)) << ADC_ASC1P_COCO_SHIFT)) & ADC_ASC1P_COCO_MASK)
-/*! @} */
-
 /*! @name SC1 - ADC Status and Control Register 1 */
 /*! @{ */
 
@@ -1275,150 +950,6 @@ typedef struct {
 #define ADC_SC1_COCO_SHIFT                       (7U)
 #define ADC_SC1_COCO_WIDTH                       (1U)
 #define ADC_SC1_COCO(x)                          (((uint32_t)(((uint32_t)(x)) << ADC_SC1_COCO_SHIFT)) & ADC_SC1_COCO_MASK)
-/*! @} */
-
-/*! @name ARA - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARA_D_MASK                           (0xFFFU)
-#define ADC_ARA_D_SHIFT                          (0U)
-#define ADC_ARA_D_WIDTH                          (12U)
-#define ADC_ARA_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARA_D_SHIFT)) & ADC_ARA_D_MASK)
-/*! @} */
-
-/*! @name ARB - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARB_D_MASK                           (0xFFFU)
-#define ADC_ARB_D_SHIFT                          (0U)
-#define ADC_ARB_D_WIDTH                          (12U)
-#define ADC_ARB_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARB_D_SHIFT)) & ADC_ARB_D_MASK)
-/*! @} */
-
-/*! @name ARC - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARC_D_MASK                           (0xFFFU)
-#define ADC_ARC_D_SHIFT                          (0U)
-#define ADC_ARC_D_WIDTH                          (12U)
-#define ADC_ARC_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARC_D_SHIFT)) & ADC_ARC_D_MASK)
-/*! @} */
-
-/*! @name ARD - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARD_D_MASK                           (0xFFFU)
-#define ADC_ARD_D_SHIFT                          (0U)
-#define ADC_ARD_D_WIDTH                          (12U)
-#define ADC_ARD_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARD_D_SHIFT)) & ADC_ARD_D_MASK)
-/*! @} */
-
-/*! @name ARE - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARE_D_MASK                           (0xFFFU)
-#define ADC_ARE_D_SHIFT                          (0U)
-#define ADC_ARE_D_WIDTH                          (12U)
-#define ADC_ARE_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARE_D_SHIFT)) & ADC_ARE_D_MASK)
-/*! @} */
-
-/*! @name ARF - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARF_D_MASK                           (0xFFFU)
-#define ADC_ARF_D_SHIFT                          (0U)
-#define ADC_ARF_D_WIDTH                          (12U)
-#define ADC_ARF_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARF_D_SHIFT)) & ADC_ARF_D_MASK)
-/*! @} */
-
-/*! @name ARG - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARG_D_MASK                           (0xFFFU)
-#define ADC_ARG_D_SHIFT                          (0U)
-#define ADC_ARG_D_WIDTH                          (12U)
-#define ADC_ARG_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARG_D_SHIFT)) & ADC_ARG_D_MASK)
-/*! @} */
-
-/*! @name ARH - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARH_D_MASK                           (0xFFFU)
-#define ADC_ARH_D_SHIFT                          (0U)
-#define ADC_ARH_D_WIDTH                          (12U)
-#define ADC_ARH_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARH_D_SHIFT)) & ADC_ARH_D_MASK)
-/*! @} */
-
-/*! @name ARI - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARI_D_MASK                           (0xFFFU)
-#define ADC_ARI_D_SHIFT                          (0U)
-#define ADC_ARI_D_WIDTH                          (12U)
-#define ADC_ARI_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARI_D_SHIFT)) & ADC_ARI_D_MASK)
-/*! @} */
-
-/*! @name ARJ - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARJ_D_MASK                           (0xFFFU)
-#define ADC_ARJ_D_SHIFT                          (0U)
-#define ADC_ARJ_D_WIDTH                          (12U)
-#define ADC_ARJ_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARJ_D_SHIFT)) & ADC_ARJ_D_MASK)
-/*! @} */
-
-/*! @name ARK - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARK_D_MASK                           (0xFFFU)
-#define ADC_ARK_D_SHIFT                          (0U)
-#define ADC_ARK_D_WIDTH                          (12U)
-#define ADC_ARK_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARK_D_SHIFT)) & ADC_ARK_D_MASK)
-/*! @} */
-
-/*! @name ARL - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARL_D_MASK                           (0xFFFU)
-#define ADC_ARL_D_SHIFT                          (0U)
-#define ADC_ARL_D_WIDTH                          (12U)
-#define ADC_ARL_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARL_D_SHIFT)) & ADC_ARL_D_MASK)
-/*! @} */
-
-/*! @name ARM - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARM_D_MASK                           (0xFFFU)
-#define ADC_ARM_D_SHIFT                          (0U)
-#define ADC_ARM_D_WIDTH                          (12U)
-#define ADC_ARM_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARM_D_SHIFT)) & ADC_ARM_D_MASK)
-/*! @} */
-
-/*! @name ARN - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARN_D_MASK                           (0xFFFU)
-#define ADC_ARN_D_SHIFT                          (0U)
-#define ADC_ARN_D_WIDTH                          (12U)
-#define ADC_ARN_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARN_D_SHIFT)) & ADC_ARN_D_MASK)
-/*! @} */
-
-/*! @name ARO - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARO_D_MASK                           (0xFFFU)
-#define ADC_ARO_D_SHIFT                          (0U)
-#define ADC_ARO_D_WIDTH                          (12U)
-#define ADC_ARO_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARO_D_SHIFT)) & ADC_ARO_D_MASK)
-/*! @} */
-
-/*! @name ARP - ADC Data Result Registers */
-/*! @{ */
-
-#define ADC_ARP_D_MASK                           (0xFFFU)
-#define ADC_ARP_D_SHIFT                          (0U)
-#define ADC_ARP_D_WIDTH                          (12U)
-#define ADC_ARP_D(x)                             (((uint32_t)(((uint32_t)(x)) << ADC_ARP_D_SHIFT)) & ADC_ARP_D_MASK)
 /*! @} */
 
 /*! @name R - ADC Data Result Registers */

--- a/s32/mcux/devices/S32K146/S32K146_device.h
+++ b/s32/mcux/devices/S32K146/S32K146_device.h
@@ -786,4 +786,33 @@ typedef struct {
  * @}
  */ /* end of group RTC_Peripheral_Access_Layer */
 
+/* ----------------------------------------------------------------------------
+   -- ADC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup ADC_Peripheral_Access_Layer ADC Peripheral Access Layer
+ * @{
+ */
+
+/* ADC - Peripheral instance base addresses */
+/** Peripheral ADC0 base address */
+#define ADC0_BASE                                IP_ADC0_BASE
+/** Peripheral ADC0 base pointer */
+#define ADC0                                     IP_ADC0
+/** Peripheral ADC1 base address */
+#define ADC1_BASE                                IP_ADC1_BASE
+/** Peripheral ADC1 base pointer */
+#define ADC1                                     IP_ADC1
+/** Array initializer of ADC peripheral base addresses */
+#define ADC_BASE_ADDRS                           IP_ADC_BASE_ADDRS
+/** Array initializer of ADC peripheral base pointers */
+#define ADC_BASE_PTRS                            IP_ADC_BASE_PTRS
+/** Interrupt vectors for the ADC peripheral type */
+#define ADC_IRQS                                 { ADC0_IRQn, ADC1_IRQn }
+
+/*!
+ * @}
+ */ /* end of group ADC_Peripheral_Access_Layer */
+
 #endif /* _S32K146_DEVICE_H_ */

--- a/s32/mcux/devices/S32K146/S32K146_features.h
+++ b/s32/mcux/devices/S32K146/S32K146_features.h
@@ -9,6 +9,8 @@
 
 /* SOC module features */
 
+/* @brief ADC12 availability on the SoC. */
+#define FSL_FEATURE_SOC_ADC12_COUNT (2)
 /* @brief SYSMPU availability on the SoC. */
 #define FSL_FEATURE_SOC_SYSMPU_COUNT (1)
 /* @brief PORT availability on the SoC. */
@@ -300,5 +302,12 @@
 #define FSL_FEATURE_RTC_HAS_PCR (0)
 /* @brief Has Oscillator Enable(bitfield CR[OSCE]). */
 #define FSL_FEATURE_RTC_HAS_NO_CR_OSCE (1)
+
+/* ADC12 module features */
+
+/* @brief Has DMA support (bit SC2[DMAEN]. */
+#define FSL_FEATURE_ADC12_HAS_DMA_SUPPORT (1)
+/* @brief Conversion control count (related to number of registers SC1n and Rn). */
+#define FSL_FEATURE_ADC12_CONVERSION_CONTROL_COUNT (24)
 
 #endif /* _S32K146_FEATURES_H_ */


### PR DESCRIPTION
Enable fsl_adc12 driver on S32K146 devices.

We are getting everything ready to support ADC on the S32K146/8.
Adaption in the register header file is there to make it compatible with the existing ADC driver (kinetis-adc12).

The Zephyr PR is: https://github.com/zephyrproject-rtos/zephyr/pull/75723