### PR TITLE
Feature/enable udc sof

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -87,3 +87,4 @@ Patch List:
   11. mcux-sdk-middleware-connectivity-framework: rw61x: Fix assertion OSA Mutex Alloc fail
   12. mcux-sdk-middleware-connectivity-framework: rw61x: Remove static from hci_cal_data buffers to be used inside Zephyr
   13. devices: MCXN947: added missing inputmux_connections.cmake file
+  14. add kUSB_DeviceNotifySOF to usb_device_mcux_drv_port.h SDK USB stack already supports it in SDK 2.16.0

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_mcux_drv_port.h
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_mcux_drv_port.h
@@ -32,6 +32,7 @@ typedef enum _usb_device_notification
     kUSB_DeviceNotifyError,            /*!< Errors happened in bus */
     kUSB_DeviceNotifyDetach,           /*!< Device disconnected from a host */
     kUSB_DeviceNotifyAttach,           /*!< Device connected to a host */
+    kUSB_DeviceNotifySOF,              /*!< Start of Frame received */
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U))
     kUSB_DeviceNotifyDcdDetectFinished, /*!< Device charger detection finished */
 #endif


### PR DESCRIPTION
@dleach02 This pr need waiting your SDK 2.16.0 pr (https://github.com/zephyrproject-rtos/zephyr/pull/76604) merged because it depend on the usb controller drivers' updating of SDK 2.16.0.