### PR TITLE
s32: s32k344: add missing DMAMUX count define

### DIFF
--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -21,6 +21,8 @@
 #define FSL_FEATURE_SOC_LPSPI_COUNT (6)
 /* @brief EDMA availability on the SoC. */
 #define FSL_FEATURE_SOC_EDMA_COUNT (1)
+/* @brief DMAMUX availability on the SoC. */
+#define FSL_FEATURE_SOC_DMAMUX_COUNT (2)
 /* @brief FLEXIO availability on the SoC. */
 #define FSL_FEATURE_SOC_FLEXIO_COUNT (1)
 


### PR DESCRIPTION
Add missing define to be able to build Zephyr EDMAv3 driver.