### PR TITLE
mcux: hal_nxp: include mflash component for conn_fwloader

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -392,6 +392,13 @@ endif()
 
 if(${MCUX_DEVICE} MATCHES "RW61")
   set(CONFIG_USE_component_osa_zephyr true)
+  if(CONFIG_NXP_FW_LOADER)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk/components/flash/mflash)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk/components/flash/mflash/rdrw612bga)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk/drivers/cache/cache64)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk/drivers/flexspi)
+    include(component_mflash_rdrw610)
+  endif()
 endif()
 
 include_ifdef(CONFIG_USE_component_osa_zephyr set_component_osa)


### PR DESCRIPTION
Add cmake module path of mflash and flexspi, cache64 dependent for component conn_fwloader.