### PR TITLE
Add support for LPI2C on S32Z27x

### DIFF
--- a/s32/mcux/devices/S32Z270/S32Z270_features.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_features.h
@@ -91,4 +91,13 @@
 /* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
 #define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (1)
 
+/* I2C module features */
+
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (2)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (8)
+
 #endif /* _S32Z270_FEATURES_H_ */

--- a/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
@@ -226,4 +226,25 @@
 
 #define CAN_ORed_Message_buffer_IRQS                CAN_ORed_Message_buffer_0_31_IRQS
 
+/*!
+ * @addtogroup LPI2C_Peripheral_Access_Layer LPI2C Peripheral Access Layer
+ * @{
+ */
+
+/* LPI2C - Peripheral instance base addresses */
+/** Peripheral LPI2C1 base address */
+#define LPI2C1_BASE                              IP_LPI2C_1_BASE
+/** Peripheral LPI2C1 base pointer */
+#define LPI2C1                                   IP_LPI2C_1
+/** Peripheral LPI2C2 base address */
+#define LPI2C2_BASE                              IP_LPI2C_2_BASE
+/** Peripheral LPI2C2 base pointer */
+#define LPI2C2                                   IP_LPI2C_2
+/** Array initializer of LPI2C peripheral base addresses */
+#define LPI2C_BASE_ADDRS                         IP_LPI2C_BASE_ADDRS
+/** Array initializer of LPI2C peripheral base pointers */
+#define LPI2C_BASE_PTRS                          IP_LPI2C_BASE_PTRS
+/** Interrupt vectors for the LPI2C peripheral type */
+#define LPI2C_IRQS                               { RTU_LPI2C1_IRQn, RTU_LPI2C2_IRQn }
+
 #endif /* _S32Z270_GLUE_MCUX_H_ */


### PR DESCRIPTION
Add LPI2C instance base addresses and module features to support using LPI2C MCUX driver.