### PR TITLE
Add support dspi for s32z270dc2

### DIFF
--- a/dts/nxp/s32/S32Z27-BGA400-pinctrl.h
+++ b/dts/nxp/s32/S32Z27-BGA400-pinctrl.h
@@ -464,6 +464,9 @@
 #define PA11_DSPI_10_PCS0_O             NXP_S32_PINMUX(0, 0, 11, 1, 0, 0)
 #define PA12_DSPI_10_PCS1               NXP_S32_PINMUX(0, 0, 12, 1, 0, 0)
 #define PB6_DSPI_10_PCS2                NXP_S32_PINMUX(0, 0, 22, 6, 0, 0)
+#define LVDS_DSPI_10_SIN                NXP_S32_PINMUX(0, 0, 500, 0, 0, 0)
+#define LVDS_DSPI_10_SOUT               NXP_S32_PINMUX(0, 0, 501, 0, 0, 0)
+#define LVDS_DSPI_10_SCK                NXP_S32_PINMUX(0, 0, 502, 0, 0, 0)
 
 /* SPI_1 */
 #define PA11_DSPI_1_PCS4                NXP_S32_PINMUX(0, 0, 11, 5, 0, 0)

--- a/dts/nxp/s32/S32Z27-BGA594-pinctrl.h
+++ b/dts/nxp/s32/S32Z27-BGA594-pinctrl.h
@@ -612,6 +612,9 @@
 #define PA11_DSPI_10_PCS0_O             NXP_S32_PINMUX(0, 0, 11, 1, 0, 0)
 #define PA12_DSPI_10_PCS1               NXP_S32_PINMUX(0, 0, 12, 1, 0, 0)
 #define PB6_DSPI_10_PCS2                NXP_S32_PINMUX(0, 0, 22, 6, 0, 0)
+#define LVDS_DSPI_10_SIN                NXP_S32_PINMUX(0, 0, 500, 0, 0, 0)
+#define LVDS_DSPI_10_SOUT               NXP_S32_PINMUX(0, 0, 501, 0, 0, 0)
+#define LVDS_DSPI_10_SCK                NXP_S32_PINMUX(0, 0, 502, 0, 0, 0)
 
 /* SPI_1 */
 #define PA11_DSPI_1_PCS4                NXP_S32_PINMUX(0, 0, 11, 5, 0, 0)

--- a/mcux/README
+++ b/mcux/README
@@ -118,3 +118,5 @@ Patch List:
   - Add missing CMAKE file to ccm32k driver driver_ccm32k.cmake.
   - Add missing CMAKE file to flash_k4 driver driver_flash_k4.cmake.
   - Add missing CMAKE file to spc driver driver_spc.cmake
+  - mcux-sdk/drivers/dspi/fsl_dspi.c, mcux-sdk/drivers/dspi/fsl_dspi.h, mcux-sdk/drivers/dspi/fsl_dspi_edma.c,
+  mcux-sdk/drivers/dspi/fsl_dspi_edma.h: add the guards for unsupport features on S32Z27x devices

--- a/mcux/mcux-sdk/drivers/dspi/fsl_dspi.c
+++ b/mcux/mcux-sdk/drivers/dspi/fsl_dspi.c
@@ -20,8 +20,10 @@
 /*! @brief Typedef for master interrupt handler. */
 typedef void (*dspi_master_isr_t)(SPI_Type *base, dspi_master_handle_t *handle);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief Typedef for slave interrupt handler. */
 typedef void (*dspi_slave_isr_t)(SPI_Type *base, dspi_slave_handle_t *handle);
+#endif
 
 /*******************************************************************************
  * Prototypes
@@ -53,18 +55,22 @@ static void DSPI_MasterTransferFillUpTxFifo(SPI_Type *base, dspi_master_handle_t
  */
 static void DSPI_MasterTransferComplete(SPI_Type *base, dspi_master_handle_t *handle);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Slave fill up the TX FIFO with data.
  * This is not a public API.
  */
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Slave finish up a transfer.
  * It would call back if there is callback function and set the state to idle.
  * This is not a public API.
  */
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle);
+#endif
 
 /*!
  * @brief DSPI common interrupt handler.
@@ -111,8 +117,10 @@ static void *g_dspiHandle[ARRAY_SIZE(s_dspiBases)];
 /*! @brief Pointer to master IRQ handler for each instance. */
 static dspi_master_isr_t s_dspiMasterIsr;
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief Pointer to slave IRQ handler for each instance. */
 static dspi_slave_isr_t s_dspiSlaveIsr;
+#endif
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
 volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
@@ -285,6 +293,7 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig)
     masterConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI slave configuration.
  *
@@ -342,7 +351,9 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig)
 
     DSPI_StartTransfer(base);
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Sets the dspi_slave_config_t structure to a default value.
  *
@@ -373,6 +384,7 @@ void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig)
     slaveConfig->enableModifiedTimingFormat = false;
     slaveConfig->samplePoint                = kDSPI_SckToSin0Clock;
 }
+#endif
 
 /*!
  * brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
@@ -787,6 +799,7 @@ void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data)
     }
 }
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
  *
@@ -815,6 +828,7 @@ void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data)
     {
     }
 }
+#endif
 
 /*!
  * brief Enables the DSPI interrupts.
@@ -1707,6 +1721,7 @@ void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle)
 }
 
 /*Transactional APIs -- Slave*/
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Initializes the DSPI slave handle.
  *
@@ -1733,7 +1748,9 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
     handle->callback = callback;
     handle->userData = userData;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI slave transfers data using an interrupt.
  *
@@ -1800,11 +1817,13 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
         /* RX FIFO overflow request enable */
         DSPI_EnableInterrupts(base, (uint32_t)kDSPI_RxFifoOverflowInterruptEnable);
     }
+#if !(defined(FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT)
     if (NULL != handle->txData)
     {
         /* TX FIFO underflow request enable */
         DSPI_EnableInterrupts(base, (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable);
     }
+#endif
 
     DSPI_StartTransfer(base);
 
@@ -1813,7 +1832,9 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
 
     return kStatus_Success;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Gets the slave transfer count.
  *
@@ -1843,7 +1864,9 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
     *count = handle->totalByteCount - handle->remainingReceiveByteCount;
     return kStatus_Success;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *handle)
 {
     assert(NULL != handle);
@@ -1931,15 +1954,21 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
         DSPI_ClearStatusFlags(base, (uint32_t)kDSPI_TxFifoFillRequestFlag);
     }
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *handle)
 {
     assert(NULL != handle);
 
     /* Disable interrupt requests */
     DSPI_DisableInterrupts(
-        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
-               (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
+        base, (
+#if !(defined(FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT)
+        (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable |
+#endif
+        (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+        (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     /* The transfer is complete. */
     handle->txData                    = NULL;
@@ -1964,7 +1993,9 @@ static void DSPI_SlaveTransferComplete(SPI_Type *base, dspi_slave_handle_t *hand
         handle->callback(base, handle, status, handle->userData);
     }
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI slave aborts a transfer using an interrupt.
  *
@@ -1981,14 +2012,20 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle)
 
     /* Disable interrupt requests */
     DSPI_DisableInterrupts(
-        base, ((uint32_t)kDSPI_TxFifoUnderflowInterruptEnable | (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
+        base, (
+#if !(defined(FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT) && FSL_FEATURE_FLEXCAN_HAS_NO_RSER_TFUF_SUPPORT)
+        (uint32_t)kDSPI_TxFifoUnderflowInterruptEnable |
+#endif
+        (uint32_t)kDSPI_TxFifoFillRequestInterruptEnable |
                (uint32_t)kDSPI_RxFifoOverflowInterruptEnable | (uint32_t)kDSPI_RxFifoDrainRequestInterruptEnable));
 
     handle->state                     = (uint8_t)kDSPI_Idle;
     handle->remainingSendByteCount    = 0;
     handle->remainingReceiveByteCount = 0;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI Master IRQ handler function.
  *
@@ -2145,6 +2182,7 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
         return;
     }
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT)
     /* Catch tx fifo underflow conditions, service only if tx under flow interrupt enabled */
     if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_TxFifoUnderflowFlag))
     {
@@ -2159,6 +2197,7 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
             handle->errorCount++;
         }
     }
+#endif
 
     /* Catch rx fifo overflow conditions, service only if rx over flow interrupt enabled */
     if (0U != (DSPI_GetStatusFlags(base) & (uint32_t)kDSPI_RxFifoOverflowFlag))
@@ -2175,6 +2214,7 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
         }
     }
 }
+#endif
 
 static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
 {
@@ -2182,10 +2222,12 @@ static void DSPI_CommonIRQHandler(SPI_Type *base, void *param)
     {
         s_dspiMasterIsr(base, (dspi_master_handle_t *)param);
     }
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
     else
     {
         s_dspiSlaveIsr(base, (dspi_slave_handle_t *)param);
     }
+#endif
     SDK_ISR_EXIT_BARRIER;
 }
 

--- a/mcux/mcux-sdk/drivers/dspi/fsl_dspi.h
+++ b/mcux/mcux-sdk/drivers/dspi/fsl_dspi.h
@@ -47,13 +47,18 @@ enum _dspi_flags
 {
     kDSPI_TxCompleteFlag         = (int)SPI_SR_TCF_MASK, /*!< Transfer Complete Flag. */
     kDSPI_EndOfQueueFlag         = SPI_SR_EOQF_MASK,     /*!< End of Queue Flag.*/
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT)
     kDSPI_TxFifoUnderflowFlag    = SPI_SR_TFUF_MASK,     /*!< Transmit FIFO Underflow Flag.*/
+#endif
     kDSPI_TxFifoFillRequestFlag  = SPI_SR_TFFF_MASK,     /*!< Transmit FIFO Fill Flag.*/
     kDSPI_RxFifoOverflowFlag     = SPI_SR_RFOF_MASK,     /*!< Receive FIFO Overflow Flag.*/
     kDSPI_RxFifoDrainRequestFlag = SPI_SR_RFDF_MASK,     /*!< Receive FIFO Drain Flag.*/
     kDSPI_TxAndRxStatusFlag      = SPI_SR_TXRXS_MASK,    /*!< The module is in Stopped/Running state.*/
-    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK | SPI_SR_TFUF_MASK | SPI_SR_TFFF_MASK |
-                                SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
+    kDSPI_AllStatusFlag          = (int)(SPI_SR_TCF_MASK | SPI_SR_EOQF_MASK |
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT)
+                                SPI_SR_TFUF_MASK |
+#endif
+                                SPI_SR_TFFF_MASK | SPI_SR_RFOF_MASK | SPI_SR_RFDF_MASK | SPI_SR_TXRXS_MASK) /*!< All statuses above.*/
 };
 
 /*! @brief DSPI interrupt source.*/
@@ -61,11 +66,16 @@ enum _dspi_interrupt_enable
 {
     kDSPI_TxCompleteInterruptEnable         = (int)SPI_RSER_TCF_RE_MASK, /*!< TCF  interrupt enable.*/
     kDSPI_EndOfQueueInterruptEnable         = SPI_RSER_EOQF_RE_MASK,     /*!< EOQF interrupt enable.*/
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_RSER_TFUF_RE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_RSER_TFUF_RE_SUPPORT)
     kDSPI_TxFifoUnderflowInterruptEnable    = SPI_RSER_TFUF_RE_MASK,     /*!< TFUF interrupt enable.*/
+#endif
     kDSPI_TxFifoFillRequestInterruptEnable  = SPI_RSER_TFFF_RE_MASK,     /*!< TFFF interrupt enable, DMA disable.*/
     kDSPI_RxFifoOverflowInterruptEnable     = SPI_RSER_RFOF_RE_MASK,     /*!< RFOF interrupt enable.*/
     kDSPI_RxFifoDrainRequestInterruptEnable = SPI_RSER_RFDF_RE_MASK,     /*!< RFDF interrupt enable, DMA disable.*/
-    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK | SPI_RSER_TFUF_RE_MASK |
+    kDSPI_AllInterruptEnable = (int)(SPI_RSER_TCF_RE_MASK | SPI_RSER_EOQF_RE_MASK |
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_RSER_TFUF_RE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_RSER_TFUF_RE_SUPPORT)
+                                     SPI_RSER_TFUF_RE_MASK |
+#endif
                                      SPI_RSER_TFFF_RE_MASK | SPI_RSER_RFOF_RE_MASK | SPI_RSER_RFDF_RE_MASK)
     /*!< All above interrupts enable.*/
 };
@@ -201,14 +211,18 @@ enum _dspi_transfer_config_flag_for_master
     /*!< Indicates whether the PCS signal is active after the last frame transfer.*/
 };
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 #define DSPI_SLAVE_CTAR_SHIFT (0U)    /*!< DSPI slave CTAR shift macro; used internally. */
 #define DSPI_SLAVE_CTAR_MASK  (0x07U) /*!< DSPI slave CTAR mask macro; used internally. */
+#endif
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief Use this enumeration for the DSPI slave transfer configFlags. */
 enum _dspi_transfer_config_flag_for_slave
 {
     kDSPI_SlaveCtar0 = 0U << DSPI_SLAVE_CTAR_SHIFT, /*!< DSPI slave transfer use CTAR0 setting.
                                                          DSPI slave can only use PCS0. */
 };
+#endif
 
 /*! @brief DSPI transfer state, which is used for DSPI transactional API state machine. */
 enum _dspi_transfer_state
@@ -269,6 +283,7 @@ typedef struct _dspi_master_config
                                                  Format. It's valid only when CPHA=0. */
 } dspi_master_config_t;
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief DSPI slave ctar configuration structure.*/
 typedef struct _dspi_slave_ctar_config
 {
@@ -277,7 +292,9 @@ typedef struct _dspi_slave_ctar_config
     dspi_clock_phase_t cpha;    /*!< Clock phase. */
                                 /*!< Slave only supports MSB and does not support LSB.*/
 } dspi_slave_ctar_config_t;
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief DSPI slave configuration structure.*/
 typedef struct _dspi_slave_config
 {
@@ -294,16 +311,19 @@ typedef struct _dspi_slave_config
     dspi_master_sample_point_t samplePoint; /*!< Controls when the module master samples SIN in the Modified Transfer
                                                Format. It's valid only when CPHA=0. */
 } dspi_slave_config_t;
+#endif
 
 /*!
  * @brief Forward declaration of the @ref _dspi_master_handle typedefs.
  */
 typedef struct _dspi_master_handle dspi_master_handle_t; /*!< The master handle. */
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Forward declaration of the @ref _dspi_slave_handle typedefs.
  */
 typedef struct _dspi_slave_handle dspi_slave_handle_t; /*!< The slave handle. */
+#endif
 
 /*!
  * @brief Completion callback function pointer type.
@@ -317,6 +337,8 @@ typedef void (*dspi_master_transfer_callback_t)(SPI_Type *base,
                                                 dspi_master_handle_t *handle,
                                                 status_t status,
                                                 void *userData);
+
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Completion callback function pointer type.
  *
@@ -329,6 +351,7 @@ typedef void (*dspi_slave_transfer_callback_t)(SPI_Type *base,
                                                dspi_slave_handle_t *handle,
                                                status_t status,
                                                void *userData);
+#endif
 
 /*! @brief DSPI master/slave transfer structure.*/
 typedef struct _dspi_transfer
@@ -380,6 +403,7 @@ struct _dspi_master_handle
     void *userData;                           /*!< Callback user data. */
 };
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief DSPI slave transfer handle structure used for the transactional API. */
 struct _dspi_slave_handle
 {
@@ -399,6 +423,7 @@ struct _dspi_slave_handle
     dspi_slave_transfer_callback_t callback; /*!< Completion callback. */
     void *userData;                          /*!< Callback user data. */
 };
+#endif
 
 /**********************************************************************************************************************
  * API
@@ -457,6 +482,7 @@ void DSPI_MasterInit(SPI_Type *base, const dspi_master_config_t *masterConfig, u
  */
 void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI slave configuration.
  *
@@ -478,7 +504,9 @@ void DSPI_MasterGetDefaultConfig(dspi_master_config_t *masterConfig);
  * @param slaveConfig Pointer to the structure @ref dspi_master_config_t.
  */
 void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Sets the @ref dspi_slave_config_t structure to a default value.
  *
@@ -493,6 +521,7 @@ void DSPI_SlaveInit(SPI_Type *base, const dspi_slave_config_t *slaveConfig);
  * @param slaveConfig Pointer to the @ref dspi_slave_config_t structure.
  */
 void DSPI_SlaveGetDefaultConfig(dspi_slave_config_t *slaveConfig);
+#endif
 
 /*!
  * @brief De-initializes the DSPI peripheral. Call this API to disable the DSPI clock.
@@ -657,10 +686,12 @@ static inline uint32_t DSPI_MasterGetTxRegisterAddress(SPI_Type *base)
  * @param base DSPI peripheral address.
  * @return The DSPI slave PUSHR data register address.
  */
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 static inline uint32_t DSPI_SlaveGetTxRegisterAddress(SPI_Type *base)
 {
     return (uint32_t) & (base->PUSHR_SLAVE);
 }
+#endif
 
 /*!
  * @brief Gets the DSPI POPR data register address for the DMA operation.
@@ -998,6 +1029,7 @@ static inline uint32_t DSPI_MasterGetFormattedCommand(dspi_command_data_config_t
  */
 void DSPI_MasterWriteCommandDataBlocking(SPI_Type *base, uint32_t data);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Writes data into the data buffer in slave mode.
  *
@@ -1010,7 +1042,9 @@ static inline void DSPI_SlaveWriteData(SPI_Type *base, uint32_t data)
 {
     base->PUSHR_SLAVE = data;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Writes data into the data buffer in slave mode, waits till data was transmitted, and returns.
  *
@@ -1021,6 +1055,7 @@ static inline void DSPI_SlaveWriteData(SPI_Type *base, uint32_t data)
  * @param data The data to send.
  */
 void DSPI_SlaveWriteDataBlocking(SPI_Type *base, uint32_t data);
+#endif
 
 /*!
  * @brief Reads data from the data buffer.
@@ -1152,6 +1187,7 @@ void DSPI_MasterTransferAbort(SPI_Type *base, dspi_master_handle_t *handle);
  */
 void DSPI_MasterTransferHandleIRQ(SPI_Type *base, dspi_master_handle_t *handle);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Initializes the DSPI slave handle.
  *
@@ -1167,7 +1203,9 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
                                     dspi_slave_handle_t *handle,
                                     dspi_slave_transfer_callback_t callback,
                                     void *userData);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI slave transfers data using an interrupt.
  *
@@ -1180,7 +1218,9 @@ void DSPI_SlaveTransferCreateHandle(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *handle, dspi_transfer_t *transfer);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Gets the slave transfer count.
  *
@@ -1192,7 +1232,9 @@ status_t DSPI_SlaveTransferNonBlocking(SPI_Type *base, dspi_slave_handle_t *hand
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle, size_t *count);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI slave aborts a transfer using an interrupt.
  *
@@ -1202,7 +1244,9 @@ status_t DSPI_SlaveTransferGetCount(SPI_Type *base, dspi_slave_handle_t *handle,
  * @param handle Pointer to the @ref _dspi_slave_handle structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI Master IRQ handler function.
  *
@@ -1212,6 +1256,7 @@ void DSPI_SlaveTransferAbort(SPI_Type *base, dspi_slave_handle_t *handle);
  * @param handle Pointer to the @ref _dspi_slave_handle structure which stores the transfer state.
  */
 void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
+#endif
 
 /*!
  * brief Dummy data for each instance.

--- a/mcux/mcux-sdk/drivers/dspi/fsl_dspi_edma.c
+++ b/mcux/mcux-sdk/drivers/dspi/fsl_dspi_edma.c
@@ -26,6 +26,7 @@ typedef struct _dspi_master_edma_private_handle
     dspi_master_edma_handle_t *handle; /*!< dspi_master_edma_handle_t handle */
 } dspi_master_edma_private_handle_t;
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Structure definition for dspi_slave_edma_private_handle_t. The structure is private.
  */
@@ -34,6 +35,7 @@ typedef struct _dspi_slave_edma_private_handle
     SPI_Type *base;                   /*!< DSPI peripheral base address. */
     dspi_slave_edma_handle_t *handle; /*!< dspi_master_edma_handle_t handle */
 } dspi_slave_edma_private_handle_t;
+#endif
 
 /***********************************************************************************************************************
  * Prototypes
@@ -47,6 +49,7 @@ static void EDMA_DspiMasterCallback(edma_handle_t *edmaHandle,
                                     bool transferDone,
                                     uint32_t tcds);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief EDMA_DspiSlaveCallback after the DSPI slave transfer completed by using EDMA.
  * This is not a public API.
@@ -55,6 +58,7 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
                                    uint32_t tcds);
+#endif
 
 /***********************************************************************************************************************
  * Variables
@@ -62,7 +66,9 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
 
 /*! @brief Pointers to dspi edma handles for each instance. */
 static dspi_master_edma_private_handle_t s_dspiMasterEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 static dspi_slave_edma_private_handle_t s_dspiSlaveEdmaPrivateHandle[FSL_FEATURE_SOC_DSPI_COUNT];
+#endif
 
 /***********************************************************************************************************************
  * Code
@@ -1101,6 +1107,7 @@ status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle
     return kStatus_Success;
 }
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Initializes the DSPI slave eDMA handle.
  *
@@ -1145,7 +1152,9 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
     handle->edmaRxRegToRxDataHandle = edmaRxRegToRxDataHandle;
     handle->edmaTxDataToTxRegHandle = edmaTxDataToTxRegHandle;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI slave transfer data using eDMA.
  *
@@ -1463,7 +1472,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
 
     return kStatus_Success;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                    void *g_dspiEdmaPrivateHandle,
                                    bool transferDone,
@@ -1486,7 +1497,9 @@ static void EDMA_DspiSlaveCallback(edma_handle_t *edmaHandle,
                                                 kStatus_Success, dspiEdmaPrivateHandle->handle->userData);
     }
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief DSPI slave aborts a transfer which is using eDMA.
  *
@@ -1508,7 +1521,9 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
 
     handle->state = (uint8_t)kDSPI_Idle;
 }
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * brief Gets the slave eDMA transfer count.
  *
@@ -1544,3 +1559,4 @@ status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t
 
     return kStatus_Success;
 }
+#endif

--- a/mcux/mcux-sdk/drivers/dspi/fsl_dspi_edma.h
+++ b/mcux/mcux-sdk/drivers/dspi/fsl_dspi_edma.h
@@ -38,10 +38,12 @@
  */
 typedef struct _dspi_master_edma_handle dspi_master_edma_handle_t;
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Forward declaration of the DSPI eDMA slave handle typedefs.
  */
 typedef struct _dspi_slave_edma_handle dspi_slave_edma_handle_t;
+#endif
 
 /*!
  * @brief Completion callback function pointer type.
@@ -55,6 +57,7 @@ typedef void (*dspi_master_edma_transfer_callback_t)(SPI_Type *base,
                                                      dspi_master_edma_handle_t *handle,
                                                      status_t status,
                                                      void *userData);
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Completion callback function pointer type.
  *
@@ -67,6 +70,7 @@ typedef void (*dspi_slave_edma_transfer_callback_t)(SPI_Type *base,
                                                     dspi_slave_edma_handle_t *handle,
                                                     status_t status,
                                                     void *userData);
+#endif
 
 /*! @brief DSPI master eDMA transfer handle structure used for the transactional API. */
 struct _dspi_master_edma_handle
@@ -102,6 +106,7 @@ struct _dspi_master_edma_handle
     edma_tcd_t dspiSoftwareTCD[2]; /*!<SoftwareTCD , internal used*/
 };
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*! @brief DSPI slave eDMA transfer handle structure used for the transactional API.*/
 struct _dspi_slave_edma_handle
 {
@@ -127,6 +132,7 @@ struct _dspi_slave_edma_handle
     edma_handle_t *edmaRxRegToRxDataHandle; /*!<edma_handle_t handle point used for RxReg to RxData buff*/
     edma_handle_t *edmaTxDataToTxRegHandle; /*!<edma_handle_t handle point used for TxData to TxReg*/
 };
+#endif
 
 /***********************************************************************************************************************
  * API
@@ -221,6 +227,7 @@ void DSPI_MasterTransferAbortEDMA(SPI_Type *base, dspi_master_edma_handle_t *han
  */
 status_t DSPI_MasterTransferGetCountEDMA(SPI_Type *base, dspi_master_edma_handle_t *handle, size_t *count);
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Initializes the DSPI slave eDMA handle.
  *
@@ -246,7 +253,9 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
                                         void *userData,
                                         edma_handle_t *edmaRxRegToRxDataHandle,
                                         edma_handle_t *edmaTxDataToTxRegHandle);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI slave transfer data using eDMA.
  *
@@ -265,7 +274,9 @@ void DSPI_SlaveTransferCreateHandleEDMA(SPI_Type *base,
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, dspi_transfer_t *transfer);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief DSPI slave aborts a transfer which is using eDMA.
  *
@@ -275,7 +286,9 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
  * @param handle A pointer to the @ref _dspi_slave_edma_handle structure which stores the transfer state.
  */
 void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle);
+#endif
 
+#if !(defined(FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT) && FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT)
 /*!
  * @brief Gets the slave eDMA transfer count.
  *
@@ -287,6 +300,7 @@ void DSPI_SlaveTransferAbortEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handl
  * @return status of status_t.
  */
 status_t DSPI_SlaveTransferGetCountEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle, size_t *count);
+#endif
 
 /*!@}*/
 

--- a/s32/README
+++ b/s32/README
@@ -69,3 +69,6 @@ Patch List for S32Z/E:
      a conversion is started inside the previous end of conversion completed callback.
    - Rename the DMAMUX_Type member CHCONF to CHCFG so that the MCUX DMA driver can be reused
      for S32Z.
+   - Remove #include "S32Z2_SPI.h" from s32/drivers/s32ze/BaseNXP/header/S32Z2.h to support
+     DSPI using the MCUX driver. This removal won't affect SPI shim driver because this header
+     file is already included inside the RTD SPI driver

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2.h
@@ -211,7 +211,6 @@
 #include "S32Z2_SMU_SRG_S.h"
 #include "S32Z2_SMU_XRDC.h"
 #include "S32Z2_SPFU.h"
-#include "S32Z2_SPI.h"
 #include "S32Z2_SRAMCTL.h"
 #include "S32Z2_SRX.h"
 #include "S32Z2_SW_ETH_MAC_PORT0.h"

--- a/s32/mcux/devices/S32Z270/S32Z270_device.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_device.h
@@ -2071,7 +2071,6 @@ typedef struct {
 #define DMA_CH_GRPRI_GRPRI_SHIFT                EDMA3_MP_CH_GRPRI_GRPRI_SHIFT
 #define DMA_CH_GRPRI_GRPRI_WIDTH                EDMA3_MP_CH_GRPRI_GRPRI_WIDTH
 #define DMA_CH_GRPRI_GRPRI(x)                   EDMA3_MP_CH_GRPRI_GRPRI(x)
-/*! @} */
 
 /*!
  * @}
@@ -2476,5 +2475,823 @@ typedef struct {
 #define DMAMUX_CHCFG_ENBL_SHIFT                    DMAMUX_CHCONF_ENBL_SHIFT
 #define DMAMUX_CHCFG_ENBL_WIDTH                    DMAMUX_CHCONF_ENBL_WIDTH
 #define DMAMUX_CHCFG_ENBL(x)                       DMAMUX_CHCONF_ENBL(x)
+
+/* ----------------------------------------------------------------------------
+   -- DSPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DSPI_Peripheral_Access_Layer DSPI Peripheral Access Layer
+ * @{
+ */
+
+/** DSPI - Register Layout Typedef */
+
+typedef struct {
+        __IO uint32_t MCR;                               /**< Module Configuration Register, offset: 0x0 */
+        uint8_t RESERVED_0[4];
+        __IO uint32_t TCR;                               /**< Transfer Count Register, offset: 0x8 */
+        union {                                          /* offset: 0xC */
+            __IO uint32_t CTAR[6];                       /**< Clock and Transfer Attributes Register (In Master Mode), array offset: 0xC, array step: 0x4 */
+        };
+        uint8_t RESERVED_1[8];
+        __IO uint32_t SR;                                /**< Status Register, offset: 0x2C */
+        __IO uint32_t RSER;                              /**< DMA/Interrupt Request Select and Enable Register, offset: 0x30 */
+        union {                                          /* offset: 0x34 */
+            __IO uint32_t PUSHR;                             /**< PUSH TX FIFO Register In Master Mode, offset: 0x34 */
+        };
+        __I  uint32_t POPR;                              /**< POP RX FIFO Register, offset: 0x38 */
+        __I  uint32_t TXFR[16];                          /**< Transmit FIFO Registers, array offset: 0x3C, array step: 0x4 */
+        __I  uint32_t RXFR[16];                          /**< Receive FIFO Registers, array offset: 0x7C, array step: 0x4 */
+        __IO uint32_t DSICR0;                            /**< DSI Configuration Register 0, offset: 0xBC */
+        __I  uint32_t SDR0;                              /**< DSI Serialization Data Register 0, offset: 0xC0 */
+        __IO uint32_t ASDR0;                             /**< DSI Alternate Serialization Data Register 0, offset: 0xC4 */
+        __I  uint32_t COMPR0;                            /**< DSI Transmit Comparison Register 0, offset: 0xC8 */
+        __I  uint32_t DDR0;                              /**< DSI Deserialization Data Register 0, offset: 0xCC */
+        __IO uint32_t DSICR1;                            /**< DSI Configuration Register 1, offset: 0xD0 */
+        __IO uint32_t SSR0;                              /**< DSI Serialization Source Select Register 0, offset: 0xD4 */
+        uint8_t RESERVED_2[16];
+        __IO uint32_t DIMR0;                             /**< DSI Deserialized Data Interrupt Mask Register 0, offset: 0xE8 */
+        __IO uint32_t DPIR0;                             /**< DSI Deserialized Data Polarity Interrupt Register 0, offset: 0xEC */
+        __I  uint32_t SDR1;                              /**< DSI Serialization Data Register 1, offset: 0xF0 */
+        __IO uint32_t ASDR1;                             /**< DSI Alternate Serialization Data Register 1, offset: 0xF4 */
+        __I  uint32_t COMPR1;                            /**< DSI Transmit Comparison Register 1, offset: 0xF8 */
+        __I  uint32_t DDR1;                              /**< DSI Deserialization Data Register 1, offset: 0xFC */
+        __IO uint32_t SSR1;                              /**< DSI Serialization Source Select Register 1, offset: 0x100 */
+        uint8_t RESERVED_3[16];
+        __IO uint32_t DIMR1;                             /**< DSI Deserialized Data Interrupt Mask Register 1, offset: 0x114 */
+        __IO uint32_t DPIR1;                             /**< DSI Deserialized Data Polarity Interrupt Register 1, offset: 0x118 */
+        __IO uint32_t CTARE[6];                          /**< Clock and Transfer Attributes Register Extended, array offset: 0x11C, array step: 0x4 */
+        uint8_t RESERVED_4[8];
+        __I  uint32_t SREX;                              /**< Status Register Extended, offset: 0x13C */
+        uint8_t RESERVED_5[16];
+        __IO uint32_t TSL;                               /**< Time Slot Length Register, offset: 0x150 */
+        __IO uint32_t TS_CONF;                           /**< Time Slot Configuration Register, offset: 0x154 */
+} SPI_Type;
+
+
+/* ----------------------------------------------------------------------------
+   -- DSPI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DSPI_Register_Masks DSPI Register Masks
+ * @{
+ */
+
+/*! @name MCR - Module Configuration Register */
+/*! @{ */
+
+#define SPI_MCR_HALT_MASK                          DSPI_MCR_HALT_MASK
+#define SPI_MCR_HALT_SHIFT                         DSPI_MCR_HALT_SHIFT
+#define SPI_MCR_HALT_WIDTH                         DSPI_MCR_HALT_WIDTH
+#define SPI_MCR_HALT(x)                            DSPI_MCR_HALT(x)
+
+#define SPI_MCR_PES_MASK                           DSPI_MCR_PES_MASK
+#define SPI_MCR_PES_SHIFT                          DSPI_MCR_PES_SHIFT
+#define SPI_MCR_PES_WIDTH                          DSPI_MCR_PES_WIDTH
+#define SPI_MCR_PES(x)                             DSPI_MCR_PES(x)
+
+#define SPI_MCR_FCPCS_MASK                         DSPI_MCR_FCPCS_MASK
+#define SPI_MCR_FCPCS_SHIFT                        DSPI_MCR_FCPCS_SHIFT
+#define SPI_MCR_FCPCS_WIDTH                        DSPI_MCR_FCPCS_WIDTH
+#define SPI_MCR_FCPCS(x)                           DSPI_MCR_FCPCS(x)
+
+#define SPI_MCR_XSPI_MASK                          DSPI_MCR_XSPI_MASK
+#define SPI_MCR_XSPI_SHIFT                         DSPI_MCR_XSPI_SHIFT
+#define SPI_MCR_XSPI_WIDTH                         DSPI_MCR_XSPI_WIDTH
+#define SPI_MCR_XSPI(x)                            DSPI_MCR_XSPI(x)
+
+#define SPI_MCR_SMPL_PT_MASK                       DSPI_MCR_SMPL_PT_MASK
+#define SPI_MCR_SMPL_PT_SHIFT                      DSPI_MCR_SMPL_PT_SHIFT
+#define SPI_MCR_SMPL_PT_WIDTH                      DSPI_MCR_SMPL_PT_WIDTH
+#define SPI_MCR_SMPL_PT(x)                         DSPI_MCR_SMPL_PT(x)
+
+#define SPI_MCR_CLR_RXF_MASK                       DSPI_MCR_CLR_RXF_MASK
+#define SPI_MCR_CLR_RXF_SHIFT                      DSPI_MCR_CLR_RXF_SHIFT
+#define SPI_MCR_CLR_RXF_WIDTH                      DSPI_MCR_CLR_RXF_WIDTH
+#define SPI_MCR_CLR_RXF(x)                         DSPI_MCR_CLR_RXF(x)
+
+#define SPI_MCR_CLR_TXF_MASK                       DSPI_MCR_CLR_TXF_MASK
+#define SPI_MCR_CLR_TXF_SHIFT                      DSPI_MCR_CLR_TXF_SHIFT
+#define SPI_MCR_CLR_TXF_WIDTH                      DSPI_MCR_CLR_TXF_WIDTH
+#define SPI_MCR_CLR_TXF(x)                         DSPI_MCR_CLR_TXF(x)
+
+#define SPI_MCR_DIS_RXF_MASK                       DSPI_MCR_DIS_RXF_MASK
+#define SPI_MCR_DIS_RXF_SHIFT                      DSPI_MCR_DIS_RXF_SHIFT
+#define SPI_MCR_DIS_RXF_WIDTH                      DSPI_MCR_DIS_RXF_WIDTH
+#define SPI_MCR_DIS_RXF(x)                         DSPI_MCR_DIS_RXF(x)
+
+#define SPI_MCR_DIS_TXF_MASK                       DSPI_MCR_DIS_TXF_MASK
+#define SPI_MCR_DIS_TXF_SHIFT                      DSPI_MCR_DIS_TXF_SHIFT
+#define SPI_MCR_DIS_TXF_WIDTH                      DSPI_MCR_DIS_TXF_WIDTH
+#define SPI_MCR_DIS_TXF(x)                         DSPI_MCR_DIS_TXF(x)
+
+#define SPI_MCR_MDIS_MASK                          DSPI_MCR_MDIS_MASK
+#define SPI_MCR_MDIS_SHIFT                         DSPI_MCR_MDIS_SHIFT
+#define SPI_MCR_MDIS_WIDTH                         DSPI_MCR_MDIS_WIDTH
+#define SPI_MCR_MDIS(x)                            DSPI_MCR_MDIS(x)
+
+#define SPI_MCR_PCSIS_MASK                         DSPI_MCR_PCSIS_MASK
+#define SPI_MCR_PCSIS_SHIFT                        DSPI_MCR_PCSIS_SHIFT
+#define SPI_MCR_PCSIS_WIDTH                        DSPI_MCR_PCSIS_WIDTH
+#define SPI_MCR_PCSIS(x)                           DSPI_MCR_PCSIS(x)
+
+#define SPI_MCR_ROOE_MASK                          DSPI_MCR_ROOE_MASK
+#define SPI_MCR_ROOE_SHIFT                         DSPI_MCR_ROOE_SHIFT
+#define SPI_MCR_ROOE_WIDTH                         DSPI_MCR_ROOE_WIDTH
+#define SPI_MCR_ROOE(x)                            DSPI_MCR_ROOE(x)
+
+#define SPI_MCR_MTFE_MASK                          DSPI_MCR_MTFE_MASK
+#define SPI_MCR_MTFE_SHIFT                         DSPI_MCR_MTFE_SHIFT
+#define SPI_MCR_MTFE_WIDTH                         DSPI_MCR_MTFE_WIDTH
+#define SPI_MCR_MTFE(x)                            DSPI_MCR_MTFE(x)
+
+#define SPI_MCR_FRZ_MASK                           DSPI_MCR_FRZ_MASK
+#define SPI_MCR_FRZ_SHIFT                          DSPI_MCR_FRZ_SHIFT
+#define SPI_MCR_FRZ_WIDTH                          DSPI_MCR_FRZ_WIDTH
+#define SPI_MCR_FRZ(x)                             DSPI_MCR_FRZ(x)
+
+#define SPI_MCR_DCONF_MASK                         DSPI_MCR_DCONF_MASK
+#define SPI_MCR_DCONF_SHIFT                        DSPI_MCR_DCONF_SHIFT
+#define SPI_MCR_DCONF_WIDTH                        DSPI_MCR_DCONF_WIDTH
+#define SPI_MCR_DCONF(x)                           DSPI_MCR_DCONF(x)
+
+#define SPI_MCR_CONT_SCKE_MASK                     DSPI_MCR_CONT_SCKE_MASK
+#define SPI_MCR_CONT_SCKE_SHIFT                    DSPI_MCR_CONT_SCKE_SHIFT
+#define SPI_MCR_CONT_SCKE_WIDTH                    DSPI_MCR_CONT_SCKE_WIDTH
+#define SPI_MCR_CONT_SCKE(x)                       DSPI_MCR_CONT_SCKE(x)
+
+#define SPI_MCR_MSTR_MASK                          DSPI_MCR_MSTR_MASK
+#define SPI_MCR_MSTR_SHIFT                         DSPI_MCR_MSTR_SHIFT
+#define SPI_MCR_MSTR_WIDTH                         DSPI_MCR_MSTR_WIDTH
+#define SPI_MCR_MSTR(x)                            DSPI_MCR_MSTR(x)
+/*! @} */
+
+/*! @name TCR - Transfer Count Register */
+/*! @{ */
+
+#define SPI_TCR_SPI_TCNT_MASK                      DSPI_TCR_SPI_TCNT_MASK
+#define SPI_TCR_SPI_TCNT_SHIFT                     DSPI_TCR_SPI_TCNT_SHIFT
+#define SPI_TCR_SPI_TCNT_WIDTH                     DSPI_TCR_SPI_TCNT_WIDTH
+#define SPI_TCR_SPI_TCNT(x)                        DSPI_TCR_SPI_TCNT(x)
+/*! @} */
+
+/*! @name CTAR - Clock and Transfer Attributes Register (In Master Mode) */
+/*! @{ */
+
+#define SPI_CTAR_BR_MASK                           DSPI_CTAR_BR_MASK
+#define SPI_CTAR_BR_SHIFT                          DSPI_CTAR_BR_SHIFT
+#define SPI_CTAR_BR_WIDTH                          DSPI_CTAR_BR_WIDTH
+#define SPI_CTAR_BR(x)                             DSPI_CTAR_BR(x)
+
+#define SPI_CTAR_DT_MASK                           DSPI_CTAR_DT_MASK
+#define SPI_CTAR_DT_SHIFT                          DSPI_CTAR_DT_SHIFT
+#define SPI_CTAR_DT_WIDTH                          DSPI_CTAR_DT_WIDTH
+#define SPI_CTAR_DT(x)                             DSPI_CTAR_DT(x)
+
+#define SPI_CTAR_ASC_MASK                          DSPI_CTAR_ASC_MASK
+#define SPI_CTAR_ASC_SHIFT                         DSPI_CTAR_ASC_SHIFT
+#define SPI_CTAR_ASC_WIDTH                         DSPI_CTAR_ASC_WIDTH
+#define SPI_CTAR_ASC(x)                            DSPI_CTAR_ASC(x)
+
+#define SPI_CTAR_CSSCK_MASK                        DSPI_CTAR_CSSCK_MASK
+#define SPI_CTAR_CSSCK_SHIFT                       DSPI_CTAR_CSSCK_SHIFT
+#define SPI_CTAR_CSSCK_WIDTH                       DSPI_CTAR_CSSCK_WIDTH
+#define SPI_CTAR_CSSCK(x)                          DSPI_CTAR_CSSCK(x)
+
+#define SPI_CTAR_PBR_MASK                          DSPI_CTAR_PBR_MASK
+#define SPI_CTAR_PBR_SHIFT                         DSPI_CTAR_PBR_SHIFT
+#define SPI_CTAR_PBR_WIDTH                         DSPI_CTAR_PBR_WIDTH
+#define SPI_CTAR_PBR(x)                            DSPI_CTAR_PBR(x)
+
+#define SPI_CTAR_PDT_MASK                          DSPI_CTAR_PDT_MASK
+#define SPI_CTAR_PDT_SHIFT                         DSPI_CTAR_PDT_SHIFT
+#define SPI_CTAR_PDT_WIDTH                         DSPI_CTAR_PDT_WIDTH
+#define SPI_CTAR_PDT(x)                            DSPI_CTAR_PDT(x)
+
+#define SPI_CTAR_PASC_MASK                         DSPI_CTAR_PASC_MASK
+#define SPI_CTAR_PASC_SHIFT                        DSPI_CTAR_PASC_SHIFT
+#define SPI_CTAR_PASC_WIDTH                        DSPI_CTAR_PASC_WIDTH
+#define SPI_CTAR_PASC(x)                           DSPI_CTAR_PASC(x)
+
+#define SPI_CTAR_PCSSCK_MASK                       DSPI_CTAR_PCSSCK_MASK
+#define SPI_CTAR_PCSSCK_SHIFT                      DSPI_CTAR_PCSSCK_SHIFT
+#define SPI_CTAR_PCSSCK_WIDTH                      DSPI_CTAR_PCSSCK_WIDTH
+#define SPI_CTAR_PCSSCK(x)                         DSPI_CTAR_PCSSCK(x)
+
+#define SPI_CTAR_LSBFE_MASK                        DSPI_CTAR_LSBFE_MASK
+#define SPI_CTAR_LSBFE_SHIFT                       DSPI_CTAR_LSBFE_SHIFT
+#define SPI_CTAR_LSBFE_WIDTH                       DSPI_CTAR_LSBFE_WIDTH
+#define SPI_CTAR_LSBFE(x)                          DSPI_CTAR_LSBFE(x)
+
+#define SPI_CTAR_CPHA_MASK                         DSPI_CTAR_CPHA_MASK
+#define SPI_CTAR_CPHA_SHIFT                        DSPI_CTAR_CPHA_SHIFT
+#define SPI_CTAR_CPHA_WIDTH                        DSPI_CTAR_CPHA_WIDTH
+#define SPI_CTAR_CPHA(x)                           DSPI_CTAR_CPHA(x)
+
+#define SPI_CTAR_CPOL_MASK                         DSPI_CTAR_CPOL_MASK
+#define SPI_CTAR_CPOL_SHIFT                        DSPI_CTAR_CPOL_SHIFT
+#define SPI_CTAR_CPOL_WIDTH                        DSPI_CTAR_CPOL_WIDTH
+#define SPI_CTAR_CPOL(x)                           DSPI_CTAR_CPOL(x)
+
+#define SPI_CTAR_FMSZ_MASK                         DSPI_CTAR_FMSZ_MASK
+#define SPI_CTAR_FMSZ_SHIFT                        DSPI_CTAR_FMSZ_SHIFT
+#define SPI_CTAR_FMSZ_WIDTH                        DSPI_CTAR_FMSZ_WIDTH
+#define SPI_CTAR_FMSZ(x)                           DSPI_CTAR_FMSZ(x)
+
+#define SPI_CTAR_DBR_MASK                          DSPI_CTAR_DBR_MASK
+#define SPI_CTAR_DBR_SHIFT                         DSPI_CTAR_DBR_SHIFT
+#define SPI_CTAR_DBR_WIDTH                         DSPI_CTAR_DBR_WIDTH
+#define SPI_CTAR_DBR(x)                            DSPI_CTAR_DBR(x)
+/*! @} */
+
+/*! @name SR - Status Register */
+/*! @{ */
+
+#define SPI_SR_POPNXTPTR_MASK                      DSPI_SR_POPNXTPTR_MASK
+#define SPI_SR_POPNXTPTR_SHIFT                     DSPI_SR_POPNXTPTR_SHIFT
+#define SPI_SR_POPNXTPTR_WIDTH                     DSPI_SR_POPNXTPTR_WIDTH
+#define SPI_SR_POPNXTPTR(x)                        DSPI_SR_POPNXTPTR(x)
+
+#define SPI_SR_RXCTR_MASK                          DSPI_SR_RXCTR_MASK
+#define SPI_SR_RXCTR_SHIFT                         DSPI_SR_RXCTR_SHIFT
+#define SPI_SR_RXCTR_WIDTH                         DSPI_SR_RXCTR_WIDTH
+#define SPI_SR_RXCTR(x)                            DSPI_SR_RXCTR(x)
+
+#define SPI_SR_TXNXTPTR_MASK                       DSPI_SR_TXNXTPTR_MASK
+#define SPI_SR_TXNXTPTR_SHIFT                      DSPI_SR_TXNXTPTR_SHIFT
+#define SPI_SR_TXNXTPTR_WIDTH                      DSPI_SR_TXNXTPTR_WIDTH
+#define SPI_SR_TXNXTPTR(x)                         DSPI_SR_TXNXTPTR(x)
+
+#define SPI_SR_TXCTR_MASK                          DSPI_SR_TXCTR_MASK
+#define SPI_SR_TXCTR_SHIFT                         DSPI_SR_TXCTR_SHIFT
+#define SPI_SR_TXCTR_WIDTH                         DSPI_SR_TXCTR_WIDTH
+#define SPI_SR_TXCTR(x)                            DSPI_SR_TXCTR(x)
+
+#define SPI_SR_CMDFFF_MASK                         DSPI_SR_CMDFFF_MASK
+#define SPI_SR_CMDFFF_SHIFT                        DSPI_SR_CMDFFF_SHIFT
+#define SPI_SR_CMDFFF_WIDTH                        DSPI_SR_CMDFFF_WIDTH
+#define SPI_SR_CMDFFF(x)                           DSPI_SR_CMDFFF(x)
+
+#define SPI_SR_RFDF_MASK                           DSPI_SR_RFDF_MASK
+#define SPI_SR_RFDF_SHIFT                          DSPI_SR_RFDF_SHIFT
+#define SPI_SR_RFDF_WIDTH                          DSPI_SR_RFDF_WIDTH
+#define SPI_SR_RFDF(x)                             DSPI_SR_RFDF(x)
+
+#define SPI_SR_TFIWF_MASK                          DSPI_SR_TFIWF_MASK
+#define SPI_SR_TFIWF_SHIFT                         DSPI_SR_TFIWF_SHIFT
+#define SPI_SR_TFIWF_WIDTH                         DSPI_SR_TFIWF_WIDTH
+#define SPI_SR_TFIWF(x)                            DSPI_SR_TFIWF(x)
+
+#define SPI_SR_RFOF_MASK                           DSPI_SR_RFOF_MASK
+#define SPI_SR_RFOF_SHIFT                          DSPI_SR_RFOF_SHIFT
+#define SPI_SR_RFOF_WIDTH                          DSPI_SR_RFOF_WIDTH
+#define SPI_SR_RFOF(x)                             DSPI_SR_RFOF(x)
+
+#define SPI_SR_DDIF_MASK                           DSPI_SR_DDIF_MASK
+#define SPI_SR_DDIF_SHIFT                          DSPI_SR_DDIF_SHIFT
+#define SPI_SR_DDIF_WIDTH                          DSPI_SR_DDIF_WIDTH
+#define SPI_SR_DDIF(x)                             DSPI_SR_DDIF(x)
+
+#define SPI_SR_SPEF_MASK                           DSPI_SR_SPEF_MASK
+#define SPI_SR_SPEF_SHIFT                          DSPI_SR_SPEF_SHIFT
+#define SPI_SR_SPEF_WIDTH                          DSPI_SR_SPEF_WIDTH
+#define SPI_SR_SPEF(x)                             DSPI_SR_SPEF(x)
+
+#define SPI_SR_DPEF_MASK                           DSPI_SR_DPEF_MASK
+#define SPI_SR_DPEF_SHIFT                          DSPI_SR_DPEF_SHIFT
+#define SPI_SR_DPEF_WIDTH                          DSPI_SR_DPEF_WIDTH
+#define SPI_SR_DPEF(x)                             DSPI_SR_DPEF(x)
+
+#define SPI_SR_CMDTCF_MASK                         DSPI_SR_CMDTCF_MASK
+#define SPI_SR_CMDTCF_SHIFT                        DSPI_SR_CMDTCF_SHIFT
+#define SPI_SR_CMDTCF_WIDTH                        DSPI_SR_CMDTCF_WIDTH
+#define SPI_SR_CMDTCF(x)                           DSPI_SR_CMDTCF(x)
+
+#define SPI_SR_BSYF_MASK                           DSPI_SR_BSYF_MASK
+#define SPI_SR_BSYF_SHIFT                          DSPI_SR_BSYF_SHIFT
+#define SPI_SR_BSYF_WIDTH                          DSPI_SR_BSYF_WIDTH
+#define SPI_SR_BSYF(x)                             DSPI_SR_BSYF(x)
+
+#define SPI_SR_TFFF_MASK                           DSPI_SR_TFFF_MASK
+#define SPI_SR_TFFF_SHIFT                          DSPI_SR_TFFF_SHIFT
+#define SPI_SR_TFFF_WIDTH                          DSPI_SR_TFFF_WIDTH
+#define SPI_SR_TFFF(x)                             DSPI_SR_TFFF(x)
+
+#define SPI_SR_EOQF_MASK                           DSPI_SR_EOQF_MASK
+#define SPI_SR_EOQF_SHIFT                          DSPI_SR_EOQF_SHIFT
+#define SPI_SR_EOQF_WIDTH                          DSPI_SR_EOQF_WIDTH
+#define SPI_SR_EOQF(x)                             DSPI_SR_EOQF(x)
+
+#define SPI_SR_SPITCF_MASK                         DSPI_SR_SPITCF_MASK
+#define SPI_SR_SPITCF_SHIFT                        DSPI_SR_SPITCF_SHIFT
+#define SPI_SR_SPITCF_WIDTH                        DSPI_SR_SPITCF_WIDTH
+#define SPI_SR_SPITCF(x)                           DSPI_SR_SPITCF(x)
+
+#define SPI_SR_TXRXS_MASK                          DSPI_SR_TXRXS_MASK
+#define SPI_SR_TXRXS_SHIFT                         DSPI_SR_TXRXS_SHIFT
+#define SPI_SR_TXRXS_WIDTH                         DSPI_SR_TXRXS_WIDTH
+#define SPI_SR_TXRXS(x)                            DSPI_SR_TXRXS(x)
+
+#define SPI_SR_TCF_MASK                            DSPI_SR_TCF_MASK
+#define SPI_SR_TCF_SHIFT                           DSPI_SR_TCF_SHIFT
+#define SPI_SR_TCF_WIDTH                           DSPI_SR_TCF_WIDTH
+#define SPI_SR_TCF(x)                              DSPI_SR_TCF(x)
+/*! @} */
+
+/*! @name RSER - DMA/Interrupt Request Select and Enable Register */
+/*! @{ */
+
+#define SPI_RSER_DDIF_DIRS_MASK                    DSPI_RSER_DDIF_DIRS_MASK
+#define SPI_RSER_DDIF_DIRS_SHIFT                   DSPI_RSER_DDIF_DIRS_SHIFT
+#define SPI_RSER_DDIF_DIRS_WIDTH                   DSPI_RSER_DDIF_DIRS_WIDTH
+#define SPI_RSER_DDIF_DIRS(x)                      DSPI_RSER_DDIF_DIRS(x)
+
+#define SPI_RSER_CMDFFF_DIRS_MASK                  DSPI_RSER_CMDFFF_DIRS_MASK
+#define SPI_RSER_CMDFFF_DIRS_SHIFT                 DSPI_RSER_CMDFFF_DIRS_SHIFT
+#define SPI_RSER_CMDFFF_DIRS_WIDTH                 DSPI_RSER_CMDFFF_DIRS_WIDTH
+#define SPI_RSER_CMDFFF_DIRS(x)                    DSPI_RSER_CMDFFF_DIRS(x)
+
+#define SPI_RSER_RFDF_DIRS_MASK                    DSPI_RSER_RFDF_DIRS_MASK
+#define SPI_RSER_RFDF_DIRS_SHIFT                   DSPI_RSER_RFDF_DIRS_SHIFT
+#define SPI_RSER_RFDF_DIRS_WIDTH                   DSPI_RSER_RFDF_DIRS_WIDTH
+#define SPI_RSER_RFDF_DIRS(x)                      DSPI_RSER_RFDF_DIRS(x)
+
+#define SPI_RSER_RFDF_RE_MASK                      DSPI_RSER_RFDF_RE_MASK
+#define SPI_RSER_RFDF_RE_SHIFT                     DSPI_RSER_RFDF_RE_SHIFT
+#define SPI_RSER_RFDF_RE_WIDTH                     DSPI_RSER_RFDF_RE_WIDTH
+#define SPI_RSER_RFDF_RE(x)                        DSPI_RSER_RFDF_RE(x)
+
+#define SPI_RSER_TFIWF_RE_MASK                     DSPI_RSER_TFIWF_RE_MASK
+#define SPI_RSER_TFIWF_RE_SHIFT                    DSPI_RSER_TFIWF_RE_SHIFT
+#define SPI_RSER_TFIWF_RE_WIDTH                    DSPI_RSER_TFIWF_RE_WIDTH
+#define SPI_RSER_TFIWF_RE(x)                       DSPI_RSER_TFIWF_RE(x)
+
+#define SPI_RSER_RFOF_RE_MASK                      DSPI_RSER_RFOF_RE_MASK
+#define SPI_RSER_RFOF_RE_SHIFT                     DSPI_RSER_RFOF_RE_SHIFT
+#define SPI_RSER_RFOF_RE_WIDTH                     DSPI_RSER_RFOF_RE_WIDTH
+#define SPI_RSER_RFOF_RE(x)                        DSPI_RSER_RFOF_RE(x)
+
+#define SPI_RSER_DDIF_RE_MASK                      DSPI_RSER_DDIF_RE_MASK
+#define SPI_RSER_DDIF_RE_SHIFT                     DSPI_RSER_DDIF_RE_SHIFT
+#define SPI_RSER_DDIF_RE_WIDTH                     DSPI_RSER_DDIF_RE_WIDTH
+#define SPI_RSER_DDIF_RE(x)                        DSPI_RSER_DDIF_RE(x)
+
+#define SPI_RSER_SPEF_RE_MASK                      DSPI_RSER_SPEF_RE_MASK
+#define SPI_RSER_SPEF_RE_SHIFT                     DSPI_RSER_SPEF_RE_SHIFT
+#define SPI_RSER_SPEF_RE_WIDTH                     DSPI_RSER_SPEF_RE_WIDTH
+#define SPI_RSER_SPEF_RE(x)                        DSPI_RSER_SPEF_RE(x)
+
+#define SPI_RSER_DPEF_RE_MASK                      DSPI_RSER_DPEF_RE_MASK
+#define SPI_RSER_DPEF_RE_SHIFT                     DSPI_RSER_DPEF_RE_SHIFT
+#define SPI_RSER_DPEF_RE_WIDTH                     DSPI_RSER_DPEF_RE_WIDTH
+#define SPI_RSER_DPEF_RE(x)                        DSPI_RSER_DPEF_RE(x)
+
+#define SPI_RSER_CMDTCF_RE_MASK                    DSPI_RSER_CMDTCF_RE_MASK
+#define SPI_RSER_CMDTCF_RE_SHIFT                   DSPI_RSER_CMDTCF_RE_SHIFT
+#define SPI_RSER_CMDTCF_RE_WIDTH                   DSPI_RSER_CMDTCF_RE_WIDTH
+#define SPI_RSER_CMDTCF_RE(x)                      DSPI_RSER_CMDTCF_RE(x)
+
+#define SPI_RSER_TFFF_DIRS_MASK                    DSPI_RSER_TFFF_DIRS_MASK
+#define SPI_RSER_TFFF_DIRS_SHIFT                   DSPI_RSER_TFFF_DIRS_SHIFT
+#define SPI_RSER_TFFF_DIRS_WIDTH                   DSPI_RSER_TFFF_DIRS_WIDTH
+#define SPI_RSER_TFFF_DIRS(x)                      DSPI_RSER_TFFF_DIRS(x)
+
+#define SPI_RSER_TFFF_RE_MASK                      DSPI_RSER_TFFF_RE_MASK
+#define SPI_RSER_TFFF_RE_SHIFT                     DSPI_RSER_TFFF_RE_SHIFT
+#define SPI_RSER_TFFF_RE_WIDTH                     DSPI_RSER_TFFF_RE_WIDTH
+#define SPI_RSER_TFFF_RE(x)                        DSPI_RSER_TFFF_RE(x)
+
+#define SPI_RSER_EOQF_RE_MASK                      DSPI_RSER_EOQF_RE_MASK
+#define SPI_RSER_EOQF_RE_SHIFT                     DSPI_RSER_EOQF_RE_SHIFT
+#define SPI_RSER_EOQF_RE_WIDTH                     DSPI_RSER_EOQF_RE_WIDTH
+#define SPI_RSER_EOQF_RE(x)                        DSPI_RSER_EOQF_RE(x)
+
+#define SPI_RSER_CMDFFF_RE_MASK                    DSPI_RSER_CMDFFF_RE_MASK
+#define SPI_RSER_CMDFFF_RE_SHIFT                   DSPI_RSER_CMDFFF_RE_SHIFT
+#define SPI_RSER_CMDFFF_RE_WIDTH                   DSPI_RSER_CMDFFF_RE_WIDTH
+#define SPI_RSER_CMDFFF_RE(x)                      DSPI_RSER_CMDFFF_RE(x)
+
+#define SPI_RSER_TCF_RE_MASK                       DSPI_RSER_TCF_RE_MASK
+#define SPI_RSER_TCF_RE_SHIFT                      DSPI_RSER_TCF_RE_SHIFT
+#define SPI_RSER_TCF_RE_WIDTH                      DSPI_RSER_TCF_RE_WIDTH
+#define SPI_RSER_TCF_RE(x)                         DSPI_RSER_TCF_RE(x)
+/*! @} */
+
+/*! @name TX - DSPI_TX register */
+/*! @{ */
+
+#define SPI_TX_TX_MASK                             DSPI_TX_TX_MASK
+#define SPI_TX_TX_SHIFT                            DSPI_TX_TX_SHIFT
+#define SPI_TX_TX_WIDTH                            DSPI_TX_TX_WIDTH
+#define SPI_TX_TX(x)                               DSPI_TX_TX(x)
+/*! @} */
+
+/*! @name CMD - DSPI_CMD register */
+/*! @{ */
+
+#define SPI_CMD_CMD_MASK                           DSPI_CMD_CMD_MASK
+#define SPI_CMD_CMD_SHIFT                          DSPI_CMD_CMD_SHIFT
+#define SPI_CMD_CMD_WIDTH                          DSPI_CMD_CMD_WIDTH
+#define SPI_CMD_CMD(x)                             DSPI_CMD_CMD(x)
+/*! @} */
+
+/*! @name PUSHR - PUSH TX FIFO Register In Master Mode */
+/*! @{ */
+
+#define SPI_PUSHR_TXDATA_MASK                      DSPI_PUSHR_TXDATA_MASK
+#define SPI_PUSHR_TXDATA_SHIFT                     DSPI_PUSHR_TXDATA_SHIFT
+#define SPI_PUSHR_TXDATA_WIDTH                     DSPI_PUSHR_TXDATA_WIDTH
+#define SPI_PUSHR_TXDATA(x)                        DSPI_PUSHR_TXDATA(x)
+
+#define SPI_PUSHR_PCS_MASK                         DSPI_PUSHR_PCS_MASK
+#define SPI_PUSHR_PCS_SHIFT                        DSPI_PUSHR_PCS_SHIFT
+#define SPI_PUSHR_PCS_WIDTH                        DSPI_PUSHR_PCS_WIDTH
+#define SPI_PUSHR_PCS(x)                           DSPI_PUSHR_PCS(x)
+
+#define SPI_PUSHR_PP_MCSC_MASK                     DSPI_PUSHR_PP_MCSC_MASK
+#define SPI_PUSHR_PP_MCSC_SHIFT                    DSPI_PUSHR_PP_MCSC_SHIFT
+#define SPI_PUSHR_PP_MCSC_WIDTH                    DSPI_PUSHR_PP_MCSC_WIDTH
+#define SPI_PUSHR_PP_MCSC(x)                       DSPI_PUSHR_PP_MCSC(x)
+
+#define SPI_PUSHR_PE_MASC_MASK                     DSPI_PUSHR_PE_MASC_MASK
+#define SPI_PUSHR_PE_MASC_SHIFT                    DSPI_PUSHR_PE_MASC_SHIFT
+#define SPI_PUSHR_PE_MASC_WIDTH                    DSPI_PUSHR_PE_MASC_WIDTH
+#define SPI_PUSHR_PE_MASC(x)                       DSPI_PUSHR_PE_MASC(x)
+
+#define SPI_PUSHR_CTCNT_MASK                       DSPI_PUSHR_CTCNT_MASK
+#define SPI_PUSHR_CTCNT_SHIFT                      DSPI_PUSHR_CTCNT_SHIFT
+#define SPI_PUSHR_CTCNT_WIDTH                      DSPI_PUSHR_CTCNT_WIDTH
+#define SPI_PUSHR_CTCNT(x)                         DSPI_PUSHR_CTCNT(x)
+
+#define SPI_PUSHR_EOQ_MASK                         DSPI_PUSHR_EOQ_MASK
+#define SPI_PUSHR_EOQ_SHIFT                        DSPI_PUSHR_EOQ_SHIFT
+#define SPI_PUSHR_EOQ_WIDTH                        DSPI_PUSHR_EOQ_WIDTH
+#define SPI_PUSHR_EOQ(x)                           DSPI_PUSHR_EOQ(x)
+
+#define SPI_PUSHR_CTAS_MASK                        DSPI_PUSHR_CTAS_MASK
+#define SPI_PUSHR_CTAS_SHIFT                       DSPI_PUSHR_CTAS_SHIFT
+#define SPI_PUSHR_CTAS_WIDTH                       DSPI_PUSHR_CTAS_WIDTH
+#define SPI_PUSHR_CTAS(x)                          DSPI_PUSHR_CTAS(x)
+
+#define SPI_PUSHR_CONT_MASK                        DSPI_PUSHR_CONT_MASK
+#define SPI_PUSHR_CONT_SHIFT                       DSPI_PUSHR_CONT_SHIFT
+#define SPI_PUSHR_CONT_WIDTH                       DSPI_PUSHR_CONT_WIDTH
+#define SPI_PUSHR_CONT(x)                          DSPI_PUSHR_CONT(x)
+/*! @} */
+
+/*! @name POPR - POP RX FIFO Register */
+/*! @{ */
+
+#define SPI_POPR_RXDATA_MASK                       DSPI_POPR_RXDATA_MASK
+#define SPI_POPR_RXDATA_SHIFT                      DSPI_POPR_RXDATA_SHIFT
+#define SPI_POPR_RXDATA_WIDTH                      DSPI_POPR_RXDATA_WIDTH
+#define SPI_POPR_RXDATA(x)                         DSPI_POPR_RXDATA(x)
+/*! @} */
+
+/*! @name TXFR - Transmit FIFO Registers */
+/*! @{ */
+
+#define SPI_TXFR_TXDATA_MASK                       DSPI_TXFR_TXDATA_MASK
+#define SPI_TXFR_TXDATA_SHIFT                      DSPI_TXFR_TXDATA_SHIFT
+#define SPI_TXFR_TXDATA_WIDTH                      DSPI_TXFR_TXDATA_WIDTH
+#define SPI_TXFR_TXDATA(x)                         DSPI_TXFR_TXDATA(x)
+
+#define SPI_TXFR_TXCMD_TXDATA_MASK                 DSPI_TXFR_TXCMD_TXDATA_MASK
+#define SPI_TXFR_TXCMD_TXDATA_SHIFT                DSPI_TXFR_TXCMD_TXDATA_SHIFT
+#define SPI_TXFR_TXCMD_TXDATA_WIDTH                DSPI_TXFR_TXCMD_TXDATA_WIDTH
+#define SPI_TXFR_TXCMD_TXDATA(x)                   DSPI_TXFR_TXCMD_TXDATA(x)
+/*! @} */
+
+/*! @name RXFR - Receive FIFO Registers */
+/*! @{ */
+
+#define SPI_RXFR_RXDATA_MASK                       DSPI_RXFR_RXDATA_MASK
+#define SPI_RXFR_RXDATA_SHIFT                      DSPI_RXFR_RXDATA_SHIFT
+#define SPI_RXFR_RXDATA_WIDTH                      DSPI_RXFR_RXDATA_WIDTH
+#define SPI_RXFR_RXDATA(x)                         DSPI_RXFR_RXDATA(x)
+/*! @} */
+
+/*! @name DSICR0 - DSI Configuration Register 0 */
+/*! @{ */
+
+#define SPI_DSICR0_DPCSx_MASK                      DSPI_DSICR0_DPCSx_MASK
+#define SPI_DSICR0_DPCSx_SHIFT                     DSPI_DSICR0_DPCSx_SHIFT
+#define SPI_DSICR0_DPCSx_WIDTH                     DSPI_DSICR0_DPCSx_WIDTH
+#define SPI_DSICR0_DPCSx(x)                        DSPI_DSICR0_DPCSx(x)
+
+#define SPI_DSICR0_PP_MASK                         DSPI_DSICR0_PP_MASK
+#define SPI_DSICR0_PP_SHIFT                        DSPI_DSICR0_PP_SHIFT
+#define SPI_DSICR0_PP_WIDTH                        DSPI_DSICR0_PP_WIDTH
+#define SPI_DSICR0_PP(x)                           DSPI_DSICR0_PP(x)
+
+#define SPI_DSICR0_PE_MASK                         DSPI_DSICR0_PE_MASK
+#define SPI_DSICR0_PE_SHIFT                        DSPI_DSICR0_PE_SHIFT
+#define SPI_DSICR0_PE_WIDTH                        DSPI_DSICR0_PE_WIDTH
+#define SPI_DSICR0_PE(x)                           DSPI_DSICR0_PE(x)
+
+#define SPI_DSICR0_PES_MASK                        DSPI_DSICR0_PES_MASK
+#define SPI_DSICR0_PES_SHIFT                       DSPI_DSICR0_PES_SHIFT
+#define SPI_DSICR0_PES_WIDTH                       DSPI_DSICR0_PES_WIDTH
+#define SPI_DSICR0_PES(x)                          DSPI_DSICR0_PES(x)
+
+#define SPI_DSICR0_DMS_MASK                        DSPI_DSICR0_DMS_MASK
+#define SPI_DSICR0_DMS_SHIFT                       DSPI_DSICR0_DMS_SHIFT
+#define SPI_DSICR0_DMS_WIDTH                       DSPI_DSICR0_DMS_WIDTH
+#define SPI_DSICR0_DMS(x)                          DSPI_DSICR0_DMS(x)
+
+#define SPI_DSICR0_DSICTAS_MASK                    DSPI_DSICR0_DSICTAS_MASK
+#define SPI_DSICR0_DSICTAS_SHIFT                   DSPI_DSICR0_DSICTAS_SHIFT
+#define SPI_DSICR0_DSICTAS_WIDTH                   DSPI_DSICR0_DSICTAS_WIDTH
+#define SPI_DSICR0_DSICTAS(x)                      DSPI_DSICR0_DSICTAS(x)
+
+#define SPI_DSICR0_DCONT_MASK                      DSPI_DSICR0_DCONT_MASK
+#define SPI_DSICR0_DCONT_SHIFT                     DSPI_DSICR0_DCONT_SHIFT
+#define SPI_DSICR0_DCONT_WIDTH                     DSPI_DSICR0_DCONT_WIDTH
+#define SPI_DSICR0_DCONT(x)                        DSPI_DSICR0_DCONT(x)
+
+#define SPI_DSICR0_CID_MASK                        DSPI_DSICR0_CID_MASK
+#define SPI_DSICR0_CID_SHIFT                       DSPI_DSICR0_CID_SHIFT
+#define SPI_DSICR0_CID_WIDTH                       DSPI_DSICR0_CID_WIDTH
+#define SPI_DSICR0_CID(x)                          DSPI_DSICR0_CID(x)
+
+#define SPI_DSICR0_TXSS_MASK                       DSPI_DSICR0_TXSS_MASK
+#define SPI_DSICR0_TXSS_SHIFT                      DSPI_DSICR0_TXSS_SHIFT
+#define SPI_DSICR0_TXSS_WIDTH                      DSPI_DSICR0_TXSS_WIDTH
+#define SPI_DSICR0_TXSS(x)                         DSPI_DSICR0_TXSS(x)
+
+#define SPI_DSICR0_TSBC_MASK                       DSPI_DSICR0_TSBC_MASK
+#define SPI_DSICR0_TSBC_SHIFT                      DSPI_DSICR0_TSBC_SHIFT
+#define SPI_DSICR0_TSBC_WIDTH                      DSPI_DSICR0_TSBC_WIDTH
+#define SPI_DSICR0_TSBC(x)                         DSPI_DSICR0_TSBC(x)
+
+#define SPI_DSICR0_ITSB_MASK                       DSPI_DSICR0_ITSB_MASK
+#define SPI_DSICR0_ITSB_SHIFT                      DSPI_DSICR0_ITSB_SHIFT
+#define SPI_DSICR0_ITSB_WIDTH                      DSPI_DSICR0_ITSB_WIDTH
+#define SPI_DSICR0_ITSB(x)                         DSPI_DSICR0_ITSB(x)
+
+#define SPI_DSICR0_FMSZ5_MASK                      DSPI_DSICR0_FMSZ5_MASK
+#define SPI_DSICR0_FMSZ5_SHIFT                     DSPI_DSICR0_FMSZ5_SHIFT
+#define SPI_DSICR0_FMSZ5_WIDTH                     DSPI_DSICR0_FMSZ5_WIDTH
+#define SPI_DSICR0_FMSZ5(x)                        DSPI_DSICR0_FMSZ5(x)
+
+#define SPI_DSICR0_FMSZ4_MASK                      DSPI_DSICR0_FMSZ4_MASK
+#define SPI_DSICR0_FMSZ4_SHIFT                     DSPI_DSICR0_FMSZ4_SHIFT
+#define SPI_DSICR0_FMSZ4_WIDTH                     DSPI_DSICR0_FMSZ4_WIDTH
+#define SPI_DSICR0_FMSZ4(x)                        DSPI_DSICR0_FMSZ4(x)
+/*! @} */
+
+/*! @name SDR0 - DSI Serialization Data Register 0 */
+/*! @{ */
+
+#define SPI_SDR0_SER_DATA_MASK                     DSPI_SDR0_SER_DATA_MASK
+#define SPI_SDR0_SER_DATA_SHIFT                    DSPI_SDR0_SER_DATA_SHIFT
+#define SPI_SDR0_SER_DATA_WIDTH                    DSPI_SDR0_SER_DATA_WIDTH
+#define SPI_SDR0_SER_DATA(x)                       DSPI_SDR0_SER_DATA(x)
+/*! @} */
+
+/*! @name ASDR0 - DSI Alternate Serialization Data Register 0 */
+/*! @{ */
+
+#define SPI_ASDR0_ASER_DATA_MASK                   DSPI_ASDR0_ASER_DATA_MASK
+#define SPI_ASDR0_ASER_DATA_SHIFT                  DSPI_ASDR0_ASER_DATA_SHIFT
+#define SPI_ASDR0_ASER_DATA_WIDTH                  DSPI_ASDR0_ASER_DATA_WIDTH
+#define SPI_ASDR0_ASER_DATA(x)                     DSPI_ASDR0_ASER_DATA(x)
+/*! @} */
+
+/*! @name COMPR0 - DSI Transmit Comparison Register 0 */
+/*! @{ */
+
+#define SPI_COMPR0_COMP_DATA_MASK                  DSPI_COMPR0_COMP_DATA_MASK
+#define SPI_COMPR0_COMP_DATA_SHIFT                 DSPI_COMPR0_COMP_DATA_SHIFT
+#define SPI_COMPR0_COMP_DATA_WIDTH                 DSPI_COMPR0_COMP_DATA_WIDTH
+#define SPI_COMPR0_COMP_DATA(x)                    DSPI_COMPR0_COMP_DATA(x)
+/*! @} */
+
+/*! @name DDR0 - DSI Deserialization Data Register 0 */
+/*! @{ */
+
+#define SPI_DDR0_DESER_DATA_MASK                   DSPI_DDR0_DESER_DATA_MASK
+#define SPI_DDR0_DESER_DATA_SHIFT                  DSPI_DDR0_DESER_DATA_SHIFT
+#define SPI_DDR0_DESER_DATA_WIDTH                  DSPI_DDR0_DESER_DATA_WIDTH
+#define SPI_DDR0_DESER_DATA(x)                     DSPI_DDR0_DESER_DATA(x)
+/*! @} */
+
+/*! @name DSICR1 - DSI Configuration Register 1 */
+/*! @{ */
+
+#define SPI_DSICR1_DPCS1_x_MASK                    DSPI_DSICR1_DPCS1_x_MASK
+#define SPI_DSICR1_DPCS1_x_SHIFT                   DSPI_DSICR1_DPCS1_x_SHIFT
+#define SPI_DSICR1_DPCS1_x_WIDTH                   DSPI_DSICR1_DPCS1_x_WIDTH
+#define SPI_DSICR1_DPCS1_x(x)                      DSPI_DSICR1_DPCS1_x(x)
+
+#define SPI_DSICR1_DSE0_MASK                       DSPI_DSICR1_DSE0_MASK
+#define SPI_DSICR1_DSE0_SHIFT                      DSPI_DSICR1_DSE0_SHIFT
+#define SPI_DSICR1_DSE0_WIDTH                      DSPI_DSICR1_DSE0_WIDTH
+#define SPI_DSICR1_DSE0(x)                         DSPI_DSICR1_DSE0(x)
+
+#define SPI_DSICR1_DSE1_MASK                       DSPI_DSICR1_DSE1_MASK
+#define SPI_DSICR1_DSE1_SHIFT                      DSPI_DSICR1_DSE1_SHIFT
+#define SPI_DSICR1_DSE1_WIDTH                      DSPI_DSICR1_DSE1_WIDTH
+#define SPI_DSICR1_DSE1(x)                         DSPI_DSICR1_DSE1(x)
+
+#define SPI_DSICR1_DSI64E_MASK                     DSPI_DSICR1_DSI64E_MASK
+#define SPI_DSICR1_DSI64E_SHIFT                    DSPI_DSICR1_DSI64E_SHIFT
+#define SPI_DSICR1_DSI64E_WIDTH                    DSPI_DSICR1_DSI64E_WIDTH
+#define SPI_DSICR1_DSI64E(x)                       DSPI_DSICR1_DSI64E(x)
+
+#define SPI_DSICR1_CSE_MASK                        DSPI_DSICR1_CSE_MASK
+#define SPI_DSICR1_CSE_SHIFT                       DSPI_DSICR1_CSE_SHIFT
+#define SPI_DSICR1_CSE_WIDTH                       DSPI_DSICR1_CSE_WIDTH
+#define SPI_DSICR1_CSE(x)                          DSPI_DSICR1_CSE(x)
+
+#define SPI_DSICR1_TSBCNT_MASK                     DSPI_DSICR1_TSBCNT_MASK
+#define SPI_DSICR1_TSBCNT_SHIFT                    DSPI_DSICR1_TSBCNT_SHIFT
+#define SPI_DSICR1_TSBCNT_WIDTH                    DSPI_DSICR1_TSBCNT_WIDTH
+#define SPI_DSICR1_TSBCNT(x)                       DSPI_DSICR1_TSBCNT(x)
+/*! @} */
+
+/*! @name SSR0 - DSI Serialization Source Select Register 0 */
+/*! @{ */
+
+#define SPI_SSR0_SS_MASK                           DSPI_SSR0_SS_MASK
+#define SPI_SSR0_SS_SHIFT                          DSPI_SSR0_SS_SHIFT
+#define SPI_SSR0_SS_WIDTH                          DSPI_SSR0_SS_WIDTH
+#define SPI_SSR0_SS(x)                             DSPI_SSR0_SS(x)
+/*! @} */
+
+/*! @name DIMR0 - DSI Deserialized Data Interrupt Mask Register 0 */
+/*! @{ */
+
+#define SPI_DIMR0_MASK_MASK                        DSPI_DIMR0_MASK_MASK
+#define SPI_DIMR0_MASK_SHIFT                       DSPI_DIMR0_MASK_SHIFT
+#define SPI_DIMR0_MASK_WIDTH                       DSPI_DIMR0_MASK_WIDTH
+#define SPI_DIMR0_MASK(x)                          DSPI_DIMR0_MASK(x)
+/*! @} */
+
+/*! @name DPIR0 - DSI Deserialized Data Polarity Interrupt Register 0 */
+/*! @{ */
+
+#define SPI_DPIR0_DP_MASK                          DSPI_DPIR0_DP_MASK
+#define SPI_DPIR0_DP_SHIFT                         DSPI_DPIR0_DP_SHIFT
+#define SPI_DPIR0_DP_WIDTH                         DSPI_DPIR0_DP_WIDTH
+#define SPI_DPIR0_DP(x)                            DSPI_DPIR0_DP(x)
+/*! @} */
+
+/*! @name SDR1 - DSI Serialization Data Register 1 */
+/*! @{ */
+
+#define SPI_SDR1_SER_DATA_MASK                     DSPI_SDR1_SER_DATA_MASK
+#define SPI_SDR1_SER_DATA_SHIFT                    DSPI_SDR1_SER_DATA_SHIFT
+#define SPI_SDR1_SER_DATA_WIDTH                    DSPI_SDR1_SER_DATA_WIDTH
+#define SPI_SDR1_SER_DATA(x)                       DSPI_SDR1_SER_DATA(x)
+/*! @} */
+
+/*! @name ASDR1 - DSI Alternate Serialization Data Register 1 */
+/*! @{ */
+
+#define SPI_ASDR1_ASER_DATA_MASK                   DSPI_ASDR1_ASER_DATA_MASK
+#define SPI_ASDR1_ASER_DATA_SHIFT                  DSPI_ASDR1_ASER_DATA_SHIFT
+#define SPI_ASDR1_ASER_DATA_WIDTH                  DSPI_ASDR1_ASER_DATA_WIDTH
+#define SPI_ASDR1_ASER_DATA(x)                     DSPI_ASDR1_ASER_DATA(x)
+/*! @} */
+
+/*! @name COMPR1 - DSI Transmit Comparison Register 1 */
+/*! @{ */
+
+#define SPI_COMPR1_COMP_DATA_MASK                  DSPI_COMPR1_COMP_DATA_MASK
+#define SPI_COMPR1_COMP_DATA_SHIFT                 DSPI_COMPR1_COMP_DATA_SHIFT
+#define SPI_COMPR1_COMP_DATA_WIDTH                 DSPI_COMPR1_COMP_DATA_WIDTH
+#define SPI_COMPR1_COMP_DATA(x)                    DSPI_COMPR1_COMP_DATA(x)
+/*! @} */
+
+/*! @name DDR1 - DSI Deserialization Data Register 1 */
+/*! @{ */
+
+#define SPI_DDR1_DESER_DATA_MASK                   DSPI_DDR1_DESER_DATA_MASK
+#define SPI_DDR1_DESER_DATA_SHIFT                  DSPI_DDR1_DESER_DATA_SHIFT
+#define SPI_DDR1_DESER_DATA_WIDTH                  DSPI_DDR1_DESER_DATA_WIDTH
+#define SPI_DDR1_DESER_DATA(x)                     DSPI_DDR1_DESER_DATA(x)
+/*! @} */
+
+/*! @name SSR1 - DSI Serialization Source Select Register 1 */
+/*! @{ */
+
+#define SPI_SSR1_SS_MASK                           DSPI_SSR1_SS_MASK
+#define SPI_SSR1_SS_SHIFT                          DSPI_SSR1_SS_SHIFT
+#define SPI_SSR1_SS_WIDTH                          DSPI_SSR1_SS_WIDTH
+#define SPI_SSR1_SS(x)                             DSPI_SSR1_SS(x)
+/*! @} */
+
+/*! @name DIMR1 - DSI Deserialized Data Interrupt Mask Register 1 */
+/*! @{ */
+
+#define SPI_DIMR1_MASK_MASK                        DSPI_DIMR1_MASK_MASK
+#define SPI_DIMR1_MASK_SHIFT                       DSPI_DIMR1_MASK_SHIFT
+#define SPI_DIMR1_MASK_WIDTH                       DSPI_DIMR1_MASK_WIDTH
+#define SPI_DIMR1_MASK(x)                          DSPI_DIMR1_MASK(x)
+/*! @} */
+
+/*! @name DPIR1 - DSI Deserialized Data Polarity Interrupt Register 1 */
+/*! @{ */
+
+#define SPI_DPIR1_DP_MASK                          DSPI_DPIR1_DP_MASK
+#define SPI_DPIR1_DP_SHIFT                         DSPI_DPIR1_DP_SHIFT
+#define SPI_DPIR1_DP_WIDTH                         DSPI_DPIR1_DP_WIDTH
+#define SPI_DPIR1_DP(x)                            DSPI_DPIR1_DP(x)
+/*! @} */
+
+/*! @name CTARE - Clock and Transfer Attributes Register Extended */
+/*! @{ */
+
+#define SPI_CTARE_DTCP_MASK                        DSPI_CTARE_DTCP_MASK
+#define SPI_CTARE_DTCP_SHIFT                       DSPI_CTARE_DTCP_SHIFT
+#define SPI_CTARE_DTCP_WIDTH                       DSPI_CTARE_DTCP_WIDTH
+#define SPI_CTARE_DTCP(x)                          DSPI_CTARE_DTCP(x)
+
+#define SPI_CTARE_FMSZE_MASK                       DSPI_CTARE_FMSZE_MASK
+#define SPI_CTARE_FMSZE_SHIFT                      DSPI_CTARE_FMSZE_SHIFT
+#define SPI_CTARE_FMSZE_WIDTH                      DSPI_CTARE_FMSZE_WIDTH
+#define SPI_CTARE_FMSZE(x)                         DSPI_CTARE_FMSZE(x)
+/*! @} */
+
+/*! @name SREX - Status Register Extended */
+/*! @{ */
+
+#define SPI_SREX_CMDNXTPTR_MASK                    DSPI_SREX_CMDNXTPTR_MASK
+#define SPI_SREX_CMDNXTPTR_SHIFT                   DSPI_SREX_CMDNXTPTR_SHIFT
+#define SPI_SREX_CMDNXTPTR_WIDTH                   DSPI_SREX_CMDNXTPTR_WIDTH
+#define SPI_SREX_CMDNXTPTR(x)                      DSPI_SREX_CMDNXTPTR(x)
+
+#define SPI_SREX_CMDCTR_MASK                       DSPI_SREX_CMDCTR_MASK
+#define SPI_SREX_CMDCTR_SHIFT                      DSPI_SREX_CMDCTR_SHIFT
+#define SPI_SREX_CMDCTR_WIDTH                      DSPI_SREX_CMDCTR_WIDTH
+#define SPI_SREX_CMDCTR(x)                         DSPI_SREX_CMDCTR(x)
+
+#define SPI_SREX_RXCTR4_MASK                       DSPI_SREX_RXCTR4_MASK
+#define SPI_SREX_RXCTR4_SHIFT                      DSPI_SREX_RXCTR4_SHIFT
+#define SPI_SREX_RXCTR4_WIDTH                      DSPI_SREX_RXCTR4_WIDTH
+#define SPI_SREX_RXCTR4(x)                         DSPI_SREX_RXCTR4(x)
+
+#define SPI_SREX_TXCTR4_MASK                       DSPI_SREX_TXCTR4_MASK
+#define SPI_SREX_TXCTR4_SHIFT                      DSPI_SREX_TXCTR4_SHIFT
+#define SPI_SREX_TXCTR4_WIDTH                      DSPI_SREX_TXCTR4_WIDTH
+#define SPI_SREX_TXCTR4(x)                         DSPI_SREX_TXCTR4(x)
+/*! @} */
+
+/*! @name TSL - Time Slot Length Register */
+/*! @{ */
+
+#define SPI_TSL_TS0_LEN_MASK                       DSPI_TSL_TS0_LEN_MASK
+#define SPI_TSL_TS0_LEN_SHIFT                      DSPI_TSL_TS0_LEN_SHIFT
+#define SPI_TSL_TS0_LEN_WIDTH                      DSPI_TSL_TS0_LEN_WIDTH
+#define SPI_TSL_TS0_LEN(x)                         DSPI_TSL_TS0_LEN(x)
+
+#define SPI_TSL_TS1_LEN_MASK                       DSPI_TSL_TS1_LEN_MASK
+#define SPI_TSL_TS1_LEN_SHIFT                      DSPI_TSL_TS1_LEN_SHIFT
+#define SPI_TSL_TS1_LEN_WIDTH                      DSPI_TSL_TS1_LEN_WIDTH
+#define SPI_TSL_TS1_LEN(x)                         DSPI_TSL_TS1_LEN(x)
+
+#define SPI_TSL_TS2_LEN_MASK                       DSPI_TSL_TS2_LEN_MASK
+#define SPI_TSL_TS2_LEN_SHIFT                      DSPI_TSL_TS2_LEN_SHIFT
+#define SPI_TSL_TS2_LEN_WIDTH                      DSPI_TSL_TS2_LEN_WIDTH
+#define SPI_TSL_TS2_LEN(x)                         DSPI_TSL_TS2_LEN(x)
+
+#define SPI_TSL_TS3_LEN_MASK                       DSPI_TSL_TS3_LEN_MASK
+#define SPI_TSL_TS3_LEN_SHIFT                      DSPI_TSL_TS3_LEN_SHIFT
+#define SPI_TSL_TS3_LEN_WIDTH                      DSPI_TSL_TS3_LEN_WIDTH
+#define SPI_TSL_TS3_LEN(x)                         DSPI_TSL_TS3_LEN(x)
+/*! @} */
+
+/*! @name TS_CONF - Time Slot Configuration Register */
+/*! @{ */
+
+#define SPI_TS_CONF_TS0_MASK                       DSPI_TS_CONF_TS0_MASK
+#define SPI_TS_CONF_TS0_SHIFT                      DSPI_TS_CONF_TS0_SHIFT
+#define SPI_TS_CONF_TS0_WIDTH                      DSPI_TS_CONF_TS0_WIDTH
+#define SPI_TS_CONF_TS0(x)                         DSPI_TS_CONF_TS0(x)
+
+#define SPI_TS_CONF_TS1_MASK                       DSPI_TS_CONF_TS1_MASK
+#define SPI_TS_CONF_TS1_SHIFT                      DSPI_TS_CONF_TS1_SHIFT
+#define SPI_TS_CONF_TS1_WIDTH                      DSPI_TS_CONF_TS1_WIDTH
+#define SPI_TS_CONF_TS1(x)                         DSPI_TS_CONF_TS1(x)
+
+#define SPI_TS_CONF_TS2_MASK                       DSPI_TS_CONF_TS2_MASK
+#define SPI_TS_CONF_TS2_SHIFT                      DSPI_TS_CONF_TS2_SHIFT
+#define SPI_TS_CONF_TS2_WIDTH                      DSPI_TS_CONF_TS2_WIDTH
+#define SPI_TS_CONF_TS2(x)                         DSPI_TS_CONF_TS2(x)
+
+#define SPI_TS_CONF_TS3_MASK                       DSPI_TS_CONF_TS3_MASK
+#define SPI_TS_CONF_TS3_SHIFT                      DSPI_TS_CONF_TS3_SHIFT
+#define SPI_TS_CONF_TS3_WIDTH                      DSPI_TS_CONF_TS3_WIDTH
+#define SPI_TS_CONF_TS3(x)                         DSPI_TS_CONF_TS3(x)
+/*! @} */
+
+/* end of group DSPI_Register_Masks */
+
+/*!
+ * @}
+ */ /* end of group DSPI_Peripheral_Access_Layer */
 
 #endif /* _S32Z270_DEVICE_H_ */

--- a/s32/mcux/devices/S32Z270/S32Z270_features.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_features.h
@@ -222,4 +222,33 @@
 /* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
 #define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (8)
 
+/* DSPI module features */
+
+/* @brief DSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_DSPI_COUNT (1)
+/* @brief Receive/transmit FIFO size in number of items. */
+#define FSL_FEATURE_DSPI_FIFO_SIZEn(x) (16)
+/* @brief Maximum transfer data width in bits. */
+#define FSL_FEATURE_DSPI_MAX_DATA_WIDTH (16)
+/* @brief Maximum number of chip select pins. (Reflects the width of register bit field PUSHR[PCS].) */
+#define FSL_FEATURE_DSPI_MAX_CHIP_SELECT_COUNT (3)
+/* @brief Number of chip select pins. */
+#define FSL_FEATURE_DSPI_CHIP_SELECT_COUNT (3)
+/* @brief Number of CTAR registers. */
+#define FSL_FEATURE_DSPI_CTAR_COUNT (6)
+/* @brief Has chip select strobe capability on the PCS5 pin. */
+#define FSL_FEATURE_DSPI_HAS_CHIP_SELECT_STROBE (0)
+/* @brief Has separated TXDATA and CMD FIFOs (register SREX). */
+#define FSL_FEATURE_DSPI_HAS_SEPARATE_TXDATA_CMD_FIFO (0)
+/* @brief Has 16-bit data transfer support. */
+#define FSL_FEATURE_DSPI_16BIT_TRANSFERS (1)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_DSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Does not support Transmit FIFO Fill Flag (bitfield SR[TFUF]. */
+#define FSL_FEATURE_DSPI_HAS_NO_SR_TFUF_SUPPORT (1)
+/* @brief Does not support Transmit FIFO Underflow Request Enable (bitfield RSER[TFUF_RE]. */
+#define FSL_FEATURE_DSPI_HAS_NO_RSER_TFUF_RE_SUPPORT (1)
+/* @brief  Does not support Slave mode . */
+#define FSL_FEATURE_DSPI_HAS_NO_SLAVE_SUPPORT (1)
+
 #endif /* _S32Z270_FEATURES_H_ */

--- a/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
@@ -50,6 +50,18 @@
 #define I3C_IBIEXT2_EXT6(x)                     0
 #define I3C_IBIEXT2_EXT7(x)                     0
 
+/* SPI - Peripheral instance base addresses */
+/** Peripheral MSC_0_DSPI base address */
+#define SPI0_BASE                                  IP_MSC_0_DSPI_BASE
+/** Peripheral MSC_0_DSPI base pointer */
+#define SPI0                                       ((SPI_Type *)SPI0_BASE)
+/** Array initializer of DSPI peripheral base addresses */
+#define SPI_BASE_ADDRS                             { SPI0_BASE }
+/** Array initializer of DSPI peripheral base pointers */
+#define SPI_BASE_PTRS                              { SPI0 }
+
+#define SPI_IRQS                                   { RTU_MSC0_DSPI_IRQn }
+
 /* CAN - Peripheral instance base addresses */
 /** Peripheral CAN_0 base address */
 #define CAN0_BASE                                   IP_CE_CAN_0_BASE


### PR DESCRIPTION
This PR to add support dspi for s32z27x devices
Tested on tests\drivers\spi\spi_loopback\drivers.spi.s32z_dspi.loopback
------ TESTSUITE SUMMARY START ------
SUITE PASS - 100.00% [spi_loopback]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.366 seconds
PASS - [spi_loopback.test_spi_loopback] duration = 0.366 seconds
------ TESTSUITE SUMMARY END ------