### PR TITLE
Support edma3 for s32z270dc2

### DIFF
--- a/s32/README
+++ b/s32/README
@@ -67,3 +67,5 @@ Patch List for S32Z/E:
    - Clear the EOC flag before Adc_Sar_CheckAndCallEocNotification() is called to avoid the
      race condition that prevents the next end of conversion callback to be executed, when
      a conversion is started inside the previous end of conversion completed callback.
+   - Rename the DMAMUX_Type member CHCONF to CHCFG so that the MCUX DMA driver can be reused
+     for S32Z.

--- a/s32/drivers/s32ze/BaseNXP/header/S32Z2_DMAMUX.h
+++ b/s32/drivers/s32ze/BaseNXP/header/S32Z2_DMAMUX.h
@@ -73,7 +73,7 @@
 
 /** DMAMUX - Register Layout Typedef */
 typedef struct {
-  __IO uint8_t CHCONF[DMAMUX_CHCFG_COUNT];         /**< Channel Configuration, array offset: 0x0, array step: 0x1, irregular array, not all indices are valid */
+  __IO uint8_t CHCFG[DMAMUX_CHCFG_COUNT];         /**< Channel Configuration, array offset: 0x0, array step: 0x1, irregular array, not all indices are valid */
 } DMAMUX_Type, *DMAMUX_MemMapPtr;
 
 /** Number of instances of the DMAMUX module. */

--- a/s32/mcux/devices/S32Z270/S32Z270_device.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_device.h
@@ -1865,4 +1865,616 @@ typedef struct {
 /* The count of CAN_ERFFEL */
 #define CAN_ERFFEL_COUNT (128U)
 
+/* ----------------------------------------------------------------------------
+   -- DMA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup DMA_Peripheral_Access_Layer DMA Peripheral Access Layer
+ * @{
+ */
+
+/** DMA - Register Layout Typedef */
+typedef struct {
+    __IO uint32_t MP_CSR;                            /**< Management Page Control, offset: 0x0 */
+    __I  uint32_t MP_ES;                             /**< Management Page Error Status, offset: 0x4 */
+    __I  uint32_t MP_INT;                            /**< Management Page Interrupt Request Status, offset: 0x8 */
+    __I  uint32_t MP_HRS;                            /**< Management Page Hardware Request Status, offset: 0xC */
+         uint8_t RESERVED_0[240];
+    __IO uint32_t CH_GRPRI[32];                      /**< Channel Arbitration Group, array offset: 0x100, array step: 0x4 */
+         uint8_t RESERVED_1[196224];
+    struct {                                         /* offset: 0x10000, array step: 0x10000 */
+        __IO uint32_t CH_CSR;                            /**< Channel Control and Status, array offset: 0x0, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint32_t CH_ES;                             /**< Channel Error Status, array offset: 0x4, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint32_t CH_INT;                            /**< Channel Interrupt Status, array offset: 0x8, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint32_t CH_SBR;                            /**< Channel System Bus, array offset: 0xC, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint32_t CH_PRI;                            /**< Channel Priority, array offset: 0x10, array step: 0x10000, irregular array, not all indices are valid */
+        uint8_t RESERVED_0[12];
+        __IO uint32_t TCD_SADDR;                             /**< TCD Source Address, array offset: 0x20, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint16_t TCD_SOFF;                              /**< TCD Signed Source Address Offset, array offset: 0x24, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint16_t TCD_ATTR;                              /**< TCD Transfer Attributes, array offset: 0x26, array step: 0x10000, irregular array, not all indices are valid */
+        union {                                          /* offset: 0x1028, array step: 0x1000 */
+            __IO uint32_t TCD_NBYTES_MLOFFNO;                /**< TCD Transfer Size Without Minor Loop Offsets, array offset: 0x1028, array step: 0x1000, irregular array, not all indices are valid */
+            __IO uint32_t TCD_NBYTES_MLOFFYES;               /**< TCD Transfer Size with Minor Loop Offsets, array offset: 0x1028, array step: 0x1000, irregular array, not all indices are valid */
+        };
+        __IO uint32_t TCD_SLAST_SDA;                         /**< TCD Last Source Address Adjustment / Store DADDR Address, array offset: 0x2C, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint32_t TCD_DADDR;                             /**< TCD Destination Address, array offset: 0x30, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint16_t TCD_DOFF;                              /**< TCD Signed Destination Address Offset, array offset: 0x34, array step: 0x10000, irregular array, not all indices are valid */
+        union {                                          /* offset: 0x1036, array step: 0x1000 */
+            __IO uint16_t TCD_CITER_ELINKNO;                 /**< TCD Current Major Loop Count (Minor Loop Channel Linking Disabled), array offset: 0x1036, array step: 0x1000, irregular array, not all indices are valid */
+            __IO uint16_t TCD_CITER_ELINKYES;                /**< TCD Current Major Loop Count (Minor Loop Channel Linking Enabled), array offset: 0x1036, array step: 0x1000, irregular array, not all indices are valid */
+        };
+        __IO uint32_t TCD_DLAST_SGA;                         /**< TCD Last Destination Address Adjustment / Scatter Gather Address, array offset: 0x38, array step: 0x10000, irregular array, not all indices are valid */
+        __IO uint16_t TCD_CSR;                               /**< TCD Control and Status, array offset: 0x3C, array step: 0x10000, irregular array, not all indices are valid */
+        union {                                          /* offset: 0x103E, array step: 0x1000 */
+            __IO uint16_t TCD_BITER_ELINKNO;                 /**< TCD Beginning Major Loop Count (Minor Loop Channel Linking Disabled), array offset: 0x103E, array step: 0x1000, irregular array, not all indices are valid */
+            __IO uint16_t TCD_BITER_ELINKYES;                /**< TCD Beginning Major Loop Count (Minor Loop Channel Linking Enabled), array offset: 0x103E, array step: 0x1000, irregular array, not all indices are valid */
+        };
+        uint8_t RESERVED_1[65472];
+    } CH[32];
+} DMA_Type;
+
+/* ----------------------------------------------------------------------------
+   -- EDMA3_MP Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EDMA3_MP_Register_Masks EDMA3_MP Register Masks
+ * @{
+ */
+
+/*! @name CSR - Management Page Control */
+/*! @{ */
+
+#define DMA_MP_CSR_EDBG_MASK                       EDMA3_MP_CSR_EDBG_MASK
+#define DMA_MP_CSR_EDBG_SHIFT                      EDMA3_MP_CSR_EDBG_SHIFT
+#define DMA_MP_CSR_EDBG_WIDTH                      EDMA3_MP_CSR_EDBG_WIDTH
+#define DMA_MP_CSR_EDBG(x)                         EDMA3_MP_CSR_EDBG(x)
+
+#define DMA_MP_CSR_ERCA_MASK                       EDMA3_MP_CSR_ERCA_MASK
+#define DMA_MP_CSR_ERCA_SHIFT                      EDMA3_MP_CSR_ERCA_SHIFT
+#define DMA_MP_CSR_ERCA_WIDTH                      EDMA3_MP_CSR_ERCA_WIDTH
+#define DMA_MP_CSR_ERCA(x)                         EDMA3_MP_CSR_ERCA(x)
+
+#define DMA_MP_CSR_HAE_MASK                        EDMA3_MP_CSR_HAE_MASK
+#define DMA_MP_CSR_HAE_SHIFT                       EDMA3_MP_CSR_HAE_SHIFT
+#define DMA_MP_CSR_HAE_WIDTH                       EDMA3_MP_CSR_HAE_WIDTH
+#define DMA_MP_CSR_HAE(x)                          EDMA3_MP_CSR_HAE(x)
+
+#define DMA_MP_CSR_HALT_MASK                       EDMA3_MP_CSR_HALT_MASK
+#define DMA_MP_CSR_HALT_SHIFT                      EDMA3_MP_CSR_HALT_SHIFT
+#define DMA_MP_CSR_HALT_WIDTH                      EDMA3_MP_CSR_HALT_WIDTH
+#define DMA_MP_CSR_HALT(x)                         EDMA3_MP_CSR_HALT(x)
+
+#define DMA_MP_CSR_GCLC_MASK                       EDMA3_MP_CSR_GCLC_MASK
+#define DMA_MP_CSR_GCLC_SHIFT                      EDMA3_MP_CSR_GCLC_SHIFT
+#define DMA_MP_CSR_GCLC_WIDTH                      EDMA3_MP_CSR_GCLC_WIDTH
+#define DMA_MP_CSR_GCLC(x)                         EDMA3_MP_CSR_GCLC(x)
+
+#define DMA_MP_CSR_GMRC_MASK                       EDMA3_MP_CSR_GMRC_MASK
+#define DMA_MP_CSR_GMRC_SHIFT                      EDMA3_MP_CSR_GMRC_SHIFT
+#define DMA_MP_CSR_GMRC_WIDTH                      EDMA3_MP_CSR_GMRC_WIDTH
+#define DMA_MP_CSR_GMRC(x)                         EDMA3_MP_CSR_GMRC(x)
+
+#define DMA_MP_CSR_ECX_MASK                        EDMA3_MP_CSR_ECX_MASK
+#define DMA_MP_CSR_ECX_SHIFT                       EDMA3_MP_CSR_ECX_SHIFT
+#define DMA_MP_CSR_ECX_WIDTH                       EDMA3_MP_CSR_ECX_WIDTH
+#define DMA_MP_CSR_ECX(x)                          EDMA3_MP_CSR_ECX(x)
+
+#define DMA_MP_CSR_CX_MASK                         EDMA3_MP_CSR_CX_MASK
+#define DMA_MP_CSR_CX_SHIFT                        EDMA3_MP_CSR_CX_SHIFT
+#define DMA_MP_CSR_CX_WIDTH                        EDMA3_MP_CSR_CX_WIDTH
+#define DMA_MP_CSR_CX(x)                           EDMA3_MP_CSR_CX(x)
+
+#define DMA_MP_CSR_ACTIVE_ID_MASK                  EDMA3_MP_CSR_ACTIVE_ID_MASK
+#define DMA_MP_CSR_ACTIVE_ID_SHIFT                 EDMA3_MP_CSR_ACTIVE_ID_SHIFT
+#define DMA_MP_CSR_ACTIVE_ID_WIDTH                 EDMA3_MP_CSR_ACTIVE_ID_WIDTH
+#define DMA_MP_CSR_ACTIVE_ID(x)                    EDMA3_MP_CSR_ACTIVE_ID(x)
+
+#define DMA_MP_CSR_ACTIVE_MASK                     EDMA3_MP_CSR_ACTIVE_MASK
+#define DMA_MP_CSR_ACTIVE_SHIFT                    EDMA3_MP_CSR_ACTIVE_SHIFT
+#define DMA_MP_CSR_ACTIVE_WIDTH                    EDMA3_MP_CSR_ACTIVE_WIDTH
+#define DMA_MP_CSR_ACTIVE(x)                       EDMA3_MP_CSR_ACTIVE(x)
+
+#define DMA_MP_CSR_EBW_MASK                        EDMA3_TCD_CH_CSR_EBW_MASK
+#define DMA_MP_CSR_EBW_SHIFT                       EDMA3_TCD_CH_CSR_EBW_SHIFT
+#define DMA_MP_CSR_EBW_WIDTH                       EDMA3_TCD_CH_CSR_EBW_WIDTH
+#define DMA_MP_CSR_EBW(x)                          EDMA3_TCD_CH_CSR_EBW(x)
+/*! @} */
+
+/*! @name ES - Management Page Error Status */
+/*! @{ */
+
+#define DMA_MP_ES_DBE_MASK                         EDMA3_MP_ES_DBE_MASK
+#define DMA_MP_ES_DBE_SHIFT                        EDMA3_MP_ES_DBE_SHIFT
+#define DMA_MP_ES_DBE_WIDTH                        EDMA3_MP_ES_DBE_WIDTH
+#define DMA_MP_ES_DBE(x)                           EDMA3_MP_ES_DBE(x)
+
+#define DMA_MP_ES_SBE_MASK                         EDMA3_MP_ES_SBE_MASK
+#define DMA_MP_ES_SBE_SHIFT                        EDMA3_MP_ES_SBE_SHIFT
+#define DMA_MP_ES_SBE_WIDTH                        EDMA3_MP_ES_SBE_WIDTH
+#define DMA_MP_ES_SBE(x)                           EDMA3_MP_ES_SBE(x)
+
+#define DMA_MP_ES_SGE_MASK                         EDMA3_MP_ES_SGE_MASK
+#define DMA_MP_ES_SGE_SHIFT                        EDMA3_MP_ES_SGE_SHIFT
+#define DMA_MP_ES_SGE_WIDTH                        EDMA3_MP_ES_SGE_WIDTH
+#define DMA_MP_ES_SGE(x)                           EDMA3_MP_ES_SGE(x)
+
+#define DMA_MP_ES_NCE_MASK                         EDMA3_MP_ES_NCE_MASK
+#define DMA_MP_ES_NCE_SHIFT                        EDMA3_MP_ES_NCE_SHIFT
+#define DMA_MP_ES_NCE_WIDTH                        EDMA3_MP_ES_NCE_WIDTH
+#define DMA_MP_ES_NCE(x)                           EDMA3_MP_ES_NCE(x)
+
+#define DMA_MP_ES_DOE_MASK                         EDMA3_MP_ES_DOE_MASK
+#define DMA_MP_ES_DOE_SHIFT                        EDMA3_MP_ES_DOE_SHIFT
+#define DMA_MP_ES_DOE_WIDTH                        EDMA3_MP_ES_DOE_WIDTH
+#define DMA_MP_ES_DOE(x)                           EDMA3_MP_ES_DOE(x)
+
+#define DMA_MP_ES_DAE_MASK                         EDMA3_MP_ES_DAE_MASK
+#define DMA_MP_ES_DAE_SHIFT                        EDMA3_MP_ES_DAE_SHIFT
+#define DMA_MP_ES_DAE_WIDTH                        EDMA3_MP_ES_DAE_WIDTH
+#define DMA_MP_ES_DAE(x)                           EDMA3_MP_ES_DAE(x)
+
+#define DMA_MP_ES_SOE_MASK                         EDMA3_MP_ES_SOE_MASK
+#define DMA_MP_ES_SOE_SHIFT                        EDMA3_MP_ES_SOE_SHIFT
+#define DMA_MP_ES_SOE_WIDTH                        EDMA3_MP_ES_SOE_WIDTH
+#define DMA_MP_ES_SOE(x)                           EDMA3_MP_ES_SOE(x)
+
+#define DMA_MP_ES_SAE_MASK                         EDMA3_MP_ES_SAE_MASK
+#define DMA_MP_ES_SAE_SHIFT                        EDMA3_MP_ES_SAE_SHIFT
+#define DMA_MP_ES_SAE_WIDTH                        EDMA3_MP_ES_SAE_WIDTH
+#define DMA_MP_ES_SAE(x)                           EDMA3_MP_ES_SAE(x)
+
+#define DMA_MP_ES_ECX_MASK                         EDMA3_MP_ES_ECX_MASK
+#define DMA_MP_ES_ECX_SHIFT                        EDMA3_MP_ES_ECX_SHIFT
+#define DMA_MP_ES_ECX_WIDTH                        EDMA3_MP_ES_ECX_WIDTH
+#define DMA_MP_ES_ECX(x)                           EDMA3_MP_ES_ECX(x)
+
+#define DMA_MP_ES_UCE_MASK                         EDMA3_MP_ES_UCE_MASK
+#define DMA_MP_ES_UCE_SHIFT                        EDMA3_MP_ES_UCE_SHIFT
+#define DMA_MP_ES_UCE_WIDTH                        EDMA3_MP_ES_UCE_WIDTH
+#define DMA_MP_ES_UCE(x)                           EDMA3_MP_ES_UCE(x)
+
+#define DMA_MP_ES_ERRCHN_MASK                      EDMA3_MP_ES_ERRCHN_MASK
+#define DMA_MP_ES_ERRCHN_SHIFT                     EDMA3_MP_ES_ERRCHN_SHIFT
+#define DMA_MP_ES_ERRCHN_WIDTH                     EDMA3_MP_ES_ERRCHN_WIDTH
+#define DMA_MP_ES_ERRCHN(x)                        EDMA3_MP_ES_ERRCHN(x)
+
+#define DMA_MP_ES_VLD_MASK                         EDMA3_MP_ES_VLD_MASK
+#define DMA_MP_ES_VLD_SHIFT                        EDMA3_MP_ES_VLD_SHIFT
+#define DMA_MP_ES_VLD_WIDTH                        EDMA3_MP_ES_VLD_WIDTH
+#define DMA_MP_ES_VLD(x)                           EDMA3_MP_ES_VLD(x)
+/*! @} */
+
+/*! @name INT - Management Page Interrupt Request Status */
+/*! @{ */
+
+#define DMA_MP_INT_INT_MASK                        EDMA3_MP_INT_INT_MASK
+#define DMA_MP_INT_INT_SHIFT                       EDMA3_MP_INT_INT_SHIFT
+#define DMA_MP_INT_INT_WIDTH                       EDMA3_MP_INT_INT_WIDTH
+#define DMA_MP_INT_INT(x)                          EDMA3_MP_INT_INT(x)
+/*! @} */
+
+/*! @name HRS - Management Page Hardware Request Status */
+/*! @{ */
+
+#define DMA_MP_HRS_HRS_MASK                        EDMA3_MP_HRS_HRS_MASK
+#define DMA_MP_HRS_HRS_SHIFT                       EDMA3_MP_HRS_HRS_SHIFT
+#define DMA_MP_HRS_HRS_WIDTH                       EDMA3_MP_HRS_HRS_WIDTH
+#define DMA_MP_HRS_HRS(x)                          EDMA3_MP_HRS_HRS(x)
+/*! @} */
+
+/*! @name CH_GRPRI - Channel Arbitration Group */
+/*! @{ */
+
+#define DMA_CH_GRPRI_GRPRI_MASK                 EDMA3_MP_CH_GRPRI_GRPRI_MASK
+#define DMA_CH_GRPRI_GRPRI_SHIFT                EDMA3_MP_CH_GRPRI_GRPRI_SHIFT
+#define DMA_CH_GRPRI_GRPRI_WIDTH                EDMA3_MP_CH_GRPRI_GRPRI_WIDTH
+#define DMA_CH_GRPRI_GRPRI(x)                   EDMA3_MP_CH_GRPRI_GRPRI(x)
+/*! @} */
+
+/*!
+ * @}
+ */ /* end of group EDMA3_MP_Register_Masks */
+
+/* ----------------------------------------------------------------------------
+   -- EDMA3_TCD Register Masks
+   ---------------------------------------------------------------------------- */
+
+/*!
+ * @addtogroup EDMA3_TCD_Register_Masks EDMA3_TCD Register Masks
+ * @{
+ */
+
+/*! @name CH_CSR - Channel Control and Status */
+/*! @{ */
+
+#define DMA_CH_CSR_ERQ_MASK                        EDMA3_TCD_CH_CSR_ERQ_MASK
+#define DMA_CH_CSR_ERQ_SHIFT                       EDMA3_TCD_CH_CSR_ERQ_SHIFT
+#define DMA_CH_CSR_ERQ_WIDTH                       EDMA3_TCD_CH_CSR_ERQ_WIDTH
+#define DMA_CH_CSR_ERQ(x)                          EDMA3_TCD_CH_CSR_ERQ(x)
+
+#define DMA_CH_CSR_EARQ_MASK                       EDMA3_TCD_CH_CSR_EARQ_MASK
+#define DMA_CH_CSR_EARQ_SHIFT                      EDMA3_TCD_CH_CSR_EARQ_SHIFT
+#define DMA_CH_CSR_EARQ_WIDTH                      EDMA3_TCD_CH_CSR_EARQ_WIDTH
+#define DMA_CH_CSR_EARQ(x)                         EDMA3_TCD_CH_CSR_EARQ(x)
+
+#define DMA_CH_CSR_EEI_MASK                        EDMA3_TCD_CH_CSR_EEI_MASK
+#define DMA_CH_CSR_EEI_SHIFT                       EDMA3_TCD_CH_CSR_EEI_SHIFT
+#define DMA_CH_CSR_EEI_WIDTH                       EDMA3_TCD_CH_CSR_EEI_WIDTH
+#define DMA_CH_CSR_EEI(x)                          EDMA3_TCD_CH_CSR_EEI(x)
+
+#define DMA_CH_CSR_EBW_MASK                        EDMA3_TCD_CH_CSR_EBW_MASK
+#define DMA_CH_CSR_EBW_SHIFT                       EDMA3_TCD_CH_CSR_EBW_SHIFT
+#define DMA_CH_CSR_EBW_WIDTH                       EDMA3_TCD_CH_CSR_EBW_WIDTH
+#define DMA_CH_CSR_EBW(x)                          EDMA3_TCD_CH_CSR_EBW(x)
+
+#define DMA_CH_CSR_DONE_MASK                       EDMA3_TCD_CH_CSR_DONE_MASK
+#define DMA_CH_CSR_DONE_SHIFT                      EDMA3_TCD_CH_CSR_DONE_SHIFT
+#define DMA_CH_CSR_DONE_WIDTH                      EDMA3_TCD_CH_CSR_DONE_WIDTH
+#define DMA_CH_CSR_DONE(x)                         EDMA3_TCD_CH_CSR_DONE(x)
+
+#define DMA_CH_CSR_ACTIVE_MASK                     EDMA3_TCD_CH_CSR_ACTIVE_MASK
+#define DMA_CH_CSR_ACTIVE_SHIFT                    EDMA3_TCD_CH_CSR_ACTIVE_SHIFT
+#define DMA_CH_CSR_ACTIVE_WIDTH                    EDMA3_TCD_CH_CSR_ACTIVE_WIDTH
+#define DMA_CH_CSR_ACTIVE(x)                       EDMA3_TCD_CH_CSR_ACTIVE(x)
+/*! @} */
+
+/*! @name CH_ES - Channel Error Status */
+/*! @{ */
+
+#define DMA_CH_ES_DBE_MASK                         EDMA3_TCD_CH_ES_DBE_MASK
+#define DMA_CH_ES_DBE_SHIFT                        EDMA3_TCD_CH_ES_DBE_SHIFT
+#define DMA_CH_ES_DBE_WIDTH                        EDMA3_TCD_CH_ES_DBE_WIDTH
+#define DMA_CH_ES_DBE(x)                           EDMA3_TCD_CH_ES_DBE(x)
+
+#define DMA_CH_ES_SBE_MASK                         EDMA3_TCD_CH_ES_SBE_MASK
+#define DMA_CH_ES_SBE_SHIFT                        EDMA3_TCD_CH_ES_SBE_SHIFT
+#define DMA_CH_ES_SBE_WIDTH                        EDMA3_TCD_CH_ES_SBE_WIDTH
+#define DMA_CH_ES_SBE(x)                           EDMA3_TCD_CH_ES_SBE(x)
+
+#define DMA_CH_ES_SGE_MASK                         EDMA3_TCD_CH_ES_SGE_MASK
+#define DMA_CH_ES_SGE_SHIFT                        EDMA3_TCD_CH_ES_SGE_SHIFT
+#define DMA_CH_ES_SGE_WIDTH                        EDMA3_TCD_CH_ES_SGE_WIDTH
+#define DMA_CH_ES_SGE(x)                           EDMA3_TCD_CH_ES_SGE(x)
+
+#define DMA_CH_ES_NCE_MASK                         EDMA3_TCD_CH_ES_NCE_MASK
+#define DMA_CH_ES_NCE_SHIFT                        EDMA3_TCD_CH_ES_NCE_SHIFT
+#define DMA_CH_ES_NCE_WIDTH                        EDMA3_TCD_CH_ES_NCE_WIDTH
+#define DMA_CH_ES_NCE(x)                           EDMA3_TCD_CH_ES_NCE(x)
+
+#define DMA_CH_ES_DOE_MASK                         EDMA3_TCD_CH_ES_DOE_MASK
+#define DMA_CH_ES_DOE_SHIFT                        EDMA3_TCD_CH_ES_DOE_SHIFT
+#define DMA_CH_ES_DOE_WIDTH                        EDMA3_TCD_CH_ES_DOE_WIDTH
+#define DMA_CH_ES_DOE(x)                           EDMA3_TCD_CH_ES_DOE(x)
+
+#define DMA_CH_ES_DAE_MASK                         EDMA3_TCD_CH_ES_DAE_MASK
+#define DMA_CH_ES_DAE_SHIFT                        EDMA3_TCD_CH_ES_DAE_SHIFT
+#define DMA_CH_ES_DAE_WIDTH                        EDMA3_TCD_CH_ES_DAE_WIDTH
+#define DMA_CH_ES_DAE(x)                           EDMA3_TCD_CH_ES_DAE(x)
+
+#define DMA_CH_ES_SOE_MASK                         EDMA3_TCD_CH_ES_SOE_MASK
+#define DMA_CH_ES_SOE_SHIFT                        EDMA3_TCD_CH_ES_SOE_SHIFT
+#define DMA_CH_ES_SOE_WIDTH                        EDMA3_TCD_CH_ES_SOE_WIDTH
+#define DMA_CH_ES_SOE(x)                           EDMA3_TCD_CH_ES_SOE(x)
+
+#define DMA_CH_ES_SAE_MASK                         EDMA3_TCD_CH_ES_SAE_MASK
+#define DMA_CH_ES_SAE_SHIFT                        EDMA3_TCD_CH_ES_SAE_SHIFT
+#define DMA_CH_ES_SAE_WIDTH                        EDMA3_TCD_CH_ES_SAE_WIDTH
+#define DMA_CH_ES_SAE(x)                           EDMA3_TCD_CH_ES_SAE(x)
+
+#define DMA_CH_ES_ERR_MASK                         EDMA3_TCD_CH_ES_ERR_MASK
+#define DMA_CH_ES_ERR_SHIFT                        EDMA3_TCD_CH_ES_ERR_SHIFT
+#define DMA_CH_ES_ERR_WIDTH                        EDMA3_TCD_CH_ES_ERR_WIDTH
+#define DMA_CH_ES_ERR(x)                           EDMA3_TCD_CH_ES_ERR(x)
+/*! @} */
+
+/*! @name CH_INT - Channel Interrupt Status */
+/*! @{ */
+
+#define DMA_CH_INT_INT_MASK                        EDMA3_TCD_CH_INT_INT_MASK
+#define DMA_CH_INT_INT_SHIFT                       EDMA3_TCD_CH_INT_INT_SHIFT
+#define DMA_CH_INT_INT_WIDTH                       EDMA3_TCD_CH_INT_INT_WIDTH
+#define DMA_CH_INT_INT(x)                          EDMA3_TCD_CH_INT_INT(x)
+/*! @} */
+
+/*! @name CH_SBR - Channel System Bus */
+/*! @{ */
+
+#define DMA_CH_SBR_MID_MASK                        EDMA3_TCD_CH_SBR_MID_MASK
+#define DMA_CH_SBR_MID_SHIFT                       EDMA3_TCD_CH_SBR_MID_SHIFT
+#define DMA_CH_SBR_MID_WIDTH                       EDMA3_TCD_CH_SBR_MID_WIDTH
+#define DMA_CH_SBR_MID(x)                          EDMA3_TCD_CH_SBR_MID(x)
+
+#define DMA_CH_SBR_PAL_MASK                        EDMA3_TCD_CH_SBR_PAL_MASK
+#define DMA_CH_SBR_PAL_SHIFT                       EDMA3_TCD_CH_SBR_PAL_SHIFT
+#define DMA_CH_SBR_PAL_WIDTH                       EDMA3_TCD_CH_SBR_PAL_WIDTH
+#define DMA_CH_SBR_PAL(x)                          EDMA3_TCD_CH_SBR_PAL(x)
+
+#define DMA_CH_SBR_EMI_MASK                        EDMA3_TCD_CH_SBR_EMI_MASK
+#define DMA_CH_SBR_EMI_SHIFT                       EDMA3_TCD_CH_SBR_EMI_SHIFT
+#define DMA_CH_SBR_EMI_WIDTH                       EDMA3_TCD_CH_SBR_EMI_WIDTH
+#define DMA_CH_SBR_EMI(x)                          EDMA3_TCD_CH_SBR_EMI(x)
+
+#define DMA_CH_SBR_ATTR_MASK                       EDMA3_TCD_CH_SBR_ATTR_MASK
+#define DMA_CH_SBR_ATTR_SHIFT                      EDMA3_TCD_CH_SBR_ATTR_SHIFT
+#define DMA_CH_SBR_ATTR_WIDTH                      EDMA3_TCD_CH_SBR_ATTR_WIDTH
+#define DMA_CH_SBR_ATTR(x)                         EDMA3_TCD_CH_SBR_ATTR(x)
+/*! @} */
+
+/*! @name CH_PRI - Channel Priority */
+/*! @{ */
+
+#define DMA_CH_PRI_APL_MASK                        EDMA3_TCD_CH_PRI_APL_MASK
+#define DMA_CH_PRI_APL_SHIFT                       EDMA3_TCD_CH_PRI_APL_SHIFT
+#define DMA_CH_PRI_APL_WIDTH                       EDMA3_TCD_CH_PRI_APL_WIDTH
+#define DMA_CH_PRI_APL(x)                          EDMA3_TCD_CH_PRI_APL(x)
+
+#define DMA_CH_PRI_DPA_MASK                        EDMA3_TCD_CH_PRI_DPA_MASK
+#define DMA_CH_PRI_DPA_SHIFT                       EDMA3_TCD_CH_PRI_DPA_SHIFT
+#define DMA_CH_PRI_DPA_WIDTH                       EDMA3_TCD_CH_PRI_DPA_WIDTH
+#define DMA_CH_PRI_DPA(x)                          EDMA3_TCD_CH_PRI_DPA(x)
+
+#define DMA_CH_PRI_ECP_MASK                        EDMA3_TCD_CH_PRI_ECP_MASK
+#define DMA_CH_PRI_ECP_SHIFT                       EDMA3_TCD_CH_PRI_ECP_SHIFT
+#define DMA_CH_PRI_ECP_WIDTH                       EDMA3_TCD_CH_PRI_ECP_WIDTH
+#define DMA_CH_PRI_ECP(x)                          EDMA3_TCD_CH_PRI_ECP(x)
+/*! @} */
+
+/*! @name SADDR - TCD Source Address */
+/*! @{ */
+
+#define DMA_TCD_SADDR_SADDR_MASK                   EDMA3_TCD_SADDR_SADDR_MASK
+#define DMA_TCD_SADDR_SADDR_SHIFT                  EDMA3_TCD_SADDR_SADDR_SHIFT
+#define DMA_TCD_SADDR_SADDR_WIDTH                  EDMA3_TCD_SADDR_SADDR_WIDTH
+#define DMA_TCD_SADDR_SADDR(x)                     EDMA3_TCD_SADDR_SADDR(x)
+/*! @} */
+
+/*! @name SOFF - TCD Signed Source Address Offset */
+/*! @{ */
+
+#define DMA_TCD_SOFF_SOFF_MASK                     EDMA3_TCD_SOFF_SOFF_MASK
+#define DMA_TCD_SOFF_SOFF_SHIFT                    EDMA3_TCD_SOFF_SOFF_SHIFT
+#define DMA_TCD_SOFF_SOFF_WIDTH                    EDMA3_TCD_SOFF_SOFF_WIDTH
+#define DMA_TCD_SOFF_SOFF(x)                       EDMA3_TCD_SOFF_SOFF(x)
+/*! @} */
+
+/*! @name ATTR - TCD Transfer Attributes */
+/*! @{ */
+
+#define DMA_TCD_ATTR_DSIZE_MASK                    EDMA3_TCD_ATTR_DSIZE_MASK
+#define DMA_TCD_ATTR_DSIZE_SHIFT                   EDMA3_TCD_ATTR_DSIZE_SHIFT
+#define DMA_TCD_ATTR_DSIZE_WIDTH                   EDMA3_TCD_ATTR_DSIZE_WIDTH
+#define DMA_TCD_ATTR_DSIZE(x)                      EDMA3_TCD_ATTR_DSIZE(x)
+
+#define DMA_TCD_ATTR_DMOD_MASK                     EDMA3_TCD_ATTR_DMOD_MASK
+#define DMA_TCD_ATTR_DMOD_SHIFT                    EDMA3_TCD_ATTR_DMOD_SHIFT
+#define DMA_TCD_ATTR_DMOD_WIDTH                    EDMA3_TCD_ATTR_DMOD_WIDTH
+#define DMA_TCD_ATTR_DMOD(x)                       EDMA3_TCD_ATTR_DMOD(x)
+
+#define DMA_TCD_ATTR_SSIZE_MASK                    EDMA3_TCD_ATTR_SSIZE_MASK
+#define DMA_TCD_ATTR_SSIZE_SHIFT                   EDMA3_TCD_ATTR_SSIZE_SHIFT
+#define DMA_TCD_ATTR_SSIZE_WIDTH                   EDMA3_TCD_ATTR_SSIZE_WIDTH
+#define DMA_TCD_ATTR_SSIZE(x)                      EDMA3_TCD_ATTR_SSIZE(x)
+
+#define DMA_TCD_ATTR_SMOD_MASK                     EDMA3_TCD_ATTR_SMOD_MASK
+#define DMA_TCD_ATTR_SMOD_SHIFT                    EDMA3_TCD_ATTR_SMOD_SHIFT
+#define DMA_TCD_ATTR_SMOD_WIDTH                    EDMA3_TCD_ATTR_SMOD_WIDTH
+#define DMA_TCD_ATTR_SMOD(x)                       EDMA3_TCD_ATTR_SMOD(x)
+/*! @} */
+
+/*! @name NBYTES_MLOFFNO - TCD Transfer Size Without Minor Loop Offsets */
+/*! @{ */
+
+#define DMA_TCD_NBYTES_MLOFFNO_NBYTES_MASK         EDMA3_TCD_NBYTES_MLOFFNO_NBYTES_MASK
+#define DMA_TCD_NBYTES_MLOFFNO_NBYTES_SHIFT        EDMA3_TCD_NBYTES_MLOFFNO_NBYTES_SHIFT
+#define DMA_TCD_NBYTES_MLOFFNO_NBYTES_WIDTH        EDMA3_TCD_NBYTES_MLOFFNO_NBYTES_WIDTH
+#define DMA_TCD_NBYTES_MLOFFNO_NBYTES(x)           EDMA3_TCD_NBYTES_MLOFFNO_NBYTES(x)
+
+#define DMA_TCD_NBYTES_MLOFFNO_DMLOE_MASK          EDMA3_TCD_NBYTES_MLOFFNO_DMLOE_MASK
+#define DMA_TCD_NBYTES_MLOFFNO_DMLOE_SHIFT         EDMA3_TCD_NBYTES_MLOFFNO_DMLOE_SHIFT
+#define DMA_TCD_NBYTES_MLOFFNO_DMLOE_WIDTH         EDMA3_TCD_NBYTES_MLOFFNO_DMLOE_WIDTH
+#define DMA_TCD_NBYTES_MLOFFNO_DMLOE(x)            EDMA3_TCD_NBYTES_MLOFFNO_DMLOE(x)
+
+#define DMA_TCD_NBYTES_MLOFFNO_SMLOE_MASK          EDMA3_TCD_NBYTES_MLOFFNO_SMLOE_MASK
+#define DMA_TCD_NBYTES_MLOFFNO_SMLOE_SHIFT         EDMA3_TCD_NBYTES_MLOFFNO_SMLOE_SHIFT
+#define DMA_TCD_NBYTES_MLOFFNO_SMLOE_WIDTH         EDMA3_TCD_NBYTES_MLOFFNO_SMLOE_WIDTH
+#define DMA_TCD_NBYTES_MLOFFNO_SMLOE(x)            EDMA3_TCD_NBYTES_MLOFFNO_SMLOE(x)
+/*! @} */
+
+/*! @name NBYTES_MLOFFYES - TCD Transfer Size with Minor Loop Offsets */
+/*! @{ */
+
+#define DMA_TCD_NBYTES_MLOFFYES_NBYTES_MASK        EDMA3_TCD_NBYTES_MLOFFYES_NBYTES_MASK
+#define DMA_TCD_NBYTES_MLOFFYES_NBYTES_SHIFT       EDMA3_TCD_NBYTES_MLOFFYES_NBYTES_SHIFT
+#define DMA_TCD_NBYTES_MLOFFYES_NBYTES_WIDTH       EDMA3_TCD_NBYTES_MLOFFYES_NBYTES_WIDTH
+#define DMA_TCD_NBYTES_MLOFFYES_NBYTES(x)          EDMA3_TCD_NBYTES_MLOFFYES_NBYTES(x)
+
+#define DMA_TCD_NBYTES_MLOFFYES_MLOFF_MASK         EDMA3_TCD_NBYTES_MLOFFYES_MLOFF_MASK
+#define DMA_TCD_NBYTES_MLOFFYES_MLOFF_SHIFT        EDMA3_TCD_NBYTES_MLOFFYES_MLOFF_SHIFT
+#define DMA_TCD_NBYTES_MLOFFYES_MLOFF_WIDTH        EDMA3_TCD_NBYTES_MLOFFYES_MLOFF_WIDTH
+#define DMA_TCD_NBYTES_MLOFFYES_MLOFF(x)           EDMA3_TCD_NBYTES_MLOFFYES_MLOFF(x)
+
+#define DMA_TCD_NBYTES_MLOFFYES_DMLOE_MASK         EDMA3_TCD_NBYTES_MLOFFYES_DMLOE_MASK
+#define DMA_TCD_NBYTES_MLOFFYES_DMLOE_SHIFT        EDMA3_TCD_NBYTES_MLOFFYES_DMLOE_SHIFT
+#define DMA_TCD_NBYTES_MLOFFYES_DMLOE_WIDTH        EDMA3_TCD_NBYTES_MLOFFYES_DMLOE_WIDTH
+#define DMA_TCD_NBYTES_MLOFFYES_DMLOE(x)           EDMA3_TCD_NBYTES_MLOFFYES_DMLOE(x)
+
+#define DMA_TCD_NBYTES_MLOFFYES_SMLOE_MASK         EDMA3_TCD_NBYTES_MLOFFYES_SMLOE_MASK
+#define DMA_TCD_NBYTES_MLOFFYES_SMLOE_SHIFT        EDMA3_TCD_NBYTES_MLOFFYES_SMLOE_SHIFT
+#define DMA_TCD_NBYTES_MLOFFYES_SMLOE_WIDTH        EDMA3_TCD_NBYTES_MLOFFYES_SMLOE_WIDTH
+#define DMA_TCD_NBYTES_MLOFFYES_SMLOE(x)           EDMA3_TCD_NBYTES_MLOFFYES_SMLOE(x)
+/*! @} */
+
+/*! @name SLAST_SDA - TCD Last Source Address Adjustment / Store DADDR Address */
+/*! @{ */
+
+#define DMA_TCD_SLAST_SDA_SLAST_SDA_MASK           EDMA3_TCD_SLAST_SDA_SLAST_SDA_MASK
+#define DMA_TCD_SLAST_SDA_SLAST_SDA_SHIFT          EDMA3_TCD_SLAST_SDA_SLAST_SDA_SHIFT
+#define DMA_TCD_SLAST_SDA_SLAST_SDA_WIDTH          EDMA3_TCD_SLAST_SDA_SLAST_SDA_WIDTH
+#define DMA_TCD_SLAST_SDA_SLAST_SDA(x)             EDMA3_TCD_SLAST_SDA_SLAST_SDA(x)
+/*! @} */
+
+/*! @name DADDR - TCD Destination Address */
+/*! @{ */
+
+#define DMA_TCD_DADDR_DADDR_MASK                   EDMA3_TCD_DADDR_DADDR_MASK
+#define DMA_TCD_DADDR_DADDR_SHIFT                  EDMA3_TCD_DADDR_DADDR_SHIFT
+#define DMA_TCD_DADDR_DADDR_WIDTH                  EDMA3_TCD_DADDR_DADDR_WIDTH
+#define DMA_TCD_DADDR_DADDR(x)                     EDMA3_TCD_DADDR_DADDR(x)
+/*! @} */
+
+/*! @name DOFF - TCD Signed Destination Address Offset */
+/*! @{ */
+
+#define DMA_TCD_DOFF_DOFF_MASK                     EDMA3_TCD_DOFF_DOFF_MASK
+#define DMA_TCD_DOFF_DOFF_SHIFT                    EDMA3_TCD_DOFF_DOFF_SHIFT
+#define DMA_TCD_DOFF_DOFF_WIDTH                    EDMA3_TCD_DOFF_DOFF_WIDTH
+#define DMA_TCD_DOFF_DOFF(x)                       EDMA3_TCD_DOFF_DOFF(x)
+/*! @} */
+
+/*! @name CITER_ELINKNO - TCD Current Major Loop Count (Minor Loop Channel Linking Disabled) */
+/*! @{ */
+
+#define DMA_TCD_CITER_ELINKNO_CITER_MASK           EDMA3_TCD_CITER_ELINKNO_CITER_MASK
+#define DMA_TCD_CITER_ELINKNO_CITER_SHIFT          EDMA3_TCD_CITER_ELINKNO_CITER_SHIFT
+#define DMA_TCD_CITER_ELINKNO_CITER_WIDTH          EDMA3_TCD_CITER_ELINKNO_CITER_WIDTH
+#define DMA_TCD_CITER_ELINKNO_CITER(x)             EDMA3_TCD_CITER_ELINKNO_CITER(x)
+
+#define DMA_TCD_CITER_ELINKNO_ELINK_MASK           EDMA3_TCD_CITER_ELINKNO_ELINK_MASK
+#define DMA_TCD_CITER_ELINKNO_ELINK_SHIFT          EDMA3_TCD_CITER_ELINKNO_ELINK_SHIFT
+#define DMA_TCD_CITER_ELINKNO_ELINK_WIDTH          EDMA3_TCD_CITER_ELINKNO_ELINK_WIDTH
+#define DMA_TCD_CITER_ELINKNO_ELINK(x)             EDMA3_TCD_CITER_ELINKNO_ELINK(x)
+/*! @} */
+
+/*! @name CITER_ELINKYES - TCD Current Major Loop Count (Minor Loop Channel Linking Enabled) */
+/*! @{ */
+
+#define DMA_TCD_CITER_ELINKYES_CITER_MASK          EDMA3_TCD_CITER_ELINKYES_CITER_MASK
+#define DMA_TCD_CITER_ELINKYES_CITER_SHIFT         EDMA3_TCD_CITER_ELINKYES_CITER_SHIFT
+#define DMA_TCD_CITER_ELINKYES_CITER_WIDTH         EDMA3_TCD_CITER_ELINKYES_CITER_WIDTH
+#define DMA_TCD_CITER_ELINKYES_CITER(x)            EDMA3_TCD_CITER_ELINKYES_CITER(x)
+
+#define DMA_TCD_CITER_ELINKYES_LINKCH_MASK         EDMA3_TCD_CITER_ELINKYES_LINKCH_MASK
+#define DMA_TCD_CITER_ELINKYES_LINKCH_SHIFT        EDMA3_TCD_CITER_ELINKYES_LINKCH_SHIFT
+#define DMA_TCD_CITER_ELINKYES_LINKCH_WIDTH        EDMA3_TCD_CITER_ELINKYES_LINKCH_WIDTH
+#define DMA_TCD_CITER_ELINKYES_LINKCH(x)           EDMA3_TCD_CITER_ELINKYES_LINKCH(x)
+
+#define DMA_TCD_CITER_ELINKYES_ELINK_MASK          EDMA3_TCD_CITER_ELINKYES_ELINK_MASK
+#define DMA_TCD_CITER_ELINKYES_ELINK_SHIFT         EDMA3_TCD_CITER_ELINKYES_ELINK_SHIFT
+#define DMA_TCD_CITER_ELINKYES_ELINK_WIDTH         EDMA3_TCD_CITER_ELINKYES_ELINK_WIDTH
+#define DMA_TCD_CITER_ELINKYES_ELINK(x)            EDMA3_TCD_CITER_ELINKYES_ELINK(x)
+/*! @} */
+
+/*! @name DLAST_SGA - TCD Last Destination Address Adjustment / Scatter Gather Address */
+/*! @{ */
+
+#define DMA_TCD_DLAST_SGA_DLAST_SGA_MASK           EDMA3_TCD_DLAST_SGA_DLAST_SGA_MASK
+#define DMA_TCD_DLAST_SGA_DLAST_SGA_SHIFT          EDMA3_TCD_DLAST_SGA_DLAST_SGA_SHIFT
+#define DMA_TCD_DLAST_SGA_DLAST_SGA_WIDTH          EDMA3_TCD_DLAST_SGA_DLAST_SGA_WIDTH
+#define DMA_TCD_DLAST_SGA_DLAST_SGA(x)             EDMA3_TCD_DLAST_SGA_DLAST_SGA(x)
+/*! @} */
+
+/*! @name CSR - TCD Control and Status */
+/*! @{ */
+
+#define DMA_TCD_CSR_START_MASK                     EDMA3_TCD_CSR_START_MASK
+#define DMA_TCD_CSR_START_SHIFT                    EDMA3_TCD_CSR_START_SHIFT
+#define DMA_TCD_CSR_START_WIDTH                    EDMA3_TCD_CSR_START_WIDTH
+#define DMA_TCD_CSR_START(x)                       EDMA3_TCD_CSR_START(x)
+
+#define DMA_TCD_CSR_INTMAJOR_MASK                  EDMA3_TCD_CSR_INTMAJOR_MASK
+#define DMA_TCD_CSR_INTMAJOR_SHIFT                 EDMA3_TCD_CSR_INTMAJOR_SHIFT
+#define DMA_TCD_CSR_INTMAJOR_WIDTH                 EDMA3_TCD_CSR_INTMAJOR_WIDTH
+#define DMA_TCD_CSR_INTMAJOR(x)                    EDMA3_TCD_CSR_INTMAJOR(x)
+
+#define DMA_TCD_CSR_INTHALF_MASK                   EDMA3_TCD_CSR_INTHALF_MASK
+#define DMA_TCD_CSR_INTHALF_SHIFT                  EDMA3_TCD_CSR_INTHALF_SHIFT
+#define DMA_TCD_CSR_INTHALF_WIDTH                  EDMA3_TCD_CSR_INTHALF_WIDTH
+#define DMA_TCD_CSR_INTHALF(x)                     EDMA3_TCD_CSR_INTHALF(x)
+
+#define DMA_TCD_CSR_DREQ_MASK                      EDMA3_TCD_CSR_DREQ_MASK
+#define DMA_TCD_CSR_DREQ_SHIFT                     EDMA3_TCD_CSR_DREQ_SHIFT
+#define DMA_TCD_CSR_DREQ_WIDTH                     EDMA3_TCD_CSR_DREQ_WIDTH
+#define DMA_TCD_CSR_DREQ(x)                        EDMA3_TCD_CSR_DREQ(x)
+
+#define DMA_TCD_CSR_ESG_MASK                       EDMA3_TCD_CSR_ESG_MASK
+#define DMA_TCD_CSR_ESG_SHIFT                      EDMA3_TCD_CSR_ESG_SHIFT
+#define DMA_TCD_CSR_ESG_WIDTH                      EDMA3_TCD_CSR_ESG_WIDTH
+#define DMA_TCD_CSR_ESG(x)                         EDMA3_TCD_CSR_ESG(x)
+
+#define DMA_TCD_CSR_MAJORELINK_MASK                EDMA3_TCD_CSR_MAJORELINK_MASK
+#define DMA_TCD_CSR_MAJORELINK_SHIFT               EDMA3_TCD_CSR_MAJORELINK_SHIFT
+#define DMA_TCD_CSR_MAJORELINK_WIDTH               EDMA3_TCD_CSR_MAJORELINK_WIDTH
+#define DMA_TCD_CSR_MAJORELINK(x)                  EDMA3_TCD_CSR_MAJORELINK(x)
+
+#define DMA_TCD_CSR_ESDA_MASK                      EDMA3_TCD_CSR_ESDA_MASK
+#define DMA_TCD_CSR_ESDA_SHIFT                     EDMA3_TCD_CSR_ESDA_SHIFT
+#define DMA_TCD_CSR_ESDA_WIDTH                     EDMA3_TCD_CSR_ESDA_WIDTH
+#define DMA_TCD_CSR_ESDA(x)                        EDMA3_TCD_CSR_ESDA(x)
+
+#define DMA_TCD_CSR_MAJORLINKCH_MASK               EDMA3_TCD_CSR_MAJORLINKCH_MASK
+#define DMA_TCD_CSR_MAJORLINKCH_SHIFT              EDMA3_TCD_CSR_MAJORLINKCH_SHIFT
+#define DMA_TCD_CSR_MAJORLINKCH_WIDTH              EDMA3_TCD_CSR_MAJORLINKCH_WIDTH
+#define DMA_TCD_CSR_MAJORLINKCH(x)                 EDMA3_TCD_CSR_MAJORLINKCH(x)
+
+#define DMA_TCD_CSR_BWC_MASK                       EDMA3_TCD_CSR_BWC_MASK
+#define DMA_TCD_CSR_BWC_SHIFT                      EDMA3_TCD_CSR_BWC_SHIFT
+#define DMA_TCD_CSR_BWC_WIDTH                      EDMA3_TCD_CSR_BWC_WIDTH
+#define DMA_TCD_CSR_BWC(x)                         EDMA3_TCD_CSR_BWC(x)
+/*! @} */
+
+/*! @name BITER_ELINKNO - TCD Beginning Major Loop Count (Minor Loop Channel Linking Disabled) */
+/*! @{ */
+
+#define DMA_TCD_BITER_ELINKNO_BITER_MASK           EDMA3_TCD_BITER_ELINKNO_BITER_MASK
+#define DMA_TCD_BITER_ELINKNO_BITER_SHIFT          EDMA3_TCD_BITER_ELINKNO_BITER_SHIFT
+#define DMA_TCD_BITER_ELINKNO_BITER_WIDTH          EDMA3_TCD_BITER_ELINKNO_BITER_WIDTH
+#define DMA_TCD_BITER_ELINKNO_BITER(x)             EDMA3_TCD_BITER_ELINKNO_BITER(x)
+
+#define DMA_TCD_BITER_ELINKNO_ELINK_MASK           EDMA3_TCD_BITER_ELINKNO_ELINK_MASK
+#define DMA_TCD_BITER_ELINKNO_ELINK_SHIFT          EDMA3_TCD_BITER_ELINKNO_ELINK_SHIFT
+#define DMA_TCD_BITER_ELINKNO_ELINK_WIDTH          EDMA3_TCD_BITER_ELINKNO_ELINK_WIDTH
+#define DMA_TCD_BITER_ELINKNO_ELINK(x)             EDMA3_TCD_BITER_ELINKNO_ELINK(x)
+/*! @} */
+
+/*! @name BITER_ELINKYES - TCD Beginning Major Loop Count (Minor Loop Channel Linking Enabled) */
+/*! @{ */
+
+#define DMA_TCD_BITER_ELINKYES_BITER_MASK          EDMA3_TCD_BITER_ELINKYES_BITER_MASK
+#define DMA_TCD_BITER_ELINKYES_BITER_SHIFT         EDMA3_TCD_BITER_ELINKYES_BITER_SHIFT
+#define DMA_TCD_BITER_ELINKYES_BITER_WIDTH         EDMA3_TCD_BITER_ELINKYES_BITER_WIDTH
+#define DMA_TCD_BITER_ELINKYES_BITER(x)            EDMA3_TCD_BITER_ELINKYES_BITER(x)
+
+#define DMA_TCD_BITER_ELINKYES_LINKCH_MASK         EDMA3_TCD_BITER_ELINKYES_LINKCH_MASK
+#define DMA_TCD_BITER_ELINKYES_LINKCH_SHIFT        EDMA3_TCD_BITER_ELINKYES_LINKCH_SHIFT
+#define DMA_TCD_BITER_ELINKYES_LINKCH_WIDTH        EDMA3_TCD_BITER_ELINKYES_LINKCH_WIDTH
+#define DMA_TCD_BITER_ELINKYES_LINKCH(x)           EDMA3_TCD_BITER_ELINKYES_LINKCH(x)
+
+#define DMA_TCD_BITER_ELINKYES_ELINK_MASK          EDMA3_TCD_BITER_ELINKYES_ELINK_MASK
+#define DMA_TCD_BITER_ELINKYES_ELINK_SHIFT         EDMA3_TCD_BITER_ELINKYES_ELINK_SHIFT
+#define DMA_TCD_BITER_ELINKYES_ELINK_WIDTH         EDMA3_TCD_BITER_ELINKYES_ELINK_WIDTH
+#define DMA_TCD_BITER_ELINKYES_ELINK(x)            EDMA3_TCD_BITER_ELINKYES_ELINK(x)
+/*! @} */
+
+/*!
+ * @addtogroup DMAMUX_Register_Masks DMAMUX Register Masks
+ * @{
+ */
+
+#define DMAMUX_CHCFG_SOURCE_MASK                   DMAMUX_CHCONF_SOURCE_MASK
+#define DMAMUX_CHCFG_SOURCE_SHIFT                  DMAMUX_CHCONF_SOURCE_SHIFT
+#define DMAMUX_CHCFG_SOURCE_WIDTH                  DMAMUX_CHCONF_SOURCE_WIDTH
+#define DMAMUX_CHCFG_SOURCE(x)                     DMAMUX_CHCONF_SOURCE(x)
+
+#define DMAMUX_CHCFG_TRIG_MASK                     DMAMUX_CHCONF_TRIG_MASK
+#define DMAMUX_CHCFG_TRIG_SHIFT                    DMAMUX_CHCONF_TRIG_SHIFT
+#define DMAMUX_CHCFG_TRIG_WIDTH                    DMAMUX_CHCONF_TRIG_WIDTH
+#define DMAMUX_CHCFG_TRIG(x)                       DMAMUX_CHCONF_TRIG(x)
+
+#define DMAMUX_CHCFG_ENBL_MASK                     DMAMUX_CHCONF_ENBL_MASK
+#define DMAMUX_CHCFG_ENBL_SHIFT                    DMAMUX_CHCONF_ENBL_SHIFT
+#define DMAMUX_CHCFG_ENBL_WIDTH                    DMAMUX_CHCONF_ENBL_WIDTH
+#define DMAMUX_CHCFG_ENBL(x)                       DMAMUX_CHCONF_ENBL(x)
+
 #endif /* _S32Z270_DEVICE_H_ */

--- a/s32/mcux/devices/S32Z270/S32Z270_features.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_features.h
@@ -110,6 +110,108 @@
 #define FSL_FEATURE_FLEXCAN_HAS_NO_SLFWAK_SUPPORT (1)
 /* @brief Does not support Wake Up Source (bitfield MCR[WAKSRC]. */
 #define FSL_FEATURE_FLEXCAN_HAS_NO_WAKSRC_SUPPORT (1)
+/* @brief EDMA availability on the SoC. */
+#define FSL_FEATURE_SOC_EDMA_COUNT (4)
+
+/* EDMA module features */
+
+/* @brief Number of DMA channels (related to number of registers TCD, DCHPRI, bit fields ERQ[ERQn], EEI[EEIn], INT[INTn], ERR[ERRn], HRS[HRSn] and bit field widths ES[ERRCHN], CEEI[CEEI], SEEI[SEEI], CERQ[CERQ], SERQ[SERQ], CDNE[CDNE], SSRT[SSRT], CERR[CERR], CINT[CINT], TCDn_CITER_ELINKYES[LINKCH], TCDn_CSR[MAJORLINKCH], TCDn_BITER_ELINKYES[LINKCH]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL (32)
+/* @brief If 8 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_8_BYTES_TRANSFER (1)
+/* @brief Number of channel for each EDMA instance, (only defined for soc with different channel numbers for difference instance) */
+#define FSL_FEATURE_EDMA_INSTANCE_CHANNELn(x)  \
+    (((x) == DMA0) ? (32) : \
+    (((x) == DMA1) ? (16) : \
+    (((x) == DMA4) ? (16) : \
+    (((x) == DMA5) ? (16) : (0)))))
+/* @brief Has register CH_CSR. */
+/* @brief If 16 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_16_BYTES_TRANSFER (1)
+/* @brief Number of DMA channel groups (register bit fields CR[ERGA], CR[GRPnPRI], ES[GPE], DCHPRIn[GRPPRI]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT (0)
+/* @brief Has register bit fields MP_CSR[GMRC]. */
+#define FSL_FEATURE_EDMA_HAS_GLOBAL_MASTER_ID_REPLICATION (1)
+/* @brief If 64 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_64_BYTES_TRANSFER (1)
+/* @brief Has DMA_Error interrupt vector. */
+#define FSL_FEATURE_EDMA_HAS_ERROR_IRQ (1)
+/* @brief Has register bit fields CR[CLM]. */
+#define FSL_FEATURE_EDMA_HAS_CONTINUOUS_LINK_MODE (0)
+/* @brief If 128 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_128_BYTES_TRANSFER (0)
+/* @brief Has register access permission. */
+#define FSL_FEATURE_HAVE_DMA_CONTROL_REGISTER_ACCESS_PERMISSION (1)
+/* @brief NBYTES must be multiple of 8 when using scatter gather. */
+#define FSL_FEATURE_EDMA_HAS_ERRATA_51327 (0)
+/* @brief If 128 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_INSTANCE_SUPPORT_128_BYTES_TRANSFERn(x) (0)
+/* @brief If channel clock controlled independently */
+#define FSL_FEATURE_EDMA_CHANNEL_HAS_OWN_CLOCK_GATE (1)
+/* @brief NBYTES must be multiple of 8 when using scatter gather. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_ERRATA_51327n(x) (0)
+/* @brief Has register CH_CSR. */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_CONFIG (1)
+/* @brief Has channel mux */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_MUX (0)
+/* @brief Has no register bit fields MP_CSR[EBW]. */
+#define FSL_FEATURE_EDMA_HAS_NO_MP_CSR_EBW (0)
+/* @brief Instance has channel mux */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_CHANNEL_MUXn(x) (0)
+/* @brief If dma has common clock gate */
+#define FSL_FEATURE_EDMA_HAS_COMMON_CLOCK_GATE (0)
+/* @brief Has register CH_SBR. */
+#define FSL_FEATURE_EDMA_HAS_SBR (1)
+/* @brief If dma channel IRQ support parameter */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL_IRQ_ENTRY_SUPPORT_PARAMETER (0)
+/* @brief Has no register bit fields CH_SBR[ATTR]. */
+#define FSL_FEATURE_EDMA_HAS_NO_CH_SBR_ATTR (1)
+/* @brief Has register bit field CH_CSR[SWAP]. */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_SWAP_SIZE (0)
+/* @brief Instance has register bit field CH_CSR[SWAP]. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_CHANNEL_SWAP_SIZEn(x) (0)
+/* @brief Has register bit field CH_SBR[INSTR]. */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_ACCESS_TYPE (0)
+/* @brief Whether has prot register. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_PROT_REGISTERn(x) (0)
+/* @brief Instance has register bit field CH_SBR[INSTR]. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_CHANNEL_ACCESS_TYPEn(x) (0)
+/* @brief Whether has MP channel mux. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_MP_CHANNEL_MUXn(x) (0)
+/* @brief Has register bit fields CH_MATTR[WCACHE], CH_MATTR[RCACHE]. */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_MEMORY_ATTRIBUTE (0)
+/* @brief Instance has register CH_MATTR. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_CHANNEL_MEMORY_ATTRIBUTEn(x) (0)
+/* @brief Has register bit field CH_CSR[SIGNEXT]. */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_SIGN_EXTENSION (0)
+/* @brief Instance Has register bit field CH_CSR[SIGNEXT]. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_CHANNEL_SIGN_EXTENSIONn(x) (0)
+/* @brief Has register bit field TCD_CSR[BWC]. */
+#define FSL_FEATURE_EDMA_HAS_BANDWIDTH (1)
+/* @brief Instance has register bit field TCD_CSR[BWC]. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_BANDWIDTHn(x) (1)
+/* @brief Has register bit fields TCD_CSR[TMC]. */
+#define FSL_FEATURE_EDMA_HAS_TRANSFER_MODE (0)
+/* @brief Instance has register bit fields TCD_CSR[TMC]. */
+#define FSL_FEATURE_EDMA_INSTANCE_HAS_TRANSFER_MODEn(x) (0)
+
+/* @brief edma5 has different tcd type. */
+#define FSL_FEATURE_EDMA_TCD_TYPEn(x) (0)
+/* @brief Has no register bit fields CH_SBR[SEC]. */
+#define FSL_FEATURE_EDMA_HAS_NO_CH_SBR_SEC (1)
+
+/* DMAMUX module features */
+
+/* @brief Total number of DMA channels on all modules. Note: this is including channels used as offset. */
+#define FSL_FEATURE_EDMA_DMAMUX_CHANNELS (80)
+/* @brief DMAMUX availability on the SoC. */
+#define FSL_FEATURE_SOC_DMAMUX_COUNT (5)
+/* @brief Number of DMA channels (related to number of register CHCFGn). */
+#define FSL_FEATURE_DMAMUX_MODULE_CHANNEL (16)
+/* @brief Has the periodic trigger capability for the triggered DMA channel (register bit CHCFG0[TRIG]). */
+#define FSL_FEATURE_DMAMUX_HAS_TRIG (1)
+/* @brief Register CHCFGn width. */
+#define FSL_FEATURE_DMAMUX_CHCFG_REGISTER_WIDTH (8)
 
 /* I2C module features */
 

--- a/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
+++ b/s32/mcux/devices/S32Z270/S32Z270_glue_mcux.h
@@ -247,4 +247,56 @@
 /** Interrupt vectors for the LPI2C peripheral type */
 #define LPI2C_IRQS                               { RTU_LPI2C1_IRQn, RTU_LPI2C2_IRQn }
 
+/* EDMA3 - Peripheral instance base addresses */
+
+/** Peripheral DMA0 base pointer */
+#define DMA0                                      ((DMA_Type *)IP_EDMA_0_MP_BASE)
+/** Interrupt vectors for the DMA0 peripheral type */
+#define DMA0_IRQS                                 { RTU_DMA0_0_IRQn, RTU_DMA0_1_IRQn, RTU_DMA0_2_IRQn, RTU_DMA0_3_IRQn,    \
+                                                    RTU_DMA0_4_IRQn, RTU_DMA0_5_IRQn, RTU_DMA0_6_IRQn, RTU_DMA0_7_IRQn,    \
+                                                    RTU_DMA0_8_IRQn, RTU_DMA0_9_IRQn, RTU_DMA0_10_IRQn, RTU_DMA0_11_IRQn,  \
+                                                    RTU_DMA0_12_IRQn, RTU_DMA0_13_IRQn, RTU_DMA0_14_IRQn, RTU_DMA0_15_IRQn,\
+                                                    RTU_DMA0_16_IRQn, RTU_DMA0_17_IRQn, RTU_DMA0_18_IRQn, RTU_DMA0_19_IRQn,\
+                                                    RTU_DMA0_20_IRQn, RTU_DMA0_21_IRQn, RTU_DMA0_22_IRQn, RTU_DMA0_23_IRQn,\
+                                                    RTU_DMA0_24_IRQn, RTU_DMA0_25_IRQn, RTU_DMA0_26_IRQn, RTU_DMA0_27_IRQn,\
+                                                    RTU_DMA0_28_IRQn, RTU_DMA0_29_IRQn, RTU_DMA0_30_IRQn, RTU_DMA0_31_IRQn }
+
+#define DMA0_ERROR_IRQS                           { RTU_DMA0_ERR_IRQn }
+
+/** Peripheral DMA1 base pointer */
+#define DMA1                                      ((DMA_Type *)IP_EDMA_1_MP_BASE)
+/** Interrupt vectors for the DMA1 peripheral type */
+#define DMA1_IRQS                                 { RTU_DMA1_0_IRQn, RTU_DMA1_1_IRQn, RTU_DMA1_2_IRQn, RTU_DMA1_3_IRQn,    \
+                                                    RTU_DMA1_4_IRQn, RTU_DMA1_5_IRQn, RTU_DMA1_6_IRQn, RTU_DMA1_7_IRQn,    \
+                                                    RTU_DMA1_8_IRQn, RTU_DMA1_9_IRQn, RTU_DMA1_10_IRQn, RTU_DMA1_11_IRQn,  \
+                                                    RTU_DMA1_12_IRQn, RTU_DMA1_13_IRQn, RTU_DMA1_14_IRQn, RTU_DMA1_15_IRQn }
+
+#define DMA1_ERROR_IRQS                           { RTU_DMA1_ERR_IRQn }
+
+/** Peripheral DMA4 base pointer */
+#define DMA4                                      ((DMA_Type *)IP_EDMA_4_MP_BASE)
+/** Interrupt vectors for the DMA4 peripheral type */
+#define DMA4_IRQS                                 { RTU_DMA4_0_IRQn, RTU_DMA4_1_IRQn, RTU_DMA4_2_IRQn, RTU_DMA4_3_IRQn,    \
+                                                    RTU_DMA4_4_IRQn, RTU_DMA4_5_IRQn, RTU_DMA4_6_IRQn, RTU_DMA4_7_IRQn,    \
+                                                    RTU_DMA4_8_IRQn, RTU_DMA4_9_IRQn, RTU_DMA4_10_IRQn, RTU_DMA4_11_IRQn,  \
+                                                    RTU_DMA4_12_IRQn, RTU_DMA4_13_IRQn, RTU_DMA4_14_IRQn, RTU_DMA4_15_IRQn }
+
+#define DMA4_ERROR_IRQS                           { RTU_DMA4_ERR_IRQn }
+
+/** Peripheral DMA5 base pointer */
+#define DMA5                                      ((DMA_Type *)IP_EDMA_5_MP_BASE)
+/** Interrupt vectors for the DMA5 peripheral type */
+#define DMA5_IRQS                                 { RTU_DMA5_0_IRQn, RTU_DMA5_1_IRQn, RTU_DMA5_2_IRQn, RTU_DMA5_3_IRQn,    \
+                                                    RTU_DMA5_4_IRQn, RTU_DMA5_5_IRQn, RTU_DMA5_6_IRQn, RTU_DMA5_7_IRQn,    \
+                                                    RTU_DMA5_8_IRQn, RTU_DMA5_9_IRQn, RTU_DMA5_10_IRQn, RTU_DMA5_11_IRQn,  \
+                                                    RTU_DMA5_12_IRQn, RTU_DMA5_13_IRQn, RTU_DMA5_14_IRQn, RTU_DMA5_15_IRQn }
+
+#define DMA5_ERROR_IRQS                           { RTU_DMA5_ERR_IRQn }
+
+/** Array initializer of DMA peripheral base pointers */
+#define DMA_BASE_PTRS                             { DMA0, DMA1, DMA4, DMA5 }
+/** Interrupt vectors for the DMA peripheral type */
+#define DMA_IRQS                                  { DMA0_IRQS, DMA1_IRQS, DMA4_IRQS, DMA5_IRQS }
+#define DMA_ERROR_IRQS                            { DMA0_ERROR_IRQS, DMA1_ERROR_IRQS, DMA4_ERROR_IRQS, DMA5_ERROR_IRQS }
+
 #endif /* _S32Z270_GLUE_MCUX_H_ */

--- a/s32/mcux/devices/S32Z270/drivers/driver_memory.cmake
+++ b/s32/mcux/devices/S32Z270/drivers/driver_memory.cmake
@@ -1,0 +1,1 @@
+#Not used this file, but required to build.


### PR DESCRIPTION
Add EDMAv3 instances base addresses and module features to support using the EDMA MCUX driver.