### PR TITLE
Add imx9352 mu1 driver to build

### DIFF
--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -280,7 +280,7 @@ elseif(CONFIG_SOC_MIMXRT1189_CM33)
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE    cache/xcache  driver_cache_xcache)
 endif()
 
-if (${MCUX_DEVICE} MATCHES "MIMX9596")
+if ((${MCUX_DEVICE} MATCHES "MIMX9596") OR (${MCUX_DEVICE} MATCHES "MIMX9352"))
   include_driver_ifdef(CONFIG_IPM_IMX			mu1		driver_mu1)
   include_driver_ifdef(CONFIG_MBOX_NXP_IMX_MU		mu1		driver_mu1)
 else()

--- a/mcux/mcux-sdk/drivers/mu/fsl_mu.h
+++ b/mcux/mcux-sdk/drivers/mu/fsl_mu.h
@@ -374,6 +374,28 @@ static inline uint32_t MU_GetStatusFlags(MU_Type *base)
 }
 
 /*!
+ * brief Return the RX status flags in reverse order.
+ *
+ * This function return the RX status flags in reverse order.
+ * 
+ * @code
+ * status_reg = MU_GetRxStatusFlags(base);
+ * @endcode
+ *
+ * @param base MU peripheral base address.
+ * @return MU RX status
+ */
+
+static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)
+{
+    uint32_t flags = 0;
+
+    flags = ((MU_GetStatusFlags(base)>>kMU_Rx0FullFlag) | 0x0000000F);
+
+    return flags;
+}
+
+/*!
  * @brief Gets the MU IRQ pending status.
  *
  * This function returns the bit mask of the pending MU IRQs.

--- a/mcux/mcux-sdk/drivers/mu1/fsl_mu.h
+++ b/mcux/mcux-sdk/drivers/mu1/fsl_mu.h
@@ -894,6 +894,33 @@ static inline void MU_ClearGeneralPurposeStatusFlags(MU_Type *base, uint32_t fla
 }
 
 /*!
+ * brief Return the RX status flags in reverse order.
+ *
+ * This function return the RX status flags in reverse order.
+ * 
+ * @code
+ * status_reg = MU_GetRxStatusFlags(base);
+ * @endcode
+ *
+ * @param base MU peripheral base address.
+ * @return MU RX status flags in reverse order
+ */
+
+static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)
+{
+    uint32_t flags = 0;
+
+    flags = ((MU_GetStatusFlags(base)>>kMU_Rx0FullFlag) | 0x0000000F);
+
+    flags = (((flags>>MU_RSR_RF3_SHIFT)<<MU_RSR_RF0_SHIFT) |
+             ((flags>>MU_RSR_RF2_SHIFT)<<MU_RSR_RF1_SHIFT) |
+             ((flags>>MU_RSR_RF1_SHIFT)<<MU_RSR_RF2_SHIFT) |
+             ((flags>>MU_RSR_RF0_SHIFT)<<MU_RSR_RF3_SHIFT));
+
+    return flags;
+}
+
+/*!
  * @brief Triggers general purpose interrupts to the other core.
  *
  * This function triggers the specific general purpose interrupts to the other core.


### PR DESCRIPTION
PR details:
- include the mu1 driver when building the the project for MIMX9352. 
- add MU_GetRxStatusFlags() function in the  fsl_mu.h of the mu and mu1 drivers.