### PR TITLE
mcux: fix hang when cpu3 reset

### DIFF
--- a/mcux/mcux-sdk/components/rpmsg/fsl_adapter_rfimu.c
+++ b/mcux/mcux-sdk/components/rpmsg/fsl_adapter_rfimu.c
@@ -1544,16 +1544,16 @@ static void HAL_ImuTaskDeinit(uint8_t link)
 #ifndef __ZEPHYR__
         (void)OSA_EventDestroy((osa_event_handle_t)ImuQ13FlagsRef);
         (void)OSA_TaskDestroy(ImuTaskHandleCpu13);
-#endif
         imu_task_flag &= ~(1U << link);
+#endif
     }
     else if (link == kIMU_LinkCpu2Cpu3 && (imu_task_flag & (1U << link)) != 0)
     {
 #ifndef __ZEPHYR__
         (void)OSA_EventDestroy((osa_event_handle_t)ImuQ23FlagsRef);
         (void)OSA_TaskDestroy(ImuTaskHandleCpu23);
-#endif
         imu_task_flag &= ~(1U << link);
+#endif
     }
     else
     {


### PR DESCRIPTION
Destroy cpu1 and cpu3 imu task but not set flag when cpu3 reset.
because flag is not set, so zephyr task list is loop when create
cpu1 and cpu3 task again, and will hang when pick next task

Don't reset imu_task_flag when destroying imu task when deinit imu