### PR TITLE
mcux: middleware: enable FWK for Openthread

### DIFF
--- a/mcux/middleware/CMakeLists.txt
+++ b/mcux/middleware/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CONFIG_BT)
+if(CONFIG_BT OR CONFIG_NET_L2_OPENTHREAD)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk-middleware-connectivity-framework)
     include(connectivity_framework)
     if(CONFIG_SOC_SERIES_MCXW)


### PR DESCRIPTION
Enable connectivity_framework to be used by Openthread RCP