### PR TITLE
mcux: mcux-sdk: drivers: cache64: remove invalid assert in GetInstance

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -121,3 +121,6 @@ Patch List:
   - mcux-sdk/drivers/dspi/fsl_dspi.c, mcux-sdk/drivers/dspi/fsl_dspi.h, mcux-sdk/drivers/dspi/fsl_dspi_edma.c,
   mcux-sdk/drivers/dspi/fsl_dspi_edma.h: add the guards for unsupport features on S32Z27x devices
   - drivers: irqsteer: adjust CHn_MASK index computation
+  - mcux-sdk/drivers/cache/cache64/fsl_cache.c: remove invalid assertion when
+    CACHE64_GetInstanceByAddr() is passed an address not managed by the CACHE64
+    controller

--- a/mcux/mcux-sdk/drivers/cache/cache64/fsl_cache.c
+++ b/mcux/mcux-sdk/drivers/cache/cache64/fsl_cache.c
@@ -108,7 +108,6 @@ uint32_t CACHE64_GetInstanceByAddr(uint32_t address)
         i++;
     }
 		
-    assert(false);
     return 0xFFFFFFFFUL;
 }
 


### PR DESCRIPTION
CACHE64_GetInstanceByAddr() asserts when an address is passed in that is not managed by the CACHE64 controller. This is incorrect behavior, as the CACHE64 driver checks to see if the returned instance number is out of range when using this function, so we should not assert here.

Remove the assert so that cache invalidation functions can be used with addresses not the CACHE64 controller's range.