### PR TITLE
gitignore: update with common paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
+*.swp
+zephyr/blobs/
 


### PR DESCRIPTION
Update gitignore file to ignore blobs directory within HAL, as well as vim .swp files

This should reduce the odds of accidentally committing these files in the future