### PR TITLE
zephyr: rw61x: rework cpu2 monolithic handling

### DIFF
--- a/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
+++ b/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
@@ -19,17 +19,19 @@ if(CONFIG_SOC_SERIES_RW6XX)
 
     zephyr_compile_definitions(gPlatformDisableVendorSpecificInit=1U)
 
-    if (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_BT OR CONFIG_NXP_MONOLITHIC_IEEE802154)
-        zephyr_compile_definitions(gPlatformMonolithicApp_d=1U)
+    if (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_NBU)
+        zephyr_compile_definitions(
+            gPlatformMonolithicApp_d=1U
+            fw_cpu2_ble=fw_cpu2
+            fw_cpu2_combo=fw_cpu2
+        )
 
-        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_BT
-                                          BLE_FW_ADDRESS=0U)
+        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_NBU
+                                          BLE_FW_ADDRESS=0U
+                                          COMBO_FW_ADDRESS=0U)
 
         zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_WIFI
                                           WIFI_FW_ADDRESS=0U)
-
-        zephyr_compile_definitions_ifndef(CONFIG_NXP_MONOLITHIC_IEEE802154
-                                          COMBO_FW_ADDRESS=0U)
     endif()
 endif()
 

--- a/zephyr/src/rw61x/CMakeLists.txt
+++ b/zephyr/src/rw61x/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_BT OR CONFIG_NXP_MONOLITHIC_IEEE802154)
+if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_NBU)
 	set(hal_blobs_dir ${ZEPHYR_HAL_NXP_MODULE_DIR}/zephyr/blobs/rw61x)
 
 	set(signed_binary_blobs_list)
@@ -14,21 +14,15 @@ if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_NXP_MONOLITHIC_BT OR CONFIG_NXP_MONOLITH
 
 		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu1.c)
 	endif()
-	if(CONFIG_NXP_MONOLITHIC_IEEE802154)
-		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_combo_fw.bin.inc)
-
-		set(signed_binary_blob_name rw61x_sb_combo_a2.bin)
-
-		list(APPEND signed_binary_blobs_list ${hal_blobs_dir}/${signed_binary_blob_name})
-
-		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu2.c)
-	elseif(CONFIG_NXP_MONOLITHIC_BT)
-		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_ble_fw.bin.inc)
-
-		set(signed_binary_blob_name rw61x_sb_ble_a2.bin)
+	if(CONFIG_NXP_MONOLITHIC_NBU)
+		if(CONFIG_SOC_RW612)
+			set(signed_binary_blob_name rw61x_sb_combo_a2.bin)
+		else()
+			set(signed_binary_blob_name rw61x_sb_ble_a2.bin)
+		endif()
+		list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/rw61x_cpu2_fw.bin.inc)
 
 		list(APPEND signed_binary_blobs_list ${hal_blobs_dir}/${signed_binary_blob_name})
-
 		zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/rw61x_cpu2.c)
 	endif()
 

--- a/zephyr/src/rw61x/rw61x_cpu2.c
+++ b/zephyr/src/rw61x/rw61x_cpu2.c
@@ -9,14 +9,9 @@
 
 #include <stdint.h>
 
-#if defined(CONFIG_NXP_MONOLITHIC_IEEE802154)
-__attribute__ ((__section__(".fw_cpu2_combo"), used))
-const uint8_t fw_cpu2_combo[] = {
-    #include <rw61x_combo_fw.bin.inc>
-};
-#elif defined(CONFIG_NXP_MONOLITHIC_BT)
-__attribute__ ((__section__(".fw_cpu2_ble"), used))
-const uint8_t fw_cpu2_ble[] = {
-    #include <rw61x_ble_fw.bin.inc>
+#if defined(CONFIG_NXP_MONOLITHIC_NBU)
+__attribute__ ((__section__(".fw_cpu2"), used))
+const uint8_t fw_cpu2[] = {
+    #include <rw61x_cpu2_fw.bin.inc>
 };
 #endif


### PR DESCRIPTION
To simplify how coexistence between BLE and 15.4 works, we decided to choose the cpu2 firmware based on which SoC is used. If RW612 is used, then we use the combo firmware.
If RW610 is used, then we use the ble only firmware.

MONOLITHIC_BT and MONOLITHIC_IEEE802154 configs have been combined into a single one: MONOLITHIC_NBR.

We also unify the fw array symbol to `fw_cpu2` and make it transparent to the connectivity_framework by using the preprocessor.