### PR TITLE
mcux-sdk: Fix message for ccm32k

### DIFF
--- a/mcux/mcux-sdk/drivers/ccm32k/driver_ccm32k.cmake
+++ b/mcux/mcux-sdk/drivers/ccm32k/driver_ccm32k.cmake
@@ -1,6 +1,6 @@
 #Description: GPIO Driver; user_visible: True
 include_guard(GLOBAL)
-message("driver_gpio component is included.")
+message("driver_ccm32k component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/fsl_ccm32k.c


### PR DESCRIPTION
Fix message should say ccm32k not gpio

there is no zephyr side PR because this is extremely trivial, it can get pulled in by any other manifest change