### PR TITLE
drivers: wifi: nxp: Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,4 @@ else()
 endif()
 
 add_subdirectory(zephyr/src)
+zephyr_include_directories_ifdef(CONFIG_NXP_88W8987 zephyr/blobs/SD8987)

--- a/mcux/middleware/wifi_nxp/CMakeLists.txt
+++ b/mcux/middleware/wifi_nxp/CMakeLists.txt
@@ -24,120 +24,160 @@ zephyr_compile_definitions_ifdef(CONFIG_NXP_RW610
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW_rw610.h"
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8987_AW_CM358_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8987_AW_CM358_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8987_AW_CM358MA_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8987_AW_CM358MA_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8987_MURATA_1ZM_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8987_MURATA_1ZM_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_1ZM_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x06
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x06
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8987_MURATA_1ZM_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8987_MURATA_1ZM_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_1ZM_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x06
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x06
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_AW_AM457_USD
+if(CONFIG_NXP_88W8987)
+zephyr_include_directories(
+    wifi_bt_firmware/8987
+)
+
+zephyr_library_sources_ifdef(CONFIG_NXP_88W8987
+    wifi_bt_firmware/8987/8987_cpu12.c
+)
+endif()
+
+if(CONFIG_NXP_IW416)
+zephyr_include_directories(
+    wifi_bt_firmware/IW416
+)
+
+zephyr_library_sources_ifdef(CONFIG_NXP_IW416
+    wifi_bt_firmware/IW416/IW416_cpu12.c
+)
+endif()
+
+if(CONFIG_NXP_88W8801)
+zephyr_include_directories(
+    wifi_bt_firmware/8801
+)
+
+zephyr_library_sources_ifdef(CONFIG_NXP_88W8801
+    wifi_bt_firmware/8801/8801_cpu1.c
+)
+endif()
+
+if(CONFIG_NXP_IW61X)
+zephyr_include_directories(
+    wifi_bt_firmware/nw61x
+)
+
+zephyr_library_sources_ifdef(CONFIG_NXP_IW61X
+    wifi_bt_firmware/nw61x/nw61x_cpu12_se.c
+)
+endif()
+
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_AW_AM457_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_AW_AM457MA_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_AW_AM457MA_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_AW_AM510_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_AW_AM510_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_AW_AM510MA_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_AW_AM510MA_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_1XK_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x09
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_MURATA_1XK_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_MURATA_1XK_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_1XK_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x00
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW416_MURATA_1XK_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW416_MURATA_1XK_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_1XK_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x00
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0C
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW612_MURATA_2EL_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW612_MURATA_2EL_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2EL_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0A
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0A
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW612_MURATA_2EL_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW612_MURATA_2EL_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2EL_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0A
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0A
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW611_MURATA_2DL_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW611_MURATA_2DL_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2EL_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0A
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0A
     WIFI_BT_USE_USD_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_IW611_MURATA_2DL_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_IW611_MURATA_2DL_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2EL_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0A
     CONFIG_NXP_WIFI_ED_OFFSET_5G=0x0A
     WIFI_BT_USE_M2_INTERFACE
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8801_AW_NM191_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8801_AW_NM191_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x1B
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8801_AW_NM191MA_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8801_AW_NM191MA_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x1B
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8801_MURATA_2DS_USD
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8801_MURATA_2DS_USD
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2DS_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0E
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_88W8801_MURATA_2DS_M2
+zephyr_compile_definitions_ifdef(CONFIG_NXP_88W8801_MURATA_2DS_M2
     WIFI_BT_TX_PWR_LIMITS="wlan_txpwrlimit_cfg_murata_2DS_WW.h"
     CONFIG_NXP_WIFI_ED_OFFSET_2G=0x0E
 )

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio_api.h
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio_api.h
@@ -45,16 +45,6 @@
 #define sdio_d(...)
 #endif /* CONFIG_WIFI_SDIO_DEBUG */
 
-#define SDIO_GO_IDLE_STATE      ((uint8_t)0)
-#define SDIO_SET_REL_ADDR       ((uint8_t)3)
-#define SDIO_SDIO_SEN_OP_COND   ((uint8_t)5)
-#define SDIO_SEL_DESEL_CARD     ((uint8_t)7)
-#define SDIO_RW_DIRECT          ((uint8_t)52)
-#define SDIO_RW_DIRECT_EXTENDED ((uint8_t)53)
-
-/* Depends on DMA_BUFSZ */
-#define DMA_BOUNDARY_SIZE (512 * 1024)
-
 /** Read Card Register
  *
  * This is used to read card register using CMD52.

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
@@ -8,12 +8,12 @@
  *
  */
 #include <wmerrno.h>
-#include <board.h>
-#include <wifi_bt_config.h>
-
 #include <mlan_sdio_api.h>
 #include <osa.h>
+#include <fsl_common.h>
+#include <fsl_gpio.h>
 #include <zephyr/sd/sdio.h>
+#include <zephyr/drivers/gpio.h>
 
 #define SDIO_CMD_TIMEOUT 2000
 
@@ -87,15 +87,105 @@ void sdio_enable_interrupt(void)
     return;
 }
 
+
+struct wifi_gpio_config
+{
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), pdn_gpios)
+    const struct gpio_dt_spec pdn;
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), wl_rst_gpios)
+    const struct gpio_dt_spec wl_rst;
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), bt_rst_gpios)
+    const struct gpio_dt_spec bt_rst;
+#endif
+};
+
+static const struct wifi_gpio_config wifi_gpio = {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), pdn_gpios)
+    .pdn = GPIO_DT_SPEC_GET(DT_NODELABEL(wifi), pdn_gpios),
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), wl_rst_gpios)
+    .wl_rst = GPIO_DT_SPEC_GET(DT_NODELABEL(wifi), wl_rst_gpios),
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), bt_rst_gpios)
+    .bt_rst = GPIO_DT_SPEC_GET(DT_NODELABEL(wifi), bt_rst_gpios),
+#endif
+};
+
+void BOARD_WIFI_BT_Enable(bool enable)
+{
+    if (enable)
+    {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), pdn_gpios)
+        gpio_pin_set_dt(&wifi_gpio.pdn, 1);
+        k_msleep(100);
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), wl_rst_gpios)
+        gpio_pin_set_dt(&wifi_gpio.wl_rst, 1);
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), bt_rst_gpios)
+        gpio_pin_set_dt(&wifi_gpio.bt_rst, 1);
+#endif
+
+        k_msleep(100);
+    }
+    else
+    {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), wl_rst_gpios)
+        gpio_pin_set_dt(&wifi_gpio.wl_rst, 0);
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), bt_rst_gpios)
+        gpio_pin_set_dt(&wifi_gpio.bt_rst, 0);
+#endif
+
+        k_msleep(10);
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), pdn_gpios)
+        gpio_pin_set_dt(&wifi_gpio.pdn, 0);
+#endif
+
+        k_msleep(100);
+    }
+}
+
 static void sdio_controller_init(void)
 {
     (void)memset(&wm_g_sd, 0, sizeof(struct sd_card));
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), wl_rst_gpios)
+    if (gpio_pin_configure_dt(&wifi_gpio.wl_rst, GPIO_OUTPUT) < 0)
+    {
+        sdio_e("Failed to configure WiFi reset pin");
+    }
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), pdn_gpios)
+    if (gpio_pin_configure_dt(&wifi_gpio.pdn, GPIO_OUTPUT) < 0)
+    {
+        sdio_e("Failed to configure power down pin");
+    }
+#endif
+
+#if DT_NODE_HAS_PROP(DT_NODELABEL(wifi), bt_rst_gpios)
+    if (gpio_pin_configure_dt(&wifi_gpio.bt_rst, GPIO_OUTPUT) < 0)
+    {
+        sdio_e("Failed to configure BT reset pin");
+    }
+#endif
+
+    BOARD_WIFI_BT_Enable(false);
 }
 
 static int sdio_card_init(void)
 {
     int ret = WM_SUCCESS;
     uint32_t resp;
+
+    BOARD_WIFI_BT_Enable(true);
 
     if (!device_is_ready(sdhc_dev))
     {

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
@@ -2761,11 +2761,7 @@ void handle_cdint(int error)
     if (!error && g_txrx_flag)
     {
         g_txrx_flag = false;
-#if CONFIG_ZEPHYR
-        (void)OSA_EventNotifyPost(wm_wifi.wifi_core_task_Handle);
-#else
-        (void)OSA_EventSet((osa_event_handle_t)wm_wifi.wifi_event_Handle, WIFI_EVENT_SDIO);
-#endif
+        (void)OSA_TaskNotifyPost(wm_wifi.wifi_core_task_Handle);
     }
 }
 

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -59,3 +59,12 @@ blobs:
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
     url: https://github.com/nxp-mcuxpresso/mcux-sdk-middleware-ieee_802.15.4/raw/MCUX_2.16.100/bin/mcxw71/mcxw71_nbu_ble_15_4_dyn_1_0_17_2.sb3
     description: "BLE Controller and IEEE 802.15.4 PHY combo firmware for MCXW71 boards"
+#SD8987
+  - path: SD8987/sduart8987_wlan_bt.bin.inc
+    sha256: e8f0db42a54769d5d1c54f2b931121713211d3925acb3c8753f117f6376c8ffb
+    type: img
+    version: '1.0'
+    license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
+    url: https://raw.githubusercontent.com/NXP/wifi_nxp/mcux_wifi_release/wifi_bt_firmware/8987/sduart8987_wlan_bt.bin.inc
+    description: "Firmware for NXP SD8987 Wi-Fi + Bluetooth single-chip solution"
+    doc-url: https://github.com/NXP/wifi_nxp/blob/mcux_wifi_release/wifi_bt_firmware/version.txt


### PR DESCRIPTION
drivers: wifi: nxp: Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module

- Fix the compilation error on the MIMXRT1170_EVK board with the NXP_88W8987_MURATA_1ZM_M2 WiFi module