### PR TITLE
middleware: wifi_nxp: Include new hostap glue layer header file

### DIFF
--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -19,6 +19,9 @@
 #include "rtos_wpa_supp_if.h"
 #include "wifi-internal.h"
 #include "supp_main.h"
+#if CONFIG_NXP_WIFI_SOFTAP_SUPPORT
+#include "hapd_main.h"
+#endif
 
 #define MAX_MGMT_TX_FRAME_SIZE 1500
 

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -6002,7 +6002,7 @@ static enum cm_uap_state uap_state_machine(struct wifi_message *msg)
             break;
         case CM_UAP_USER_REQUEST_STOP:
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
-            supplicant_ap_disable(net_if_get_device((void *)netif));
+            net_mgmt(NET_REQUEST_WIFI_AP_DISABLE, (struct net_if *)netif, NULL, 0);
 #else
             if (wlan.uap_state < CM_UAP_CONFIGURED)
             {


### PR DESCRIPTION
Include new header file to support hostapd source code split in glue layer.