### PR TITLE
Feature/enable usb host controller

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -194,3 +194,9 @@ Patch List:
     (usb_device_ehci.c and usb_device_lpcip3511.c) in Zephyr environment.
   - drivers: dmamux: Fix build error when FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL is defined as 1.
   - mcux-sdk-ng: drivers: dma3: Add peripheral to peripheral support.
+  - Add usb_host_mcux_drv_port.h file for using MCUX SDK USB host controller driver easily in Zephyr.
+      - usb_host_mcux_drv_port.h contains the simplified structs, enums and APIs that MCUX SDK USB host controller drivers need.
+      - Update usb_host_ehci.c, usb_host_khci.c, usb_host_ohci.c and usb_host_ip3516hs.c if in Zephyr environment.
+        - Add include of usb_host_mcux_drv_port.h.
+        - Remove include of usb_host.h, usb_host_hci.h, usb_host_devices.h and usb_host_framework.h.
+      - Update usb_host_ehci.c and usb_host_ip3516hs.c to not depend on usb_host_device_instance_t struct.

--- a/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/drivers/fsl_clock.c
@@ -1984,6 +1984,32 @@ bool CLOCK_EnableUsbfs0HostClock(clock_usbfs_src_t src, uint32_t freq)
         /* Select FRO 96 MHz */
         CLOCK_AttachClk(kFRO_HF_to_USB0_CLK);
     }
+    else if (kCLOCK_UsbfsSrcPll0 == src)
+    {
+        /*!< Configure XTAL32M */
+        POWER_DisablePD(kPDRUNCFG_PD_XTAL32M);                                /* Ensure XTAL32M is powered */
+        POWER_DisablePD(kPDRUNCFG_PD_LDOXO32M);                               /* Ensure XTAL32M is powered */
+        (void)CLOCK_SetupExtClocking(16000000U);                              /* Enable clk_in clock */
+        SYSCON->CLOCK_CTRL |= SYSCON_CLOCK_CTRL_CLKIN_ENA_MASK;               /* Enable clk_in from XTAL32M clock  */
+        ANACTRL->XO32M_CTRL |= ANACTRL_XO32M_CTRL_ENABLE_SYSTEM_CLK_OUT_MASK; /* Enable clk_in to system  */
+
+        /*!< Set up PLL0 */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0);
+        CLOCK_AttachClk(kEXT_CLK_to_PLL0); /*!< Switch PLL0CLKSEL to EXT_CLK */
+        POWER_DisablePD(kPDRUNCFG_PD_PLL0_SSCG);
+        const pll_setup_t pll1Setup = {
+            .pllctrl = SYSCON_PLL0CTRL_CLKEN_MASK | SYSCON_PLL0CTRL_SELI(19U) | SYSCON_PLL0CTRL_SELP(9U),
+            .pllndec = SYSCON_PLL0NDEC_NDIV(1U),
+            .pllpdec = SYSCON_PLL0PDEC_PDIV(5U),
+            .pllsscg = {0x0U,(SYSCON_PLL0SSCG1_MDIV_EXT(30U) | SYSCON_PLL0SSCG1_SEL_EXT_MASK)},
+            .pllRate = 48000000U,
+            .flags   = PLL_SETUPFLAG_WAITLOCK};
+        (void)CLOCK_SetPLL0Freq(&pll1Setup);
+
+        CLOCK_SetClkDiv(kCLOCK_DivUsb0Clk, 1U, false);
+        CLOCK_AttachClk(kPLL0_to_USB0_CLK);
+        SDK_DelayAtLeastUs(50U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
     else
     {
         /*!< Configure XTAL32M */

--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ip3516hs.c
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ip3516hs.c
@@ -8,11 +8,17 @@
 
 #include "usb_host_config.h"
 #if (defined(USB_HOST_CONFIG_IP3516HS) && (USB_HOST_CONFIG_IP3516HS > 0U))
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ip3516hs.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_ip3516hs.h"
 #include "usb_host_devices.h"
+#endif
 #if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT > 0U))
 #include "usb_phy.h"
 #endif
@@ -352,6 +358,15 @@ static void USB_HostIp3516HsDelay(usb_host_ip3516hs_state_struct_t *usbHostState
             (USB_HOST_IP3516HS_FLADJ_FRINDEX_MASK >> USB_HOST_IP3516HS_FLADJ_FRINDEX_SHIFT));
     } while ((distance) < (ms)); /* compute the distance between sofStart and SofEnd */
 }
+
+static uint8_t USB_HostIp3516HsGetDeviceInfo(usb_device_handle deviceHandle, uint32_t infoCode)
+{
+    uint32_t info_val = 0U;
+
+    USB_HostHelperGetPeripheralInformation(deviceHandle, (uint32_t)infoCode, &info_val);
+    return (uint8_t)info_val;
+}
+
 /*seperate bus control to standlone alone function for misra Rule17.2*/
 static usb_status_t USB_HostIp3516HsControlBusReset(usb_host_ip3516hs_state_struct_t *usbHostState)
 {
@@ -471,14 +486,11 @@ static usb_status_t USB_HostIp3516HsControlBus(usb_host_ip3516hs_state_struct_t 
                     ((uint32_t)usbHostState->L1remoteWakeupEnable << USB_HOST_IP3516HS_USBCMD_LPM_RWU_SHIFT));
                 usbHostState->usbRegBase->USBCMD = portStatus;
 
-                usb_host_device_instance_t *deviceInstance;
-
                 usbHostState->busSuspendStatus = (uint8_t)kBus_Ip3516HsL1StartSleep;
 
-                deviceInstance = (usb_host_device_instance_t *)hostPointer->suspendedDevice;
                 usbHostState->usbRegBase->PORTSC1 |= (uint32_t)(
                     (uint32_t)USB_HOST_IP3516HS_PORTSC1_SUSP_MASK | (uint32_t)USB_HOST_IP3516HS_PORTSC1_SUS_L1_MASK |
-                    (((uint32_t)deviceInstance->setAddress << USB_HOST_IP3516HS_PORTSC1_DEV_ADD_SHIFT) &
+                    (((uint32_t)USB_HostIp3516HsGetDeviceInfo(hostPointer->suspendedDevice, kUSB_HostGetDeviceAddress) << USB_HOST_IP3516HS_PORTSC1_DEV_ADD_SHIFT) &
                      (uint32_t)USB_HOST_IP3516HS_PORTSC1_DEV_ADD_MASK));
 #if (defined(FSL_FEATURE_USBHSH_VERSION) && (FSL_FEATURE_USBHSH_VERSION >= 300U))
 #else
@@ -1126,7 +1138,7 @@ static usb_status_t USB_HostIp3516HsFindStartFrame(usb_host_ip3516hs_state_struc
     uint32_t total = 0U;
     void *temp;
     uint8_t slotTime[8];
-    uint8_t speed = ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed;
+    uint8_t speed = USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed);
 
     pipe->startUFrame = 0U;
 
@@ -1280,7 +1292,7 @@ static usb_status_t USB_HostIp3516BaudWidthCheck(usb_host_ip3516hs_state_struct_
                                                  usb_host_ip3516hs_pipe_struct_t *pipe)
 {
     usb_status_t error;
-    uint8_t speed = ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed;
+    uint8_t speed = USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed);
     OSA_SR_ALLOC();
 
     pipe->busHsTime = (uint16_t)USB_HostIp3516HsBusTime(
@@ -1334,11 +1346,11 @@ static usb_status_t USB_HostIp3516HsOpenControlBulkPipe(usb_host_ip3516hs_state_
     atl->control1Union.stateBitField.Mult = pipe->pipeCommon.numberPerUframe;
     atl->control2Union.stateBitField.EP   = pipe->pipeCommon.endpointAddress;
     atl->control2Union.stateBitField.DeviceAddress =
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->setAddress;
+        USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceAddress);
     if (USB_SPEED_HIGH == usbHostState->portState[0].portSpeed)
     {
         atl->control2Union.stateBitField.S =
-            (USB_SPEED_HIGH == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 0U : 1U;
+            (USB_SPEED_HIGH == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 0U : 1U;
     }
     else
     {
@@ -1347,16 +1359,16 @@ static usb_status_t USB_HostIp3516HsOpenControlBulkPipe(usb_host_ip3516hs_state_
     atl->control2Union.stateBitField.RL  = 0xFU;
     atl->stateUnion.stateBitField.NakCnt = 0xFU;
     atl->control2Union.stateBitField.SE =
-        (USB_SPEED_LOW == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 2U : 0U;
+        (USB_SPEED_LOW == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 2U : 0U;
     atl->control2Union.stateBitField.PortNumber =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubPort;
+        USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubPort);
 #else
         0U;
 #endif
     atl->control2Union.stateBitField.HubAddress =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubNumber;
+        USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubNumber);
 #else
         0U;
 #endif
@@ -1433,11 +1445,11 @@ static usb_status_t USB_HostIp3516HsOpenIsoPipe(usb_host_ip3516hs_state_struct_t
         ptl->control1Union.stateBitField.Mult = pipe->pipeCommon.numberPerUframe;
         ptl->control2Union.stateBitField.EP   = pipe->pipeCommon.endpointAddress;
         ptl->control2Union.stateBitField.DeviceAddress =
-            ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->setAddress;
+            USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceAddress);
         if (USB_SPEED_HIGH == usbHostState->portState[0].portSpeed)
         {
             ptl->control2Union.stateBitField.S =
-                (USB_SPEED_HIGH == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 0U : 1U;
+                (USB_SPEED_HIGH == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 0U : 1U;
         }
         else
         {
@@ -1446,18 +1458,18 @@ static usb_status_t USB_HostIp3516HsOpenIsoPipe(usb_host_ip3516hs_state_struct_t
         ptl->control2Union.stateBitField.RL  = 0U;
         ptl->stateUnion.stateBitField.NakCnt = 0U;
         ptl->control2Union.stateBitField.SE =
-            (USB_SPEED_LOW == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 2U : 0U;
+            (USB_SPEED_LOW == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 2U : 0U;
         if (0U != ptl->control2Union.stateBitField.S)
         {
             sptl->control2Union.stateBitField.PortNumber =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-                ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubPort;
+                USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubPort);
 #else
                 0U;
 #endif
             sptl->control2Union.stateBitField.HubAddress =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-                ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubNumber;
+                USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubNumber);
 #else
                 0U;
 #endif
@@ -1523,11 +1535,11 @@ static usb_status_t USB_HostIp3516HsOpenInterruptPipe(usb_host_ip3516hs_state_st
     ptl->control1Union.stateBitField.Mult = pipe->pipeCommon.numberPerUframe;
     ptl->control2Union.stateBitField.EP   = pipe->pipeCommon.endpointAddress;
     ptl->control2Union.stateBitField.DeviceAddress =
-        ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->setAddress;
+        USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceAddress);
     if (USB_SPEED_HIGH == usbHostState->portState[0].portSpeed)
     {
         ptl->control2Union.stateBitField.S =
-            (USB_SPEED_HIGH == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 0U : 1U;
+            (USB_SPEED_HIGH == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 0U : 1U;
     }
     else
     {
@@ -1536,18 +1548,18 @@ static usb_status_t USB_HostIp3516HsOpenInterruptPipe(usb_host_ip3516hs_state_st
     ptl->control2Union.stateBitField.RL  = 0xFU;
     ptl->stateUnion.stateBitField.NakCnt = 0xFU;
     ptl->control2Union.stateBitField.SE =
-        (USB_SPEED_LOW == ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed) ? 2U : 0U;
+        (USB_SPEED_LOW == USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed)) ? 2U : 0U;
     if (0U != ptl->control2Union.stateBitField.S)
     {
         sptl->control2Union.stateBitField.PortNumber =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-            ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubPort;
+            USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubPort);
 #else
             0U;
 #endif
         sptl->control2Union.stateBitField.HubAddress =
 #if (defined(USB_HOST_CONFIG_HUB) && (USB_HOST_CONFIG_HUB > 0U))
-            ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->hsHubNumber;
+            USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceHSHubNumber);
 #else
             0U;
 #endif
@@ -2221,7 +2233,7 @@ static usb_status_t USB_HostIp3516HsWriteIsoPipe(usb_host_ip3516hs_state_struct_
     indexLength_t indexLength;
     uint8_t *bufferAddress;
     void *temp;
-    uint8_t speed = ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed;
+    uint8_t speed = USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed);
     OSA_SR_ALLOC();
 
     OSA_ENTER_CRITICAL();
@@ -2425,7 +2437,7 @@ static usb_status_t USB_HostIp3516HsWriteInterruptPipe(usb_host_ip3516hs_state_s
     uint32_t insertUFrame;
     uint8_t *bufferAddress;
     void *temp;
-    uint8_t speed = ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed;
+    uint8_t speed = USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed);
     temp          = (void *)ptl;
     sptl          = (usb_host_ip3516hs_sptl_struct_t *)temp;
     OSA_SR_ALLOC();
@@ -3586,7 +3598,7 @@ usb_status_t USB_HostIp3516HsOpenPipe(usb_host_controller_handle controllerHandl
     }
     else if (USB_ENDPOINT_INTERRUPT == pipe->pipeCommon.pipeType)
     {
-        if (USB_SPEED_HIGH != ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed)
+        if (USB_SPEED_HIGH != USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed))
         {
             uint32_t interval = 0U;
             /* FS/LS interrupt interval should be the power of 2, it is used for ip3516hs bandwidth */
@@ -3613,7 +3625,7 @@ usb_status_t USB_HostIp3516HsOpenPipe(usb_host_controller_handle controllerHandl
         pipe->pipeCommon.interval = 0U;
     }
 
-    if (USB_SPEED_HIGH != ((usb_host_device_instance_t *)pipe->pipeCommon.deviceHandle)->speed)
+    if (USB_SPEED_HIGH != USB_HostIp3516HsGetDeviceInfo(pipe->pipeCommon.deviceHandle, kUSB_HostGetDeviceSpeed))
     {
         pipe->pipeCommon.interval = pipe->pipeCommon.interval << 3;
     }

--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_mcux_drv_port.h
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_mcux_drv_port.h
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* This file is used in Zephyr */
+
+#ifndef _USB_HOST_MCUX_DRV_PORT_H_
+#define _USB_HOST_MCUX_DRV_PORT_H_
+
+#include "usb.h"
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief USB host controller handle type define */
+typedef void *usb_host_controller_handle;
+
+/*! @brief USB host pipe handle type define */
+typedef void *usb_host_pipe_handle;
+
+/*! @brief USB host configuration handle type define */
+typedef void *usb_host_configuration_handle;
+
+/*! @brief USB host controller control code */
+typedef enum _usb_host_controller_control {
+	kUSB_HostCancelTransfer = 1U,          /*!< Cancel transfer code */
+	kUSB_HostBusControl,                   /*!< Bus control code */
+	kUSB_HostGetFrameNumber,               /*!< Get frame number code */
+	kUSB_HostUpdateControlEndpointAddress, /*!< Update control endpoint address */
+	kUSB_HostUpdateControlPacketSize,      /*!< Update control endpoint maximum  packet size */
+	kUSB_HostPortAttachDisable,            /*!< Disable the port attach event */
+	kUSB_HostPortAttachEnable,             /*!< Enable the port attach event */
+	kUSB_HostL1Config,                     /*!< L1 suspend Bus control code */
+	kUSB_HostSetChargerType,               /*!< set charger type */
+#if ((defined USB_HOST_CONFIG_COMPLIANCE_TEST) && (USB_HOST_CONFIG_COMPLIANCE_TEST))
+	kUSB_HostTestModeInit,                 /*!< initialize charger type */
+#endif
+} usb_host_controller_control_t;
+
+/*! @brief USB host controller bus control code */
+typedef enum _usb_host_bus_control {
+	kUSB_HostBusReset = 1U,    /*!< Reset bus */
+	kUSB_HostBusRestart,       /*!< Restart bus */
+	kUSB_HostBusEnableAttach,  /*!< Enable attach */
+	kUSB_HostBusDisableAttach, /*!< Disable attach */
+	kUSB_HostBusSuspend,       /*!< Suspend BUS */
+	kUSB_HostBusResume,        /*!< Resume BUS */
+	kUSB_HostBusL1SuspendInit, /*!< L1 Suspend BUS */
+	kUSB_HostBusL1Sleep,       /*!< L1 Suspend BUS */
+	kUSB_HostBusL1Resume,      /*!< L1 Resume BUS */
+} usb_host_bus_control_t;
+
+/*! @brief USB host device information code */
+typedef enum _usb_host_dev_info {
+	kUSB_HostGetDeviceAddress = 1U, /*!< Device's address */
+	kUSB_HostGetDeviceHubNumber,    /*!< Device's first hub address */
+	kUSB_HostGetDevicePortNumber,   /*!< Device's first hub port number */
+	kUSB_HostGetDeviceSpeed,        /*!< Device's speed */
+	kUSB_HostGetDeviceHSHubNumber,  /*!< Device's first high-speed hub address */
+	kUSB_HostGetDeviceHSHubPort,    /*!< Device's first high-speed hub number */
+	kUSB_HostGetDeviceLevel,        /*!< Device's hub level */
+	kUSB_HostGetHostHandle,         /*!< Device's host handle */
+	kUSB_HostGetDeviceControlPipe,  /*!< Device's control pipe handle */
+	kUSB_HostGetDevicePID,          /*!< Device's PID */
+	kUSB_HostGetDeviceVID,          /*!< Device's VID */
+	kUSB_HostGetHubThinkTime,       /*!< Device's hub total think time */
+	kUSB_HostGetDeviceConfigIndex,  /*!< Device's running zero-based config index */
+	kUSB_HostGetConfigurationDes,   /*!< Device's configuration descriptor pointer */
+	kUSB_HostGetConfigurationLength,/*!< Device's configuration descriptor pointer */
+} usb_host_dev_info_t;
+
+struct _usb_host_transfer;
+/*!
+ * @brief Host stack inner transfer callback function typedef.
+ *
+ * This callback function is used to notify the upper layer the result of a transfer.
+ * This callback pointer is passed when initializing the structure usb_host_transfer_t.
+ *
+ * @param param	 The parameter pointer, which is passed when calling the send/receive APIs.
+ * @param transfer  The transfer information; See the structure usb_host_transfer_t.
+ * @param status	A USB error code or kStatus_USB_Success.
+ */
+typedef void (*host_inner_transfer_callback_t)(void *param,
+		struct _usb_host_transfer *transfer, usb_status_t status);
+
+/*!
+ * @brief Controller driver callback function typedef.
+ *
+ * This callback function is used to notify upper layer suspend related event.
+ * This callback pointer is passed when initializing the host.
+ *
+ * @param deviceHandle		   The device handle, which indicates the attached device.
+ * @param configurationHandle	The configuration handle contains the attached device's
+ *				configuration information. It is not used in Zephyr environment.
+ * @param event_code		   The callback event code; See the enumeration host_event_t.
+ *
+ * @return A USB error code or kStatus_USB_Success.
+ * @retval kStatus_USB_Success	   Application handles the attached device successfully.
+ * @retval kStatus_USB_NotSupported  Application don't support the attached device.
+ * @retval kStatus_USB_Error		 Application handles the attached device falsely.
+ */
+typedef usb_status_t (*host_callback_t)(usb_device_handle deviceHandle,
+				usb_host_configuration_handle configurationHandle,
+				uint32_t eventCode);
+
+/*! @brief USB host pipe information structure for opening pipe */
+typedef struct _usb_host_pipe_init {
+	void *devInstance;	/*!< Device instance handle*/
+	uint16_t nakCount;	/*!< Maximum NAK retry count. MUST be zero for interrupt*/
+	uint16_t maxPacketSize;	/*!< Pipe's maximum packet size*/
+	uint8_t interval;	/*!< Pipe's interval*/
+	uint8_t endpointAddress;/*!< Endpoint address*/
+	uint8_t direction;	/*!< Endpoint direction*/
+	uint8_t pipeType;	/*!< Endpoint type, the value is USB_ENDPOINT_INTERRUPT,
+				 * USB_ENDPOINT_CONTROL, USB_ENDPOINT_ISOCHRONOUS,
+				 * USB_ENDPOINT_BULK
+				 */
+	uint8_t numberPerUframe;/*!< Transaction number for each micro-frame*/
+} usb_host_pipe_init_t;
+
+/*! @brief USB host pipe common structure */
+typedef struct _usb_host_pipe {
+	struct _usb_host_pipe *next;	/*!< Link the idle pipes*/
+	usb_device_handle deviceHandle; /*!< This pipe's device's handle*/
+	uint16_t currentCount;		/*!< For KHCI transfer*/
+	uint16_t nakCount;		/*!< Maximum NAK count*/
+	uint16_t maxPacketSize;		/*!< Maximum packet size*/
+	uint16_t interval;		/*!< FS/LS: frame unit; HS: micro-frame unit*/
+	uint8_t open;			/*!< 0 - closed, 1 - open*/
+	uint8_t nextdata01;		/*!< Data toggle*/
+	uint8_t endpointAddress;	/*!< Endpoint address*/
+	uint8_t direction;		/*!< Pipe direction*/
+	uint8_t pipeType;		/*!< Pipe type, for example USB_ENDPOINT_BULK*/
+	uint8_t numberPerUframe;	/*!< Transaction number per micro-frame*/
+	uint8_t update_addr;		/*!< update control ep's addr, Zephyr use it*/
+} usb_host_pipe_t;
+
+/*! @brief USB host transfer structure */
+typedef struct _usb_host_transfer {
+	struct _usb_host_transfer *next;		/*!< The next transfer structure*/
+	uint8_t *transferBuffer;			/*!< Transfer data buffer*/
+	uint32_t transferLength;			/*!< Transfer data length*/
+	uint32_t transferSofar;	/*!< Length transferred so far*/
+	host_inner_transfer_callback_t callbackFn; /*!< Transfer callback function*/
+	void *callbackParam;				/*!< Transfer callback parameter*/
+	usb_host_pipe_t *transferPipe;			/*!< Transfer pipe pointer*/
+	usb_setup_struct_t *setupPacket;		/*!< Set up packet buffer*/
+	/*! Transfer direction; it's values are USB_OUT or USB_IN */
+	uint8_t direction;
+	uint8_t setupStatus;				/*!< Set up the transfer status*/
+	union {
+		uint32_t unitHead;			/*!< xTD head for this transfer*/
+		int32_t transferResult;			/*!< KHCI transfer result */
+	} union1;
+
+	union {
+		uint32_t unitTail;			/*!<xTD tail for this transfer*/
+		uint32_t frame;				/*!< KHCI transfer frame number */
+	} union2;
+
+#if USB_HOST_CONFIG_KHCI
+	uint16_t nakTimeout;				/*!< KHCI transfer NAK timeout */
+	uint16_t retry;					/*!< KHCI transfer retry */
+#endif
+	void *uhc_xfer;
+} usb_host_transfer_t;
+
+/*! @brief Cancel transfer parameter structure */
+typedef struct _usb_host_cancel_param {
+	usb_host_pipe_handle pipeHandle;	/*!< Canceling pipe handle*/
+	usb_host_transfer_t *transfer;		/*!< Canceling transfer*/
+} usb_host_cancel_param_t;
+
+/*! @brief USB host controller interface structure */
+typedef struct _usb_host_controller_interface {
+	/*! Create a controller instance function prototype*/
+	usb_status_t (*controllerCreate)(
+		uint8_t controllerId,
+		usb_host_handle upperLayerHandle,
+		usb_host_controller_handle *controllerHandle);
+	/*! Destroy a controller instance function prototype*/
+	usb_status_t (*controllerDestory)(
+		usb_host_controller_handle controllerHandle);
+	/*! Open a controller pipe function prototype*/
+	usb_status_t (*controllerOpenPipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle *pipeHandle,
+				usb_host_pipe_init_t *pipeInit);
+	/*! Close a controller pipe function prototype*/
+	usb_status_t (*controllerClosePipe)(
+		usb_host_controller_handle controllerHandle,
+		usb_host_pipe_handle pipeHandle);
+	/*! Write data to a pipe function prototype*/
+	usb_status_t (*controllerWritePipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle pipeHandle,
+				usb_host_transfer_t *transfer);
+	/*! Read data from a pipe function prototype*/
+	usb_status_t (*controllerReadPipe)(usb_host_controller_handle controllerHandle,
+				usb_host_pipe_handle pipeHandle,
+				usb_host_transfer_t *transfer);
+	/*! Control a controller function prototype*/
+	usb_status_t (*controllerIoctl)(usb_host_controller_handle controllerHandle,
+				uint32_t ioctlEvent,
+				void *ioctlParam);
+} usb_host_controller_interface_t;
+
+/*! @brief USB host instance structure */
+typedef struct _usb_host_instance {
+	void *controllerHandle;		/*!< The low level controller handle*/
+	host_callback_t deviceCallback;	/*!< Device attach/detach callback*/
+} usb_host_instance_t;
+
+/*!
+ * @brief Controller driver calls this function when device detaches.
+ *
+ * @param hostHandle   Host instance handle.
+ * @param hubNumber    Device hub no. root device's hub no. is 0.
+ * @param portNumber   Device port no. root device's port no. is 0.
+ *
+ * @return kStatus_USB_Success or error codes.
+ */
+usb_status_t USB_HostDetachDevice(usb_host_handle hostHandle, uint8_t hubNumber,
+					uint8_t portNumber);
+
+/*!
+ * @brief Controller driver calls this function when device attach.
+ *
+ * @param hostHandle    Host instance handle.
+ * @param speed         Device speed.
+ * @param hubNumber     Device hub no. root device's hub no. is 0.
+ * @param portNumber    Device port no. root device's port no. is 0.
+ * @param level         Device level. root device's level is 1.
+ * @param deviceHandle  Return device handle.
+ *
+ * @return kStatus_USB_Success or error codes.
+ */
+usb_status_t USB_HostAttachDevice(usb_host_handle hostHandle,
+				uint8_t speed,
+				uint8_t hubNumber,
+				uint8_t portNumber,
+				uint8_t level,
+				usb_device_handle *deviceHandle);
+
+/*!
+ * @brief Controller driver calls this function to get the device information.
+ *
+ * This function gets the device information.
+ *
+ * @param[in] deviceHandle   Removing device handle.
+ * @param[in] infoCode       See the enumeration host_dev_info_t.
+ * @param[out] infoValue     Return the information value.
+ *
+ * @retval kStatus_USB_Success           Close successfully.
+ * @retval kStatus_USB_InvalidParameter  The deviceHandle or info_value is a NULL pointer.
+ * @retval kStatus_USB_Error             The info_code is not the host_dev_info_t value.
+ */
+usb_status_t USB_HostHelperGetPeripheralInformation(usb_device_handle deviceHandle,
+				uint32_t infoCode,
+				uint32_t *infoValue);
+
+#if (defined(USB_HOST_CONFIG_EHCI) && (USB_HOST_CONFIG_EHCI > 0U))
+/*!
+ * @brief Device EHCI ISR function.
+ *
+ * The function is the EHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostEhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief EHCI task function.
+ *
+ * The function is used to handle the EHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostEhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_KHCI) && (USB_HOST_CONFIG_KHCI > 0U))
+/*!
+ * @brief Device KHCI ISR function.
+ *
+ * The function is the KHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostKhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief KHCI task function.
+ *
+ * The function is used to handle the KHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+void USB_HostKhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_OHCI) && (USB_HOST_CONFIG_OHCI > 0U))
+/*!
+ * @brief Device OHCI ISR function.
+ *
+ * The function is the OHCI interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostOhciIsrFunction(void *hostHandle);
+
+/*!
+ * @brief OHCI task function.
+ *
+ * The function is used to handle the OHCI controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostOhciTaskFunction(void *hostHandle);
+#endif
+
+#if (defined(USB_HOST_CONFIG_IP3516HS) && (USB_HOST_CONFIG_IP3516HS > 0U))
+/*!
+ * @brief Device IP3516HS ISR function.
+ *
+ * The function is the IP3516HS interrupt service routine.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostIp3516HsIsrFunction(void *hostHandle);
+
+/*!
+ * @brief IP3516HS task function.
+ *
+ * The function is used to handle the IP3516HS controller message.
+ * In the bare metal environment, this function should be called periodically in the main function.
+ * In the RTOS environment, this function should be used as a function entry to create a task.
+ *
+ * @param[in] hostHandle The host handle.
+ */
+extern void USB_HostIp3516HsTaskFunction(void *hostHandle);
+#endif
+
+#endif /* _USB_HOST_MCUX_DRV_PORT_H_ */


### PR DESCRIPTION
Add the NXP USB Host controllers support in Zephyr.
Support EHCI, KHCI, OHCI and IP3516HS NXP controllers.

The Zephyr PR is: https://github.com/zephyrproject-rtos/zephyr/pull/77973


Note: This pr replace the pr (https://github.com/zephyrproject-rtos/hal_nxp/pull/327) because the old pr use nxp-zephyr repository that is deprecated