### PR TITLE
devices: MIMX8ML8: fixes for clock gating/ungating

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -126,3 +126,5 @@ Patch List:
     controller
   - drivers: edma_rev2: add macro for CHn_CSR's ACTIVE bit
   - drivers: rtwdog: Fix the issue that driver doesn't wait the over status after CS register operation
+  - devices: MIMX8ML8: fsl_clock: fix root clock gating/ungating
+  - devices: MIMX8ML8: fsl_clock: change root clock ID for SAI3

--- a/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.c
@@ -920,25 +920,27 @@ void CLOCK_EnableClock(clock_ip_name_t ccmGate)
 {
     uint32_t clockType = CLOCK_GATE_TYPE(ccmGate);
     uint32_t ccgr      = CCM_TUPLE_CCGR(ccmGate);
-    uint32_t rootClk   = 0U;
+    uint32_t rootClk     = 0U;
+    uint32_t rootClkId   = 0U;
 
     if (CLOCK_GATE_IN_AUDIOMIX == clockType)
     {
         uint32_t offset = AUDIOMIX_TUPLE_OFFSET(ccmGate);
         uint32_t gate   = AUDIOMIX_TUPLE_GATE(ccmGate);
-        rootClk         = AUDIOMIX_TUPLE_ROOT(ccmGate);
+        rootClkId       = AUDIOMIX_TUPLE_ROOT_ID(ccmGate);
 
         *(volatile uint32_t *)((uintptr_t)AUDIOMIX + offset) |= (uint32_t)1U << gate;
     }
     else
     {
         CCM_REG_SET(ccgr) = (uint32_t)kCLOCK_ClockNeededAll;
-        rootClk           = CCM_TUPLE_ROOT(ccmGate);
+        rootClkId         = CCM_TUPLE_ROOT_ID(ccmGate);
     }
 
     /* if root clock is 0xFFFFU, then skip enable root clock */
-    if (rootClk != 0xFFFFU)
+    if (rootClkId != 0xFFFFU)
     {
+        rootClk = CCM_TUPLE_ROOT(rootClkId);
         CCM_REG_SET(rootClk) = CCM_TARGET_ROOT_SET_ENABLE_MASK;
     }
 }
@@ -957,24 +959,26 @@ void CLOCK_DisableClock(clock_ip_name_t ccmGate)
     uint32_t ccgr      = CCM_TUPLE_CCGR(ccmGate);
     uint32_t clockType = CLOCK_GATE_TYPE(ccmGate);
     uint32_t rootClk   = 0U;
+    uint32_t rootClkId = 0U;
 
     if (CLOCK_GATE_IN_AUDIOMIX == clockType)
     {
         uint32_t offset = AUDIOMIX_TUPLE_OFFSET(ccmGate);
         uint32_t gate   = AUDIOMIX_TUPLE_GATE(ccmGate);
-        rootClk         = AUDIOMIX_TUPLE_ROOT(ccmGate);
+        rootClkId       = AUDIOMIX_TUPLE_ROOT_ID(ccmGate);
 
         *(volatile uint32_t *)((uintptr_t)AUDIOMIX + offset) &= ~((uint32_t)1U << gate);
     }
     else
     {
         CCM_REG(ccgr) = (uint32_t)kCLOCK_ClockNotNeeded;
-        rootClk       = CCM_TUPLE_ROOT(ccmGate);
+        rootClkId     = CCM_TUPLE_ROOT(ccmGate);
     }
 
     /* if root clock is 0xFFFFU, then skip disable root clock */
-    if (rootClk != 0xFFFFU)
+    if (rootClkId != 0xFFFFU)
     {
+        rootClk = CCM_TUPLE_ROOT(rootClkId);
         CCM_REG_CLR(rootClk) = CCM_TARGET_ROOT_CLR_ENABLE_MASK;
     }
 }

--- a/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.h
@@ -233,13 +233,14 @@
 #define CLOCK_GATE_TYPE(tuple) ((uint32_t)(tuple) >> 28U)
 #define CCM_TUPLE(ccgr, root)  ((((ccgr)&0xFFFFU) << 16U) | (root))
 #define CCM_TUPLE_CCGR(tuple)  ((uintptr_t)(&(CCM)->CCGR[(uint32_t)(tuple) >> 16U].CCGR))
-#define CCM_TUPLE_ROOT(tuple)  ((uintptr_t)(&(CCM)->ROOT[(uint32_t)(tuple)&0xFFFFU].TARGET_ROOT))
+#define CCM_TUPLE_ROOT_ID(tuple) ((uint32_t)(tuple)&0xFFFFU)
+#define CCM_TUPLE_ROOT(id)  ((uintptr_t)(&(CCM)->ROOT[id].TARGET_ROOT))
 /*!@brief audio mix CCGR */
 #define AUDIOMIX_TUPLE(offset, gate, root) \
     (((CLOCK_GATE_IN_AUDIOMIX) << 28U) | (((offset)&0xFU) << 24U) | (((gate)&0xFFU) << 16U) | ((root)&0xFFFFU))
 #define AUDIOMIX_TUPLE_OFFSET(tuple) (((uint32_t)(tuple) >> 24U) & 0xFU)
 #define AUDIOMIX_TUPLE_GATE(tuple)   (((uint32_t)(tuple) >> 16U) & 0xFFU)
-#define AUDIOMIX_TUPLE_ROOT(tuple)   ((uint32_t)(tuple)&0xFFFFU)
+#define AUDIOMIX_TUPLE_ROOT_ID(tuple)   ((uint32_t)(tuple)&0xFFFFU)
 
 /*!
  * @brief clock root source

--- a/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk/devices/MIMX8ML8/drivers/fsl_clock.h
@@ -636,7 +636,7 @@ typedef enum _clock_ip_name
     kCLOCK_Sai3_Mclk3 = AUDIOMIX_TUPLE(0U, 11U, 0xFFFF), /*!< SAI3 MCLK3 clock gate */
     kCLOCK_Sai3_Mclk2 = AUDIOMIX_TUPLE(0U, 10U, 0xFFFF), /*!< SAI3 MCLK2 clock gate */
     kCLOCK_Sai3_Mclk1 = AUDIOMIX_TUPLE(0U, 9U, 0xFFFF),  /*!< SAI3 MCLK1 clock gate */
-    kCLOCK_Sai3       = AUDIOMIX_TUPLE(0U, 8U, 77U),     /*!< SAI3 clock gate */
+    kCLOCK_Sai3       = AUDIOMIX_TUPLE(0U, 8U, 0xFFFF),     /*!< SAI3 clock gate */
 
     kCLOCK_Sai2_Mclk3 = AUDIOMIX_TUPLE(0U, 7U, 0xFFFF), /*!< SAI2 MCLK3 clock gate */
     kCLOCK_Sai2_Mclk2 = AUDIOMIX_TUPLE(0U, 6U, 0xFFFF), /*!< SAI2 MCLK2 clock gate */


### PR DESCRIPTION
Depends on: https://github.com/nxp-mcuxpresso/mcux-sdk/pull/229.