### PR TITLE
mcux: mcux-sdk-middleware-usb: disable usb controller zlt

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -136,3 +136,5 @@ Patch List:
   - drivers: rtwdog: Fix the issue that driver doesn't wait the over status after CS register operation
   - drivers: elemu: undefine BIT macro to avoid collision from util_macro.h in Zephyr
   - mcux-sdk-middleware-ieee_802.15.4: adapt code to be supported with Zephyr
+  - mcux-sdk-middleware-usb: Disable the control endpoint ZLT (Zero Length Transaction) of MCUX hal USB controller drivers
+    (usb_device_ehci.c and usb_device_lpcip3511.c) in Zephyr environment.

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_ehci.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_ehci.c
@@ -1070,7 +1070,10 @@ static usb_status_t USB_DeviceEhciTransfer(usb_device_ehci_state_struct_t *ehciS
     uint8_t qhIdle              = 0U;
     uint8_t waitingSafelyAccess = 1U;
     uint32_t primeTimesCount    = 0U;
+/* CONFIG_UDC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if !((defined CONFIG_UDC_DRIVER) && (CONFIG_UDC_DRIVER))
     void *temp;
+#endif
     OSA_SR_ALLOC();
 
     if (NULL == ehciState)
@@ -1190,6 +1193,8 @@ static usb_status_t USB_DeviceEhciTransfer(usb_device_ehci_state_struct_t *ehciS
             qhIdle                    = 1U;
         }
     } while (0U != length);
+/* CONFIG_UDC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if !((defined CONFIG_UDC_DRIVER) && (CONFIG_UDC_DRIVER))
     if ((USB_CONTROL_ENDPOINT == (endpointAddress & USB_ENDPOINT_NUMBER_MASK)) &&
         (USB_IN == ((endpointAddress & USB_DESCRIPTOR_ENDPOINT_ADDRESS_DIRECTION_MASK) >>
                     USB_DESCRIPTOR_ENDPOINT_ADDRESS_DIRECTION_SHIFT)))
@@ -1210,6 +1215,7 @@ static usb_status_t USB_DeviceEhciTransfer(usb_device_ehci_state_struct_t *ehciS
             }
         }
     }
+#endif
     /* If the QH is not empty */
     if (0U == qhIdle)
     {

--- a/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
+++ b/mcux/middleware/mcux-sdk-middleware-usb/device/usb_device_lpcip3511.c
@@ -1120,8 +1120,11 @@ static void USB_DeviceLpc3511IpInterruptToken(usb_device_lpc3511ip_state_struct_
     usb_device_callback_message_struct_t message;
     uint32_t length;
     uint32_t remainLength;
+/* CONFIG_UDC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if !((defined CONFIG_UDC_DRIVER) && (CONFIG_UDC_DRIVER))
     usb_setup_struct_t *setupPacket;
     void *temp;
+#endif
     usb_device_lpc3511ip_endpoint_state_struct_t *epState =
         USB_DeviceLpc3511IpGetEndpointStateStruct(lpc3511IpState, endpointIndex);
 #if (defined USB_DEVICE_IP3511_DOUBLE_BUFFER_ENABLE) && (USB_DEVICE_IP3511_DOUBLE_BUFFER_ENABLE)
@@ -1357,6 +1360,8 @@ static void USB_DeviceLpc3511IpInterruptToken(usb_device_lpc3511ip_state_struct_
             if ((0U != (endpointIndex & 0x01U)) && (0U != length) &&
                 (0U == (length % epState->stateUnion.stateBitField.maxPacketSize)))
             {
+/* CONFIG_UDC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if !((defined CONFIG_UDC_DRIVER) && (CONFIG_UDC_DRIVER))
                 if ((endpointIndex >> 1U) == USB_CONTROL_ENDPOINT)
                 {
                     temp        = (void *)(&(lpc3511IpState->setupData[0]));
@@ -1380,7 +1385,9 @@ static void USB_DeviceLpc3511IpInterruptToken(usb_device_lpc3511ip_state_struct_
                         return;
                     }
                 }
-                else if ((0U != epState->stateUnion.stateBitField.zlt))
+                else
+#endif
+                if ((0U != epState->stateUnion.stateBitField.zlt))
                 {
 #if (defined(USB_DEVICE_CONFIG_RETURN_VALUE_CHECK) && (USB_DEVICE_CONFIG_RETURN_VALUE_CHECK > 0U))
                     if (kStatus_USB_Success !=


### PR DESCRIPTION
Zephyr USB device stack handles the zlt and the NXP usb controller drivers process the control endpoint zlt defaultly, disable it in controller driver if in Zephyr environment. The original NXP usb controller drivers disabled it, but the change is overwritten by mistake by 6d708041ce32d3a48622e9344663b677558fff4d commit.