### PR TITLE
mcux-sdk-ng/devices: hifi1/hifi4/fusionf1/ezhv should not load SDK ar…

### DIFF
--- a/mcux/mcux-sdk-ng/devices/RT/RT500/MIMXRT595S/fusionf1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT500/MIMXRT595S/fusionf1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_dsp.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT600/MIMXRT685S/hifi4/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT600/MIMXRT685S/hifi4/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_dsp.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT735S/ezhv/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT735S/ezhv/CMakeLists.txt
@@ -9,4 +9,4 @@ include(${SdkRootDirPath}/devices/ezhv/device_header_ezhv.cmake)
 include(${SdkRootDirPath}/devices/ezhv/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT735S/hifi1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT735S/hifi1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_hifi1.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT758S/ezhv/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT758S/ezhv/CMakeLists.txt
@@ -9,4 +9,4 @@ include(${SdkRootDirPath}/devices/ezhv/device_header_ezhv.cmake)
 include(${SdkRootDirPath}/devices/ezhv/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT758S/hifi1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT758S/hifi1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_hifi1.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/ezhv/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/ezhv/CMakeLists.txt
@@ -9,4 +9,4 @@ include(${SdkRootDirPath}/devices/ezhv/device_header_ezhv.cmake)
 include(${SdkRootDirPath}/devices/ezhv/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/riscv/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/hifi1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/hifi1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_hifi1.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/hifi4/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/RT/RT700/MIMXRT798S/hifi4/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_hifi4.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8ULP/MIMX8UD5/fusionf1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8ULP/MIMX8UD5/fusionf1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_dsp.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8ULP/MIMX8UD7/fusionf1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8ULP/MIMX8UD7/fusionf1/CMakeLists.txt
@@ -10,4 +10,4 @@ include(${SdkRootDirPath}/devices/xtensa/device_header_dsp.cmake)
 include(${SdkRootDirPath}/devices/xtensa/shared.cmake)
 
 # common configuration
-include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)
+#include(${SdkRootDirPath}/arch/xtensa/configuration/common.cmake)


### PR DESCRIPTION
The commom cmake for hifi1/hifi4/fusionf1/ezhv in SDK is not needed in zephyr. Should not load it in CMakeLists.txt.