### PR TITLE
mcux-sdk-ng/driver: Roll back the cache64 driver version

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/cache/cache64/fsl_cache.c
+++ b/mcux/mcux-sdk-ng/drivers/cache/cache64/fsl_cache.c
@@ -57,7 +57,7 @@ volatile uint8_t g_cache64MemPhyAliasId = 0U;
  ******************************************************************************/
 #if (defined(FSL_FEATURE_SOC_CACHE64_POLSEL_COUNT) && (FSL_FEATURE_SOC_CACHE64_POLSEL_COUNT > 0))
 /*!
- * brief Returns an instance number given peripheral base address.
+ * brief Returns an instance number given periphearl base address.
  *
  * param base The peripheral base address.
  * return CACHE64_POLSEL instance number starting from 0.
@@ -239,10 +239,10 @@ void CACHE64_InvalidateCacheByRange(uint32_t address, uint32_t size_byte)
 {
     if (size_byte > 0UL)
     {
-        uint32_t endAddr = MSDK_REG_SECURE_ADDR(address + size_byte - 0x01U);
+        uint32_t endAddr = MSDK_REG_NONSECURE_ADDR(address + size_byte - 0x01U);
         uint32_t pccReg  = 0;
         /* Align address to cache line size. */
-        uint32_t startAddr = MSDK_REG_SECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
+        uint32_t startAddr = MSDK_REG_NONSECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
         uint32_t instance  = CACHE64_GetInstanceByAddr(address);
         uint32_t endLim;
         CACHE64_CTRL_Type *base;
@@ -256,7 +256,7 @@ void CACHE64_InvalidateCacheByRange(uint32_t address, uint32_t size_byte)
             return;
         }
         base    = s_cache64ctrlBases[instance];
-        endLim  = MSDK_REG_SECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
+        endLim  = MSDK_REG_NONSECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
         endAddr = endAddr > endLim ? endLim : endAddr;
 
         /* Set the invalidate by line command and use the physical address. */
@@ -309,10 +309,10 @@ void CACHE64_CleanCacheByRange(uint32_t address, uint32_t size_byte)
 {
     if (size_byte > 0UL)
     {
-        uint32_t endAddr = MSDK_REG_SECURE_ADDR(address + size_byte - 0x01U);
+        uint32_t endAddr = MSDK_REG_NONSECURE_ADDR(address + size_byte - 0x01U);
         uint32_t pccReg  = 0;
         /* Align address to cache line size. */
-        uint32_t startAddr = MSDK_REG_SECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
+        uint32_t startAddr = MSDK_REG_NONSECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
         uint32_t instance  = CACHE64_GetInstanceByAddr(address);
         uint32_t endLim;
         CACHE64_CTRL_Type *base;
@@ -326,7 +326,7 @@ void CACHE64_CleanCacheByRange(uint32_t address, uint32_t size_byte)
             return;
         }
         base    = s_cache64ctrlBases[instance];
-        endLim  = MSDK_REG_SECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
+        endLim  = MSDK_REG_NONSECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
         endAddr = endAddr > endLim ? endLim : endAddr;
 
         /* Set the push by line command. */
@@ -381,10 +381,10 @@ void CACHE64_CleanInvalidateCacheByRange(uint32_t address, uint32_t size_byte)
 {
     if (size_byte > 0UL)
     {
-        uint32_t endAddr = MSDK_REG_SECURE_ADDR(address + size_byte - 0x01U);
+        uint32_t endAddr = MSDK_REG_NONSECURE_ADDR(address + size_byte - 0x01U);
         uint32_t pccReg  = 0;
         /* Align address to cache line size. */
-        uint32_t startAddr = MSDK_REG_SECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
+        uint32_t startAddr = MSDK_REG_NONSECURE_ADDR(address & ~((uint32_t)CACHE64_LINESIZE_BYTE - 1U));
         uint32_t instance  = CACHE64_GetInstanceByAddr(address);
         uint32_t endLim;
         CACHE64_CTRL_Type *base;
@@ -398,7 +398,7 @@ void CACHE64_CleanInvalidateCacheByRange(uint32_t address, uint32_t size_byte)
             return;
         }
         base    = s_cache64ctrlBases[instance];
-        endLim  = MSDK_REG_SECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
+        endLim  = MSDK_REG_NONSECURE_ADDR(phyMemBase[instance][g_cache64MemPhyAliasId] + phyMemSize[instance][g_cache64MemPhyAliasId] - 0x01U);
         endAddr = endAddr > endLim ? endLim : endAddr;
 
         /* Set the push by line command. */

--- a/mcux/mcux-sdk-ng/drivers/cache/cache64/fsl_cache.h
+++ b/mcux/mcux-sdk-ng/drivers/cache/cache64/fsl_cache.h
@@ -22,7 +22,7 @@
 /*! @name Driver version */
 /*! @{ */
 /*! @brief cache driver version. */
-#define FSL_CACHE_DRIVER_VERSION (MAKE_VERSION(2, 0, 9))
+#define FSL_CACHE_DRIVER_VERSION (MAKE_VERSION(2, 0, 8))
 /*! @} */
 
 /*! @brief cache line size. */
@@ -70,7 +70,7 @@ extern "C" {
 
 #if (defined(FSL_FEATURE_SOC_CACHE64_POLSEL_COUNT) && (FSL_FEATURE_SOC_CACHE64_POLSEL_COUNT > 0))
 /*!
- * @brief Returns an instance number given peripheral base address.
+ * @brief Returns an instance number given periphearl base address.
  *
  * @param base The peripheral base address.
  * @return CACHE64_POLSEL instance number starting from 0.


### PR DESCRIPTION
After updating the hal_nxp driver to SDK 25.03.00 release, the cache64 driver will cause the MCXN947 flash test cases to fail on the zephyr side.