### PR TITLE
mcux: wifi: nxp: support override TX power limit file

### DIFF
--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_enhanced_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_enhanced_tests.c
@@ -16,7 +16,9 @@
 #include <wifi.h>
 #include <wlan_tests.h>
 
-#ifdef WIFI_BT_TX_PWR_LIMITS
+#if defined(WIFI_BT_TX_PWR_LIMITS_OVERRIDE)
+#include WIFI_BT_TX_PWR_LIMITS_OVERRIDE
+#elif defined(WIFI_BT_TX_PWR_LIMITS)
 #include WIFI_BT_TX_PWR_LIMITS
 #else
 #error "Region tx power config not defined"

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_txpwrlimit_cfg.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_txpwrlimit_cfg.c
@@ -14,7 +14,9 @@
 #include "fsl_ocotp.h"
 #endif
 
-#ifdef WIFI_BT_TX_PWR_LIMITS
+#if defined(WIFI_BT_TX_PWR_LIMITS_OVERRIDE)
+#include WIFI_BT_TX_PWR_LIMITS_OVERRIDE
+#elif defined(WIFI_BT_TX_PWR_LIMITS)
 #include WIFI_BT_TX_PWR_LIMITS
 #else
 #error "Region tx power config not defined"


### PR DESCRIPTION
Support setting TX power limit file to override the default one for customer's board.