### PR TITLE
fsl_ecspi: fix compliance with Zephyr tests

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/ecspi/fsl_ecspi.c
+++ b/mcux/mcux-sdk-ng/drivers/ecspi/fsl_ecspi.c
@@ -728,8 +728,8 @@ status_t ECSPI_MasterTransferNonBlocking(ECSPI_Type *base, ecspi_master_handle_t
         return kStatus_ECSPI_Busy;
     }
 
-    /* Check if the input arguments valid */
-    if (((xfer->txData == NULL) && (xfer->rxData == NULL)) || (xfer->dataSize == 0U))
+    /* Check if data size argument is valid */
+    if (xfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }

--- a/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi.c
+++ b/mcux/mcux-sdk/drivers/ecspi/fsl_ecspi.c
@@ -728,8 +728,8 @@ status_t ECSPI_MasterTransferNonBlocking(ECSPI_Type *base, ecspi_master_handle_t
         return kStatus_ECSPI_Busy;
     }
 
-    /* Check if the input arguments valid */
-    if (((xfer->txData == NULL) && (xfer->rxData == NULL)) || (xfer->dataSize == 0U))
+    /* Check if data size argument is valid */
+    if (xfer->dataSize == 0U)
     {
         return kStatus_InvalidArgument;
     }


### PR DESCRIPTION
The `spi_loopback` test fails because of the new `test_spi_null_rx_buf_set test`.
This test puts a null buffer for RX and TX into the driver.

Expected behavior is that the driver returns with no error, but it does at the moment.

Other NXP SPI drivers do not show this behavior (for example `spi_nxp_lpspi` or `fsl_dspi`).

First I though the test has a problem because two null buffers are given, but the test is correct: https://github.com/zephyrproject-rtos/zephyr/pull/89324

