### PR TITLE
devices: MIMX9596: fsl_memory: corrected the starting value of M7 memory offset

### DIFF
--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX95/MIMX9596/drivers/fsl_memory.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX95/MIMX9596/drivers/fsl_memory.h
@@ -76,7 +76,7 @@ static inline uint32_t MEMORY_ConvertMemoryMapAddress(uint32_t addr, mem_directi
                 dest = addr + FSL_MEM_M33_TCM_OFFSET;
             }
 #elif (__CORTEX_M == 7U)
-            if ((addr > FSL_MEM_M7_TCM_BEGIN) && (addr <= FSL_MEM_M7_TCM_END))
+            if ((addr >= FSL_MEM_M7_TCM_BEGIN) && (addr <= FSL_MEM_M7_TCM_END))
             {
                 dest = addr + FSL_MEM_M7_TCM_OFFSET;
             }


### PR DESCRIPTION
find in support edma test case, the start address is not right.