### PR TITLE
mcux-sdk-ng: flexio: spi: Fix SPI master CS continuous issue

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/flexio/spi/fsl_flexio_spi.h
+++ b/mcux/mcux-sdk-ng/drivers/flexio/spi/fsl_flexio_spi.h
@@ -189,6 +189,8 @@ struct _flexio_spi_master_handle
     flexio_spi_shift_direction_t direction;         /*!< Shift direction. */
     flexio_spi_master_transfer_callback_t callback; /*!< FlexIO SPI callback. */
     void *userData;                                 /*!< Callback parameter. */
+    bool isCsContinuous;                            /*!< Is current transfer using CS continuous mode. */
+    uint32_t timer1Cfg;                             /*!< TIMER1 TIMCFG regiser value backup. */
 };
 
 /*******************************************************************************


### PR DESCRIPTION
- With current FLEXIO SPI master CS continuous mode implementation, the TX shifter register must be filled in time, otherwise the CS won't be continuous.
- Before CS continuous mode was supported, the function FLEXIO_SPI_MasterTransferNonBlocking:
  1. When it is called to transfer data, it fills one data frame to TX shifter buffer register first, then enables the FLEXIO interrupt.
  2. Only enables the RX shift buffer register full interrupt, reads RX data and fills TX data in ISR.
- This flow can't meet CS continuous mode requirement, because: After the first data frame written to TX shifter buffer register, the second data frame is only written after RX interrupt asserts. During this period, the TX shifter is not filled in time. CS is not continuous.
- To fix this issue, the TX interrupt is also enabled in CS continuous mode, to make the second TX data be filled in time in ISR. But this fix is not good:
  - If FLEXIO interrupt is blocked by other higher priority interrupt, and not served in time, the CS will still not be continuous.
  - In the ISR, when no interrupt status flag assert (https://github.com/zephyrproject-rtos/hal_nxp/pull/221), the ISR should return directly, but current fix assumes TX interrupt occurs and writes TX shifter buffer.
- This patch uses a new way to implement the CS continuous mode:
  - Only enable RX interrupt, don't enable TX interrupt
  - Change the timer1 working mode, to make sure CS is always low during whole data transfer, it is not necessary to always fill TX shifter buffer in time.