### PR TITLE
mcux: connectivity_framework: fix debugging ble application on mcxw72

### DIFF
--- a/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
+++ b/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
@@ -49,6 +49,8 @@ if(CONFIG_SOC_SERIES_MCXW)
         ${CMAKE_CURRENT_LIST_DIR}/platform/connected_mcu/configs
     )
 
+    zephyr_compile_definitions_ifdef(CONFIG_SOC_MCXW727C FWK_KW47_MCXW72_FAMILIES=1)
+
     if(DEFINED CONFIG_SOC_SDKNG_UNSUPPORTED)
         include(set_component_osa)
         set(CONFIG_USE_component_osa_zephyr true)

--- a/mcux/middleware/mcux-sdk-middleware-connectivity-framework/platform/connected_mcu/fwk_platform.c
+++ b/mcux/middleware/mcux-sdk-middleware-connectivity-framework/platform/connected_mcu/fwk_platform.c
@@ -109,6 +109,12 @@ int PLATFORM_InitNbu(void)
         RFMC->RF2P4GHZ_CTRL = rfmc_ctrl;
         RFMC->RF2P4GHZ_TIMER |= RFMC_RF2P4GHZ_TIMER_TIM_EN(0x1U);
 
+#if defined(FWK_KW47_MCXW72_FAMILIES) && (FWK_KW47_MCXW72_FAMILIES == 1)
+        /* Allow the debugger to wakeup the target */
+        RFMC->RF2P4GHZ_CFG |= RFMC_RF2P4GHZ_CFG_FORCE_DBG_PWRUP_ACK_MASK;
+        CMC0->DBGCTL &= ~CMC_DBGCTL_SOD_MASK;
+#endif
+
         /* Enabling BLE Power Controller (BLE_LP_EN) will automatically start the XTAL
          * According to RM, we need to wait for the XTAL to be ready before accessing
          * Radio domain ressources.


### PR DESCRIPTION
Sometimes the debugger would crash on mcxw72, this is related to the debugger ability to wake up the NBU core.
Adding the correct configuration solves the issue.