### PR TITLE
Fix Multicore CI Build Failure for BT /Wi-Fi Samples Using IW416/IW612 Controller

### DIFF
--- a/zephyr/src/rt/CMakeLists.txt
+++ b/zephyr/src/rt/CMakeLists.txt
@@ -9,21 +9,37 @@ if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/nw61x_wifi_fw.bin.se.inc)
       set(wifi_binary_blob_name sduart_nw61x.bin.se)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/nw61x/nw61x_cpu1.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/nw61x/nw61x_cpu1.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/nw61x_wifi_fw.bin.se.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/nw61x/${wifi_binary_blob_name})
     elseif(CONFIG_NXP_88W8987)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/8987_wifi_fw.bin.inc)
       set(wifi_binary_blob_name sd8987_wlan.bin)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/8987/8987_cpu1.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/8987/8987_cpu1.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/8987_wifi_fw.bin.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/8987/${wifi_binary_blob_name})
     elseif(CONFIG_NXP_IW416)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/iw416_wifi_fw.bin.inc)
       set(wifi_binary_blob_name sduartIW416_wlan_bt.bin)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/IW416/IW416_cpu1.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/IW416/IW416_cpu1.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/iw416_wifi_fw.bin.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/IW416/${wifi_binary_blob_name})
     elseif(CONFIG_NXP_88W8801)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/8801_wifi_fw.bin.inc)
       set(wifi_binary_blob_name sd8801_wlan.bin)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/8801/8801_cpu1.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/8801/8801_cpu1.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/8801_wifi_fw.bin.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/8801/${wifi_binary_blob_name})
     else()
       message(FATAL_ERROR "Couldn't determine soc revision")
@@ -35,11 +51,19 @@ if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/nw61x_bt_fw.bin.inc)
       set(bt_binary_blob_name uart_nw61x.bin.se)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/nw61x/nw61x_cpu2.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/nw61x/nw61x_cpu2.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/nw61x_bt_fw.bin.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/nw61x/${bt_binary_blob_name})
     elseif(CONFIG_BT_NXP_IW416)
       list(APPEND output_includes_list ${ZEPHYR_BINARY_DIR}/include/generated/iw416_bt_fw.bin.inc)
       set(bt_binary_blob_name uartIW416_bt.bin)
       zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/IW416/IW416_cpu2.c)
+      set_source_files_properties(
+		${CMAKE_CURRENT_LIST_DIR}/IW416/IW416_cpu2.c
+		PROPERTIES OBJECT_DEPENDS ${ZEPHYR_BINARY_DIR}/include/generated/iw416_bt_fw.bin.inc
+		)
       list(APPEND wifi_bt_binary_blobs_list ${hal_blobs_dir}/IW416/${bt_binary_blob_name})
     else()
       message(FATAL_ERROR "Unsupported controller. Please select a BT conntroller, refer to ./driver/bluetooth/hci/Kconfig.nxp")
@@ -67,7 +91,7 @@ if(CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
       list(GET output_includes_list ${i} output_include)
       zephyr_blobs_verify(FILES ${binary_blob})
       message(STATUS " generate include of binary blob: ${binary_blob}")
-      generate_inc_file_for_target(app ${binary_blob} ${output_include})
+      generate_inc_file_for_target(${ZEPHYR_CURRENT_LIBRARY} ${binary_blob} ${output_include})
     endforeach()
   endif()
 


### PR DESCRIPTION
- Update cmake to add explicit dependency of header (.inc file) require by source file. Update cmake-target for header file inclusion to the same as source file cmake-target.