### PR TITLE
mcux: wifi_nxp: Update the net_mgmt event type to uint64_t

### DIFF
--- a/mcux/middleware/wifi_nxp/port/net/zephyr/net.c
+++ b/mcux/middleware/wifi_nxp/port/net/zephyr/net.c
@@ -1059,7 +1059,7 @@ static void ipv6_mcast_delete(struct net_mgmt_event_callback *cb, struct net_if 
 }
 #endif
 
-static void wifi_net_event_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event, struct net_if *iface)
+static void wifi_net_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event, struct net_if *iface)
 {
     // const struct wifi_status *status = (const struct wifi_status *)cb->info;
     enum wifi_event_reason wifi_event_reason;


### PR DESCRIPTION
The network management event type is changed from uint32_t to uint64_t so update the code to prevent compilation issues.