### PR TITLE
modules: wireless: fix cmake error

### DIFF
--- a/zephyr/src/CMakeLists.txt
+++ b/zephyr/src/CMakeLists.txt
@@ -1,5 +1,2 @@
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_RW6XX rw61x)
-
-if (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
-  add_subdirectory(wireless)
-endif()
+add_subdirectory_ifdef(CONFIG_SOC_FAMILY_NXP_IMXRT wireless)


### PR DESCRIPTION
directory rename setup improper conditions for pulling in directory causing a failure on frdm_rw612 build.