### PR TITLE
zephyr: src: don't include attached WiFi sources for RW61x

### DIFF
--- a/zephyr/src/CMakeLists.txt
+++ b/zephyr/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_subdirectory_ifdef(CONFIG_SOC_SERIES_RW6XX rw61x)
-
-if (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
+if (CONFIG_SOC_SERIES_RW6XX)
+  add_subdirectory(rw61x)
+elseif (CONFIG_NXP_MONOLITHIC_WIFI OR CONFIG_BT_H4_NXP_CTLR)
   add_subdirectory(wireless)
 endif()


### PR DESCRIPTION
Don't include attached WiFi sources for RW61x, as these aren't needed