### PR TITLE
zephyr: upgrade RW612 p41 FW and IW610 p67 FW

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -17,29 +17,29 @@ blobs:
 
 #For RW61x
   - path: rw61x/rw61x_sb_ble_15d4_combo_a2.bin
-    sha256: cb101939fbbc1b77cc13eab848f01bb5e682071a940a468d89ebd1b0f31674cc
+    sha256: fa64e15d4520c7f30a67af157ad333eddd37f15ed0c20e2edbcc00fb4ea84ef4
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/rw61x/rw61x_sb_ble_15d4_combo_a2.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/rw61x/rw61x_sb_ble_15d4_combo_a2.bin
     description: "BLE and 15.4 combo firmware for RW612 A2 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: rw61x/rw61x_sb_ble_a2.bin
-    sha256: 97fe6270806455b23dc14e78c6f710b8eb72b05307b7646b928a7c9f8fed9223
+    sha256: 3a79675f3b550f771f0550fba295fd70231d42880131f0653025bc98e7e15ab5
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/rw61x/rw61x_sb_ble_a2.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/rw61x/rw61x_sb_ble_a2.bin
     description: "BLE firmware for RW612 A2 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: rw61x/rw61x_sb_wifi_a2.bin
-    sha256: 4c0144e63a9cb679bd124fb98f49f2a686c438fa5de514329564e2b13356aa18
+    sha256: daec213471988c11c5eab52cec72b15961d3771c53900630c1e88c41eb04e11d
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/rw61x/rw61x_sb_wifi_a2.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/rw61x/rw61x_sb_wifi_a2.bin
     description: "WiFi firmware for RW612 A2 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
 
 #For MCXW71
   - path: mcxw71/mcxw71_nbu_ble.sb3
@@ -125,29 +125,29 @@ blobs:
 
 #For IW610
   - path: IW610/sd_iw610.bin.se
-    sha256: 4701b5f7b401b82f134c0b9c086164d2ba6d5b8be0b8ba4bf717f0bdd85c9b62
+    sha256: d02fe66890b629a87b29a6f4d28b1251dbe47d6b69e62562b13f5cfb7fe262ce
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/IW610/sd_iw610.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/IW610/sd_iw610.bin.se
     description: "Wi-Fi firmware for IW610 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: IW610/uart_iw610_bt.bin.se
-    sha256: 95513b49c3a3ca1fdfaf443081daafd8defe416bc7a498e52ceaf7b8dad7405c
+    sha256: 908f4653045f0b823453ad838b9d2af40edcd118a9256621bbda8dbdb66c2b65
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/IW610/uart_iw610_bt.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/IW610/uart_iw610_bt.bin.se
     description: "BT firmware for IW610 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: IW610/sduart_iw610.bin.se
-    sha256: c87a7946cffd6b82a6bebb6507cdfe0fface6b7bf9b48a03b4080f275c5c532b
+    sha256: 48a4a3d3c5d75dda29c112a4323b8a46a150c4af49bddd8e8005f8e390d70062
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.3/IW610/sduart_iw610.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/nxp-v4.1.4/IW610/sduart_iw610.bin.se
     description: "Combo firmware for IW610 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.3/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
 
 #For imx-boot-firmware
   - path: imx-boot-firmware/imx95-19x19-lpddr5-evk-boot-firmware-0.1.bin

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -71,57 +71,57 @@ blobs:
     url: https://github.com/nxp-mcuxpresso/mcuxsdk-middleware-ieee_802.15.4/raw/refs/heads/release/25.06.00-pvw2/bin/mcxw72/mcxw72_nbu_ble_15_4_dyn.bin
     description: "BLE Controller and IEEE 802.15.4 PHY combo firmware for MCXW72 boards"
 
-#For NW61x
+#For IW612
   - path: nw61x/sd_nw61x.bin.se
-    sha256: A0AA4A6761B1105C1F3CCB58EAB2A52D010ED8E228E55BFE5C090DDC33395DBB
+    sha256: bf627f7752c6cad01a30b2e576b15fbf1f6bacd66183c44b25b0adafab44064a
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/nw61x/sd_nw61x.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/nw61x/sd_nw61x.bin.se
     description: "Wi-Fi firmware for NW61x A1 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: nw61x/uart_nw61x.bin.se
-    sha256: A47E5DE79CBC4D1838D13414A6854C8F2F664CB61F9287546BF3776FC9205B21
+    sha256: 9aaae89ce053f5f51cce41cfed7c33e4e091b68ca4a5172aa404c01361705ab4
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/nw61x/uart_nw61x.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/nw61x/uart_nw61x.bin.se
     description: "BT firmware for NW61x A1 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: nw61x/sduart_nw61x.bin.se
-    sha256: D8B33EE84C0F411D296FC20CBD8823EBEBAA4703379AECB5ACB5579B66F719A0
+    sha256: 68a69953a2e70f631189cba5e552ada414e828d1f44b5bea2bbb494070b97f77
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/nw61x/sduart_nw61x.bin.se
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/nw61x/sduart_nw61x.bin.se
     description: "Combo firmware for NW61x A1 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
 
 #For IW416
   - path: IW416/sdIW416_wlan.bin
-    sha256: 8D451D19237D25B6EE5976CC0793D66B801A1FEAF191A43B5F314B61F40ACCEE
+    sha256: 414459672d873baa945db9d1bdd70cf9b52d9e6cabcff52d99abc110f40fd468
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/IW416/sdIW416_wlan.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/IW416/sdIW416_wlan.bin
     description: "Wi-Fi firmware for IW416 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: IW416/uartIW416_bt.bin
     sha256: 8EF68C3E7AC879D35605D784317936C2D9AEA279EDC4D66729AB1973FBE701C3
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/IW416/uartIW416_bt.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/IW416/uartIW416_bt.bin
     description: "BT firmware for IW416 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
   - path: IW416/sduartIW416_wlan_bt.bin
-    sha256: B06206ABBAFC08D6E8F883A7D4A975AE19E0AB3CF7E3FE794284F5C6A2FA0E41
+    sha256: d7b02e41fef73344ff3029bcd2f0b68573cbf256e49354e5e9041a51aed96cad
     type: img
     version: '1.0'
     license-path: zephyr/blobs/license/LA_OPT_NXP_Software_License.txt
-    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.0/IW416/sduartIW416_wlan_bt.bin
+    url: https://github.com/NXP/wifi_nb_fw/raw/refs/tags/nxp-v4.1.4/IW416/sduartIW416_wlan_bt.bin
     description: "Combo firmware for IW416 boards"
-    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.0/readme.txt
+    doc-url: https://github.com/NXP/wifi_nb_fw/blob/nxp-v4.1.4/readme.txt
 
 #For IW610
   - path: IW610/sd_iw610.bin.se


### PR DESCRIPTION
upgrade RW612 FW to version 6.p41,
upgrade IW610 FW to version 5.p67.