### PR TITLE
Added some expected defines that were required by soc.c in zephyr

### DIFF
--- a/mcux/mcux-sdk/devices/MIMXRT1011/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk/devices/MIMXRT1011/drivers/fsl_clock.h
@@ -510,6 +510,10 @@ typedef enum _clock_mux
                                CCM_CSCMR1_SAI3_CLK_SEL_SHIFT,
                                CCM_CSCMR1_SAI3_CLK_SEL_MASK,
                                CCM_NO_BUSY_WAIT), /*!< sai3 mux name */
+    kCLOCK_Sai2Mux       = CCM_TUPLE(CSCMR1_OFFSET,
+                               CCM_CSCMR1_SAI1_CLK_SEL_SHIFT,
+                               CCM_CSCMR1_SAI1_CLK_SEL_MASK,
+                               CCM_NO_BUSY_WAIT), /*!< readded because kCLOCK_Sai2Mux is expected to be defined */
     kCLOCK_Sai1Mux       = CCM_TUPLE(CSCMR1_OFFSET,
                                CCM_CSCMR1_SAI1_CLK_SEL_SHIFT,
                                CCM_CSCMR1_SAI1_CLK_SEL_MASK,
@@ -598,10 +602,18 @@ typedef enum _clock_div
                                      CCM_CS1CDR_FLEXIO1_CLK_PRED_SHIFT,
                                      CCM_CS1CDR_FLEXIO1_CLK_PRED_MASK,
                                      CCM_NO_BUSY_WAIT), /*!< flexio1 pre div name */
+    kCLOCK_Sai2PreDiv    = CCM_TUPLE(CS1CDR_OFFSET,
+                                  CCM_CS1CDR_SAI1_CLK_PRED_SHIFT,
+                                  CCM_CS1CDR_SAI1_CLK_PRED_MASK,
+                                  CCM_NO_BUSY_WAIT), /*!< Readded here because kCLOCK_Sai2PreDiv is expected to be defined */
     kCLOCK_Sai1PreDiv    = CCM_TUPLE(CS1CDR_OFFSET,
                                   CCM_CS1CDR_SAI1_CLK_PRED_SHIFT,
                                   CCM_CS1CDR_SAI1_CLK_PRED_MASK,
                                   CCM_NO_BUSY_WAIT), /*!< sai1 pre div name */
+    kCLOCK_Sai2Div       = CCM_TUPLE(CS1CDR_OFFSET,
+                               CCM_CS1CDR_SAI1_CLK_PODF_SHIFT,
+                               CCM_CS1CDR_SAI1_CLK_PODF_MASK,
+                               CCM_NO_BUSY_WAIT), /*!< Readded here because kCLOCK_Sai2Div is expected to be defined */
     kCLOCK_Sai1Div       = CCM_TUPLE(CS1CDR_OFFSET,
                                CCM_CS1CDR_SAI1_CLK_PODF_SHIFT,
                                CCM_CS1CDR_SAI1_CLK_PODF_MASK,


### PR DESCRIPTION
ZEPHYR/zephyr/soc/nxp/imxrt/imxrt10xx/soc.c
expects kCLOCK_Sai2Mux, kCLOCK_Sai2PreDiv, kCLOCK_Sai2Div to be defined but these were not defined for the mimxrt1011 family of devices. This fixes the compile error when doing anything with i2s with the 1010 family of devices.

Other possible fixes could be to modify soc.c to have cases for every board or to have different soc.c for every board. Also kCLOCK_Sai2Mux could be set to a known, invalid value in fsl_clock.h to cause a compile time error if being used.