### PR TITLE
enable NETC on imx95 Cortex-A55

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/common/fsl_common_arm.h
+++ b/mcux/mcux-sdk-ng/drivers/common/fsl_common_arm.h
@@ -474,15 +474,21 @@ _Pragma("diag_suppress=Pm120")
 #endif
 
 #elif (defined(__GNUC__)) || defined(DOXYGEN_OUTPUT)
+#if defined(__ARM_ARCH_8A__) /* This macro is ARMv8-A specific */
+#define MCUX_CS "//"
+#else
+#define MCUX_CS "@"
+#endif
+
 /* For GCC, when the non-cacheable section is required, please define "__STARTUP_INITIALIZE_NONCACHEDATA"
  * in your projects to make sure the non-cacheable section variables will be initialized in system startup.
  */
 #define AT_NONCACHEABLE_SECTION_INIT(var) __attribute__((section("NonCacheable.init"))) var
 #define AT_NONCACHEABLE_SECTION_ALIGN_INIT(var, alignbytes) \
     __attribute__((section("NonCacheable.init"))) var __attribute__((aligned(alignbytes)))
-#define AT_NONCACHEABLE_SECTION(var) __attribute__((section("NonCacheable,\"aw\",%nobits @"))) var
+#define AT_NONCACHEABLE_SECTION(var) __attribute__((section("NonCacheable,\"aw\",%nobits " MCUX_CS))) var
 #define AT_NONCACHEABLE_SECTION_ALIGN(var, alignbytes) \
-    __attribute__((section("NonCacheable,\"aw\",%nobits @"))) var __attribute__((aligned(alignbytes)))
+    __attribute__((section("NonCacheable,\"aw\",%nobits " MCUX_CS))) var __attribute__((aligned(alignbytes)))
 #else
 #error Toolchain not supported.
 #endif

--- a/mcux/mcux-sdk-ng/drivers/netc/netc_hw/fsl_netc_hw.c
+++ b/mcux/mcux-sdk-ng/drivers/netc/netc_hw/fsl_netc_hw.c
@@ -129,7 +129,7 @@ status_t NETC_CmdBDRInit(netc_cbdr_hw_t *base, const netc_cmd_bdr_config_t *conf
     status_t status = kStatus_Success;
     uint64_t address;
 
-    if ((0U != ((uint32_t)config->bdBase % 128U)) || (0U != (config->bdLength % 8U)))
+    if ((0U != ((uintptr_t)config->bdBase % 128U)) || (0U != (config->bdLength % 8U)))
     {
         status = kStatus_InvalidArgument;
     }

--- a/mcux/mcux-sdk/devices/MIMX9596/MIMX9596_ca55_features.h
+++ b/mcux/mcux-sdk/devices/MIMX9596/MIMX9596_ca55_features.h
@@ -605,7 +605,7 @@
 /* @brief After one or more late collision or excessive collision events, counters PMa_TOCTn and PMa_TFRMn will be higher than expected. */
 #define FSL_FEATURE_NETC_HAS_ERRATA_051710 (1)
 /* @brief MAC statistic counters TEOCT and TOCT are inaccurate after Pause frames are transmitted with flexible preamble enabled and flexible preamble count set to less than 7. */
-#define FSL_FEATURE_NETC_HAS_ERRATA_051711 (1)
+#define FSL_FEATURE_NETC_HAS_ERRATA_051711 (0)
 /* @brief Number of Switch ports. */
 #define FSL_FEATURE_NETC_SWITCH_MAX_PORT_NUMBER (5)
 /* @brief Number of Switch Ethernet MAC ports. */


### PR DESCRIPTION
1. drivers: netc: make the driver to be aarch64 compatible
2. mcux-sdk: MIMX9596_ca55: disable FSL_FEATURE_NETC_HAS_ERRATA_051711
3. mcux-sdk: MIMX9596_ca55: fix A-Core header file regard of netc struct definition
4. fsl_common_arm: Fix comment sign issue on different architectures