### PR TITLE
mcux: mcux-sdk: devices: fix MKV56F24.h wrong macro

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -202,3 +202,5 @@ Patch List:
         - Add include of usb_host_mcux_drv_port.h.
         - Remove include of usb_host.h, usb_host_hci.h, usb_host_devices.h and usb_host_framework.h.
       - Update usb_host_ehci.c and usb_host_ip3516hs.c to not depend on usb_host_device_instance_t struct.
+  - mcux-sdk: devices: fix MKV56F24.h wrong macro
+      - The MKV56F24 device doesn't contain CAN2 peripheral. Remove it from the device header.

--- a/mcux/mcux-sdk/devices/MKV56F24/MKV56F24.h
+++ b/mcux/mcux-sdk/devices/MKV56F24/MKV56F24.h
@@ -15,15 +15,13 @@
 **
 **     Reference manual:    KV5XP144M240RM Rev. 3, 02/2016
 **     Version:             rev. 0.3, 2016-02-29
-**     Build:               b210308
+**     Build:               b250717
 **
 **     Abstract:
 **         CMSIS Peripheral Access Layer for MKV56F24
 **
 **     Copyright 1997-2016 Freescale Semiconductor, Inc.
-**     Copyright 2016-2021 NXP
-**     All rights reserved.
-**
+**     Copyright 2016-2025 NXP
 **     SPDX-License-Identifier: BSD-3-Clause
 **
 **     http:                 www.nxp.com
@@ -37,6 +35,7 @@
 **         FMC - corrected base address.
 **     - rev. 0.3 (2016-02-29)
 **         PORT - removed registers GICLR, GICHR.
+**         CAN  - removed instance CAN2.
 **
 ** ###################################################################
 */
@@ -44,7 +43,7 @@
 /*!
  * @file MKV56F24.h
  * @version 0.3
- * @date 2016-02-29
+ * @date 2025-07-17
  * @brief CMSIS Peripheral Access Layer for MKV56F24
  *
  * CMSIS Peripheral Access Layer for MKV56F24
@@ -32272,7 +32271,6 @@ typedef struct {
 #define DSPI2                     SPI2
 #define FLEXCAN0                  CAN0
 #define FLEXCAN1                  CAN1
-#define FLEXCAN2                  CAN2
 #define DMAMUX0                   DMAMUX
 
 /*!


### PR DESCRIPTION
The MKV56F24 device doesn't contain CAN2 peripheral. Remove it from the device header.