### PR TITLE
mcux-sdk-ng: drivers: irqsteer_1: fix build errors

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/irqsteer_1/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/drivers/irqsteer_1/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_MCUX_COMPONENT_driver.irqsteer_1)
-    mcux_component_version(2.0.1)
+    mcux_component_version(2.0.2)
 
     mcux_add_source(SOURCES fsl_irqsteer.h fsl_irqsteer.c)
 

--- a/mcux/mcux-sdk-ng/drivers/irqsteer_1/fsl_irqsteer.c
+++ b/mcux/mcux-sdk-ng/drivers/irqsteer_1/fsl_irqsteer.c
@@ -78,7 +78,7 @@ void IRQSTEER_Init(int32_t instIdx)
         /* Mask all interrupts. */
         for (i = 0; i < data->regNum; i++)
         {
-            *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, i, data->regNum)) = 0U;
+            *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, i, data->regNum)) = 0U;
         }
 
         for (i = 0; i < data->intGrpNum; i++)
@@ -135,7 +135,7 @@ void IRQSTEER_EnableInterrupt(int32_t instIdx, IRQn_Type irq)
     regIdx = IRQSTEER_GEN_REG_IDX(data->regNum, inputIdx);
     bitOffset = inputIdx % IRQSTEER_INT_SRC_REG_WIDTH;
 
-    *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) |= (1U << bitOffset);
+    *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) |= (1U << bitOffset);
 }
 
 /*! @} */
@@ -161,7 +161,7 @@ void IRQSTEER_DisableInterrupt(int32_t instIdx, IRQn_Type irq)
     regIdx = IRQSTEER_GEN_REG_IDX(data->regNum, inputIdx);
     bitOffset = inputIdx % IRQSTEER_INT_SRC_REG_WIDTH;
 
-    *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= ~(1U << bitOffset);
+    *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= ~(1U << bitOffset);
 }
 
 /**
@@ -266,7 +266,7 @@ IRQn_Type IRQSTEER_GetMasterNextInterrupt(int32_t instIdx, int32_t outputChanIdx
         regIdx = IRQSTEER_GetRegIdx(instIdx, outputChanIdx, i);
 
         /* Get register's value */
-        chanStatus = *(uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum));
+        chanStatus = *(uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum));
 
         for (j = 0; j < IRQSTEER_INT_SRC_REG_WIDTH; j++)
         {
@@ -283,7 +283,7 @@ IRQn_Type IRQSTEER_GetMasterNextInterrupt(int32_t instIdx, int32_t outputChanIdx
                  */
                  idx = (data->regNum - 1) - regIdx;
                  inputIdx = idx * IRQSTEER_INT_SRC_REG_WIDTH + bitOffset;
-                 irqNum = inputIdx + FSL_FEATURE_IRQSTEER_IRQ_START_INDEX;
+                 irqNum = (IRQn_Type)(inputIdx + FSL_FEATURE_IRQSTEER_IRQ_START_INDEX);
                  return irqNum;
             }
 
@@ -315,7 +315,7 @@ uint64_t IRQSTEER_GetMasterInterruptsStatus(int32_t instIdx, int32_t outputChanI
     for (i = 0; i < sliceNum; i++) {
         regIdx = IRQSTEER_GetRegIdx(instIdx, outputChanIdx, i);
 
-        chanStatus = *(uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum));
+        chanStatus = *(uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum));
 
         interrupts |= ((uint64_t)chanStatus << (IRQSTEER_INT_SRC_REG_WIDTH * i));
     }

--- a/mcux/mcux-sdk-ng/drivers/irqsteer_1/fsl_irqsteer.h
+++ b/mcux/mcux-sdk-ng/drivers/irqsteer_1/fsl_irqsteer.h
@@ -21,8 +21,8 @@
 
 /*! @name Driver version */
 /*! @{ */
-/*! Version 2.0.1. */
-#define FSL_IRQSTEER_DRIVER_VERSION (MAKE_VERSION(2, 0, 1))
+/*! Version 2.0.2. */
+#define FSL_IRQSTEER_DRIVER_VERSION (MAKE_VERSION(2, 0, 2))
 /*! @} */
 
 /*
@@ -184,7 +184,7 @@ static inline bool IRQSTEER_InterruptIsEnabled(int32_t instIdx, IRQn_Type irq)
     regIdx = IRQSTEER_GEN_REG_IDX(data->regNum, inputIdx);
     bitOffset = inputIdx % IRQSTEER_INT_SRC_REG_WIDTH;
 
-    return ((*(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= (1U << bitOffset)) != 0U);
+    return ((*(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MASK(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= (1U << bitOffset)) != 0U);
 }
 
 /*!
@@ -210,11 +210,11 @@ static inline void IRQSTEER_SetInterrupt(int32_t instIdx, IRQn_Type irq, bool se
 
     if (set)
     {
-        *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_SET(data->infoPtr->irqChanIdx, regIdx, data->regNum)) |= (1U << bitOffset);
+        *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_SET(data->infoPtr->irqChanIdx, regIdx, data->regNum)) |= (1U << bitOffset);
     }
     else
     {
-        *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_SET(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= ~(1U << bitOffset);
+        *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_SET(data->infoPtr->irqChanIdx, regIdx, data->regNum)) &= ~(1U << bitOffset);
     }
 }
 
@@ -233,7 +233,7 @@ static inline void IRQSTEER_SetInterrupt(int32_t instIdx, IRQn_Type irq, bool se
 static inline void IRQSTEER_EnableMasterInterrupt(int32_t instIdx, int32_t outputChanIdx)
 {
     irqsteer_data_t *data = IRQSTEER_GetIrqsteerData(instIdx);
-    *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MINTDIS(data->infoPtr->irqChanIdx, data->regNum)) &= ~(1U << outputChanIdx);
+    *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MINTDIS(data->infoPtr->irqChanIdx, data->regNum)) &= ~(1U << outputChanIdx);
 }
 
 /*!
@@ -251,7 +251,7 @@ static inline void IRQSTEER_EnableMasterInterrupt(int32_t instIdx, int32_t outpu
 static inline void IRQSTEER_DisableMasterInterrupt(int32_t instIdx, int32_t outputChanIdx)
 {
     irqsteer_data_t *data = IRQSTEER_GetIrqsteerData(instIdx);
-    *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MINTDIS(data->infoPtr->irqChanIdx, data->regNum)) |= (1U << outputChanIdx);
+    *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MINTDIS(data->infoPtr->irqChanIdx, data->regNum)) |= (1U << outputChanIdx);
 }
 
 /*! @} */
@@ -286,7 +286,7 @@ static inline bool IRQSTEER_IsInterruptSet(int32_t instIdx, IRQn_Type irq)
     regIdx = IRQSTEER_GEN_REG_IDX(data->regNum, inputIdx);
     bitOffset = inputIdx % IRQSTEER_INT_SRC_REG_WIDTH;
 
-    return *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum)) & (1U << bitOffset);
+    return *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_STATUS(data->infoPtr->irqChanIdx, regIdx, data->regNum)) & (1U << bitOffset);
 }
 
 /*!
@@ -301,7 +301,7 @@ static inline bool IRQSTEER_IsMasterInterruptSet(int32_t instIdx)
 {
     irqsteer_data_t *data = IRQSTEER_GetIrqsteerData(instIdx);
 
-    return *(volatile uint32_t *)(data->infoPtr->reg + IRQSTEER_CHAN_MSTRSTAT(data->infoPtr->irqChanIdx, data->regNum));
+    return *(volatile uint32_t *)((uint32_t)data->infoPtr->reg + IRQSTEER_CHAN_MSTRSTAT(data->infoPtr->irqChanIdx, data->regNum));
 }
 
 /*!


### PR DESCRIPTION
Fix build errors,
  - drivers/irqsteer_1/fsl_irqsteer.h:187:56: error: pointer of type void * used in arithmetic [-Werror=pointer-arith]