### PR TITLE
mcux: wifi_nxp: Add TLSv1.3 prerequisites in mbedtls config files

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/port/mbedtls/wpa_supp_dcp_mbedtls_config.h
+++ b/mcux/middleware/wifi_nxp/incl/port/mbedtls/wpa_supp_dcp_mbedtls_config.h
@@ -3782,6 +3782,10 @@
 #define PSA_WANT_ALG_SHA_256                    1
 #define PSA_WANT_ALG_SHA_384                    1
 #define PSA_WANT_ALG_SHA_512                    1
+#define PSA_WANT_ALG_HKDF_EXTRACT               1
+#define PSA_WANT_ALG_HKDF_EXPAND                1
+#define MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT    1
+#define MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND     1
 //#define PSA_WANT_ALG_STREAM_CIPHER              1
 #define PSA_WANT_ALG_TLS12_PRF                  1
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS            1

--- a/mcux/middleware/wifi_nxp/incl/port/mbedtls/wpa_supp_els_pkc_mbedtls_config.h
+++ b/mcux/middleware/wifi_nxp/incl/port/mbedtls/wpa_supp_els_pkc_mbedtls_config.h
@@ -3785,6 +3785,10 @@
 #define PSA_WANT_ALG_SHA_256                    1
 #define PSA_WANT_ALG_SHA_384                    1
 #define PSA_WANT_ALG_SHA_512                    1
+#define PSA_WANT_ALG_HKDF_EXTRACT               1
+#define PSA_WANT_ALG_HKDF_EXPAND                1
+#define MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT    1
+#define MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND     1
 //#define PSA_WANT_ALG_STREAM_CIPHER              1
 #define PSA_WANT_ALG_TLS12_PRF                  1
 #define PSA_WANT_ALG_TLS12_PSK_TO_MS            1


### PR DESCRIPTION
Added and enable below flags in mbedtls config files: PSA_WANT_ALG_HKDF_EXTRACT
PSA_WANT_ALG_HKDF_EXPAND
MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXTRACT
MBEDTLS_PSA_BUILTIN_ALG_HKDF_EXPAND