### PR TITLE
mcux: conn_framework: Fix BLE build failures on MCXW platforms

### DIFF
--- a/mcux/middleware/CMakeLists.txt
+++ b/mcux/middleware/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CONFIG_BT OR CONFIG_NET_L2_OPENTHREAD OR CONFIG_IEEE802154)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcux-sdk-middleware-connectivity-framework)
     include(connectivity_framework)
-    if(CONFIG_SOC_SERIES_MCXW)
+    if(CONFIG_SOC_FAMILY_MCXW)
         zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk-middleware-multicore/mcmgr/src)
 
         zephyr_library_sources(

--- a/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
+++ b/mcux/middleware/mcux-sdk-middleware-connectivity-framework/connectivity_framework.cmake
@@ -35,7 +35,7 @@ if(CONFIG_SOC_SERIES_RW6XX)
     endif()
 endif()
 
-if(CONFIG_SOC_SERIES_MCXW)
+if(CONFIG_SOC_FAMILY_MCXW)
     target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/platform/connected_mcu/fwk_platform.c
         ${CMAKE_CURRENT_LIST_DIR}/platform/connected_mcu/fwk_platform_ics.c


### PR DESCRIPTION
This is caused by CONFIG_SOC_SERIES_MCXW rename to CONFIG_SOC_FAMILY_MCXW