### PR TITLE
Expose Timestamp of 1588_EVENT_IN

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.h
+++ b/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.h
@@ -1954,6 +1954,17 @@ void ENET_Ptp1588GetTimerNoIrqDisable(ENET_Type *base, enet_handle_t *handle, en
 void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime);
 
 /*!
+ * @brief Gets the last captured ENET time from the PTP 1588 timer.
+ *
+ * @param base  ENET peripheral base address.
+ * @param channel The ENET PTP timer channel number.
+ */
+static inline uint32_t ENET_Ptp1588GetChannelCaptureValue(ENET_Type *base, enet_ptp_timer_channel_t channel)
+{
+  return base->CHANNEL[channel].TCCR;
+}
+
+/*!
  * @brief Sets the ENET PTP 1588 timer to the assigned time.
  *
  * @param base  ENET peripheral base address.


### PR DESCRIPTION
ENET provides 1588_EVENT_IN signals to latch the current timer value in TCCRn when a rising edge is detected. This pull request exposes the latched timer value via ENET_Ptp1588GetCapture.