### PR TITLE
hal_nxp: Add Relative Clock Jump

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.h
+++ b/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.h
@@ -1963,6 +1963,18 @@ void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_
 void ENET_Ptp1588SetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_t *ptpTime);
 
 /*!
+ * @brief Adjusts the ENET PTP 1588 timer by jumping a relative time difference.
+ *
+ * Compared to ENET_Ptp1588SetTimer, this function yields more accurate results when
+ * the relative time difference between the PTP clock and the target clock is known
+ * (e.g., through a capture event retrieved by ENET_Ptp1588GetChannelCaptureValue).
+ *
+ * @param base  ENET peripheral base address.
+ * @param nanosecondDiff The offset that is added/subtracted from the current PTP time
+ */
+void ENET_Ptp1588JumpTimer(ENET_Type *base, int64_t nanosecondDiff);
+
+/*!
  * @brief The IEEE 1588 PTP time stamp interrupt handler.
  *
  * @param base  ENET peripheral base address.


### PR DESCRIPTION
While ENET_Ptp1588SetTimer provides a mechanism to set the clock to an absolute time value, this often introduces additional software delays. In contrast, ENET_Ptp1588JumpTimer uses a relative offset in case we already have two hardware timestamps.

The main motivation for this extension is to avoid usages like [here](https://github.com/zephyrproject-rtos/zephyr/blob/ccaaaabba2611b85f62c9dc6e7dbabd7542bce3b/subsys/net/lib/ptp/clock.c#L544), where both ingress and egress timestamps are given (hence the relative error is known) but one still has to perform a `ptp_clock_get`and `ptp_clock_set`.

Moreover, this can drastically improve the accuracy when aiming to synchronize with a 1PPS signal (e.g., generated by a GNSS module). 
```c
/** Adjust the PTP clock by jumping (if the difference exceeds a configured
 * threshold) or by increasing/decreasing the clock rate. */
static void synchronize(uint64_t ingress, uint64_t egress) {
  int64_t offset =
      (int64_t)(ingress - (int64_t)CONFIG_PTP_INGRESS_LATENCY - egress);

  /* If diff is too big, ptp_clk needs to be set first. */
  if ((offset > (int64_t)CONFIG_PTP_SYNC_JUMP_THRES) ||
      (offset < -(int64_t)CONFIG_PTP_SYNC_JUMP_THRES)) {
    LOG_WRN("Clock offset exceeds jump threshold: %lldns", offset);
    ptp_clock_jump(PTP_CLOCK, (int32_t)offset);
    return;
  }

  double ppb = ptp_clock_servo_pi(offset);
  ptp_clock_rate_adjust(PTP_CLOCK, 1.0 + (ppb / 1000000000.0));
}

static void ptp_clock_synchronize_pps(uint32_t tm) {
  if (tm % NSEC_PER_SEC > 500 * NSEC_PER_MSEC) {
    LOG_INF("offset: %d ns", (int)(tm % NSEC_PER_SEC) - NSEC_PER_SEC);
    synchronize(NSEC_PER_SEC, tm % NSEC_PER_SEC);
  } else {
    LOG_INF("offset: %u ns", tm % NSEC_PER_SEC);
    synchronize(0, tm % NSEC_PER_SEC);
  }
}

// ...
// e.g., register ptp_clock_synchronize_pps as IRQ for ENET_1588_EVENT_IN
```

For the IMXRT1060, `ENET_Ptp1588JumpTimer` yielded an accuracy in the range of  < 12us, whereas the analogous approach from [the previous example](https://github.com/zephyrproject-rtos/zephyr/blob/ccaaaabba2611b85f62c9dc6e7dbabd7542bce3b/subsys/net/lib/ptp/clock.c#L544) often yielded clock skews > 100ms. Latter is especially critical as subsequent rate adjustments are often done without validation (e.g., as described in this [issue](https://github.com/zephyrproject-rtos/zephyr/issues/93804)).

I'm of course happy to extend the proposed functionality if you have further suggestions. 
