### PR TITLE
mcux: wifi_nxp: Enable IMU IRQ after event initialized

### DIFF
--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-imu.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-imu.c
@@ -1609,10 +1609,13 @@ void WL_MCI_WAKEUP_DONE0_DriverIRQHandler(void)
 
 void mlan_init_wakeup_irq()
 {
+    NVIC_EnableIRQ(WL_MCI_WAKEUP_DONE0_IRQn);
 }
 
 void mlan_deinit_wakeup_irq()
 {
+    NVIC_DisableIRQ(WL_MCI_WAKEUP_DONE0_IRQn);
+    NVIC_ClearPendingIRQ(WL_MCI_WAKEUP_DONE0_IRQn);
 }
 
 mlan_status imu_wifi_init(enum wlan_type type, const uint8_t *fw_ram_start_addr, const size_t size)


### PR DESCRIPTION
After running 'kernel reboot' cmd on coex application, zephyr os clean bss section, IMU13 IRQ event data set as 0, then CPU3 receive IMU13 IRQ from CPU1, need access IMU13 IRQ event, cause hang.
Put enable IMU13 IRQ operation after related task and event created to fix this issue.