### PR TITLE
hal_nxp: mcux-sdk-ng: drivers: edma4: fix build errors

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.c
+++ b/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.c
@@ -1440,8 +1440,11 @@ void EDMA_ClearChannelStatusFlags(EDMA_Type *base, uint32_t channel, uint32_t ma
  *               parameters.
  * param base eDMA peripheral base address.
  * param channel eDMA channel number.
+ *
+ * @retval #kStatus_Success
+ * @retval #kStatus_InvalidArgument
  */
-void EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel)
+status_t EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel)
 {
     assert(handle != NULL);
     assert(FSL_FEATURE_EDMA_INSTANCE_CHANNELn(base) != -1);
@@ -1457,6 +1460,10 @@ void EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel)
 
     /* Get the DMA instance number */
     edmaInstance                        = EDMA_GetInstance(base);
+    if (edmaInstance >= ARRAY_SIZE(s_edmaBases))
+    {
+        return kStatus_InvalidArgument;
+    }
     s_EDMAHandle[edmaInstance][channel] = handle;
 
     handle->tcdBase     = EDMA_TCD_BASE(base, channel);
@@ -1484,6 +1491,8 @@ void EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel)
 
     /* Enable NVIC interrupt */
     (void)EnableIRQ(s_edmaIRQNumber[edmaInstance][channel]);
+
+    return kStatus_Success;
 }
 
 /*!

--- a/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.h
+++ b/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.h
@@ -1578,8 +1578,11 @@ void EDMA_ClearChannelStatusFlags(EDMA_Type *base, uint32_t channel, uint32_t ma
  *               parameters.
  * @param base eDMA peripheral base address.
  * @param channel eDMA channel number.
+ *
+ * @retval #kStatus_Success
+ * @retval #kStatus_InvalidArgument
  */
-void EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel);
+status_t EDMA_CreateHandle(edma_handle_t *handle, EDMA_Type *base, uint32_t channel);
 
 /*!
  * @brief Installs the TCDs memory pool into the eDMA handle.


### PR DESCRIPTION
This commit fixes below build errors,
- fsl_edma.c:1460:17: warning: array subscript 4 is above array bounds of edma_handle_t *[4][64] {aka struct _edma_handle *[4][64]} [-Warray-bounds]