### PR TITLE
devices: MIMX9596: ca55: NETC MSI-X table base address

### DIFF
--- a/mcux/mcux-sdk/devices/MIMX9596/MIMX9596_ca55_features.h
+++ b/mcux/mcux-sdk/devices/MIMX9596/MIMX9596_ca55_features.h
@@ -615,7 +615,7 @@
 /* @brief Max number of ENETC SI Tx/Rx BD rings. */
 #define FSL_FEATURE_NETC_SI_RING_NUM_MAX (24)
 /* @brief NETC MSI-X table base address. */
-#define FSL_FEATURE_NETC_MSIX_TABLE_BASE (0x60BC0000)
+#define FSL_FEATURE_NETC_MSIX_TABLE_BASE (0x4CD00000)
 /* @brief No switch support. */
 #define FSL_FEATURE_NETC_HAS_NO_SWITCH (1)
 


### PR DESCRIPTION
Fixed the NETC MSI-X table base address.

This update have no impact on SDK-NG, so no need to push to SDK, and no Zephyr PR, so can merge it directly, thanks.