### PR TITLE
mcux: wifi_nxp: Add NAN multicast filtering for PAF commissioning

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi_nxp.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi_nxp.h
@@ -47,7 +47,7 @@ struct wifi_nxp_ctx_rtos
     u64 remain_on_channel_cookie;
     unsigned int remain_on_channel_freq;
     unsigned int remain_on_channel_duration;
-    bool remain_on_chan_is_canceled;
+    bool remain_on_channel;
 #if CONFIG_WPA_SUPP_AP
     rtos_hostapd_dev_callbk_fns hostapd_callbk_fns;
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_main.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_main.h
@@ -2903,6 +2903,17 @@ t_u8 wlan_ft_akm_is_used(mlan_private *pmpriv, t_u8 *rsn_ie);
 t_u8 *wlan_get_specific_ie(pmlan_private priv, t_u8 *ie_buf, t_u8 ie_len, IEEEtypes_ElementId_e id, t_u8 ext_id);
 
 /**
+ *  @brief This function checks if address is multicast
+ *
+ *  @param addr  mac address
+ *  @return      1 - multicast, 0 - not multicast
+ */
+static INLINE t_bool is_mcast_addr(t_u8 *addr)
+{
+    return ((*(t_u8 *)addr & 0x01) == 0x01);
+}
+
+/**
  *  @brief This function checks tx_pause flag for peer
  *
  *  @param priv     A pointer to mlan_private

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -2485,7 +2485,8 @@ static mlan_status wlan_process_802dot11_mgmt_pkt2(mlan_private *priv, t_u8 *pay
                 PRINTM(MINFO, "T2: %d, T3: %d, ingress: %lu\n", tstamps.t2, tstamps.t3, tstamps.ingress_time);
             }
 #endif
-            if (memcmp(pieee_pkt_hdr->addr1, broadcast, MLAN_MAC_ADDR_LENGTH))
+            if (memcmp(pieee_pkt_hdr->addr1, broadcast, MLAN_MAC_ADDR_LENGTH) &&
+                !is_mcast_addr(pieee_pkt_hdr->addr1))
                 unicast = MTRUE;
             break;
         default:

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -870,9 +870,15 @@ int wifi_nxp_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 
     if (wifi_is_remain_on_channel())
     {
-        supp_e("%s: Block scan while remaining on channel", __func__);
-        ret = -EBUSY;
-        goto out;
+        status = wifi_remain_on_channel(false, 0, 0);
+        if (status == WM_SUCCESS)
+        {
+            wifi_if_ctx_rtos->remain_on_channel = false;
+        }
+           else
+        {
+            supp_e("%s: Cancel remain on channel failed", __func__);
+        }
     }
 
     wifi_d("initiating wifi-scan");
@@ -2717,7 +2723,6 @@ int wifi_nxp_wpa_supp_remain_on_channel(void *if_priv, unsigned int freq, unsign
 
     channel = freq_to_chan(wifi_if_ctx_rtos->remain_on_channel_freq);
 
-    wifi_if_ctx_rtos->remain_on_chan_is_canceled = false;
     wifi_if_ctx_rtos->remain_on_channel_cookie   = (u64)(OSA_Rand() | host_cookie);
     if (wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn != NULL)
     {
@@ -2729,11 +2734,13 @@ int wifi_nxp_wpa_supp_remain_on_channel(void *if_priv, unsigned int freq, unsign
     if (status != WM_SUCCESS)
     {
         supp_e("%s: Remain on channel cmd failed", __func__);
+        wifi_if_ctx_rtos->remain_on_channel = false;
         ret = -1;
     }
     else
     {
         supp_d("%s:Remain on channel sent successfully", __func__);
+        wifi_if_ctx_rtos->remain_on_channel = true;
         ret = 0;
     }
 out:
@@ -2752,14 +2759,13 @@ int wifi_nxp_wpa_supp_cancel_remain_on_channel(void *if_priv, u64 rpu_cookie)
         goto out;
     }
     wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)if_priv;
-    if (wifi_if_ctx_rtos->remain_on_chan_is_canceled)
+    if (wifi_if_ctx_rtos->remain_on_channel == false)
     {
         supp_d("%s:Already canceled, ignore it", __func__);
         ret = 0;
         goto out;
     }
 
-    wifi_if_ctx_rtos->remain_on_chan_is_canceled = true;
     status                                       = wifi_remain_on_channel(false, 0, 0);
 
     if (status != WM_SUCCESS)
@@ -2770,6 +2776,7 @@ int wifi_nxp_wpa_supp_cancel_remain_on_channel(void *if_priv, u64 rpu_cookie)
     else
     {
         supp_d("%s:Cancel on channel sent successfully", __func__);
+        wifi_if_ctx_rtos->remain_on_channel = false;
         ret = 0;
     }
 out:

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -2717,7 +2717,6 @@ int wifi_nxp_wpa_supp_remain_on_channel(void *if_priv, unsigned int freq, unsign
 
     channel = freq_to_chan(wifi_if_ctx_rtos->remain_on_channel_freq);
 
-    wifi_if_ctx_rtos->supp_called_remain_on_chan = true;
     wifi_if_ctx_rtos->remain_on_chan_is_canceled = false;
     wifi_if_ctx_rtos->remain_on_channel_cookie   = (u64)(OSA_Rand() | host_cookie);
     if (wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn != NULL)
@@ -2760,7 +2759,6 @@ int wifi_nxp_wpa_supp_cancel_remain_on_channel(void *if_priv, u64 rpu_cookie)
         goto out;
     }
 
-    wifi_if_ctx_rtos->supp_called_remain_on_chan = true;
     wifi_if_ctx_rtos->remain_on_chan_is_canceled = true;
     status                                       = wifi_remain_on_channel(false, 0, 0);
 

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
@@ -114,21 +114,17 @@ void wifi_process_remain_on_channel(struct wifi_message *msg)
     if (!wifi_if_ctx_rtos || !wm_wifi.supp_if_callbk_fns)
        return;
 
-    if (wifi_if_ctx_rtos->supp_called_remain_on_chan == true)
+    if ((msg->reason == WIFI_EVENT_REASON_SUCCESS) &&
+        (wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn != NULL))
     {
-        if ((msg->reason == WIFI_EVENT_REASON_SUCCESS) &&
-            (wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn != NULL))
+        if (*(t_u8 *)(msg->data) == true)
         {
-            if (*(t_u8 *)(msg->data) == true)
-            {
-                wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 1);
-            }
-            else
-            {
-                wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 0);
-            }
+            wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 1);
         }
-        wifi_if_ctx_rtos->supp_called_remain_on_chan = false;
+        else
+        {
+            wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 0);
+        }
     }
     if (msg->data)
     {

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -8097,6 +8097,24 @@ static void wlan_wait_wlmgr_ready()
     }
 }
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
+static int wlan_set_nan_mcast_addr()
+{
+    uint8_t nan_network_addr[6] = {0x51, 0x6f, 0x9a, 0x01, 0, 0};
+
+    /* Add NAN network mcast addr to multicast table */
+    return wifi_add_mcast_filter(nan_network_addr);
+}
+
+static int wlan_remove_nan_mcast_addr()
+{
+    uint8_t nan_network_addr[6] = {0x51, 0x6f, 0x9a, 0x01, 0, 0};
+
+    /* Remove NAN network mcast addr from multicast table */
+    return wifi_remove_mcast_filter(nan_network_addr);
+}
+#endif
+
 int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
 {
     static bool reset_mutex_init = 0;
@@ -8417,6 +8435,15 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
 #endif
 #endif
 
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
+    ret = wlan_set_nan_mcast_addr();
+    if (ret != WM_SUCCESS)
+    {
+        wlcm_e("Add NAN network mcast addr to multicast table failed\r\n");
+        return 0;
+    }
+#endif
+
     return WM_SUCCESS;
 }
 
@@ -8440,6 +8467,12 @@ int wlan_stop(void)
         wlcm_e("cannot stop wlcmgr. unexpected wlan.running: %d", wlan.running);
         return WLAN_ERROR_STATE;
     }
+
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
+    /* Remove NAN multicast filter before deinit */
+    (void)wlan_remove_nan_mcast_addr();
+#endif
+
 #if OTP_CHANINFO
     wifi_free_fw_region_and_cfp_tables();
 #endif


### PR DESCRIPTION
Add NAN multicast address filtering to support PAF commissioning.
NAN Service Discovery Frames use multicast addresses (51:6f:9a:01:00:00)
that need to be registered in the multicast filter table to be received
correctly.

Conditionally compiled with CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN.