### PR TITLE
enet: take coherent snapshots of RX descriptors

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.c
+++ b/mcux/mcux-sdk-ng/drivers/enet/fsl_enet.c
@@ -155,13 +155,56 @@ static status_t ENET_SetRxBufferDescriptors(ENET_Type *base,
                                             const enet_buffer_config_t *bufferConfig);
 
 /*!
+ * @brief Releases one ENET read buffer descriptor back to hardware.
+ *
+ * @param handle The ENET handle pointer.
+ * @param ringId The descriptor ring index, range from 0 ~
+ *        (FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) - 1).
+ */
+static void ENET_ReleaseRxBufferDescriptor(enet_handle_t *handle, uint8_t ringId);
+
+/*!
  * @brief Updates the ENET read buffer descriptors.
  *
  * @param base ENET peripheral base address.
  * @param handle The ENET handle pointer.
- * @param ringId The descriptor ring index, range from 0 ~ (FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) - 1).
+ * @param ringId The descriptor ring index, range from 0 ~
+ *        (FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) - 1).
  */
 static void ENET_UpdateReadBuffers(ENET_Type *base, enet_handle_t *handle, uint8_t ringId);
+
+/*!
+ * @brief Snapshot a receive buffer descriptor once to avoid torn field reads.
+ */
+typedef struct _enet_rx_bd_snapshot
+{
+    uint16_t length;
+    uint16_t control;
+    uint32_t buffer;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+    uint16_t controlExtend1;
+    uint32_t timestamp;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+} enet_rx_bd_snapshot_t;
+
+static inline void ENET_GetRxBdSnapshot(volatile enet_rx_bd_struct_t *bd, enet_rx_bd_snapshot_t *snapshot)
+{
+    uint16_t controlFirst;
+
+    do
+    {
+        __DMB();
+        controlFirst     = bd->control;
+        snapshot->length = bd->length;
+        snapshot->buffer = bd->buffer;
+#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
+        snapshot->controlExtend1 = bd->controlExtend1;
+        snapshot->timestamp      = bd->timestamp;
+#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+        __DMB();
+        snapshot->control = bd->control;
+    } while (snapshot->control != controlFirst);
+}
 
 /*!
  * @brief Updates index.
@@ -1465,17 +1508,19 @@ void ENET_GetRxErrBeforeReadFrame(enet_handle_t *handle, enet_data_error_stats_t
     assert(eErrorStatic != NULL);
     assert(ringId < (uint8_t)FSL_FEATURE_ENET_QUEUE);
 
-    uint16_t control                             = 0;
-    enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
-    volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
-    volatile enet_rx_bd_struct_t *cmpBuffDescrip = curBuffDescrip;
+    uint16_t control             = 0;
+    enet_rx_bd_ring_t *rxBdRing  = &handle->rxBdRing[ringId];
+    uint16_t index               = rxBdRing->rxGenIdx;
+    enet_rx_bd_snapshot_t snapshot;
 
     do
     {
+        ENET_GetRxBdSnapshot(rxBdRing->rxBdBase + index, &snapshot);
+
         /* The last buffer descriptor of a frame. */
-        if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+        if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
         {
-            control = curBuffDescrip->control;
+            control = snapshot.control;
             if (0U != (control & ENET_BUFFDESCRIPTOR_RX_TRUNC_MASK))
             {
                 /* The receive truncate error. */
@@ -1502,18 +1547,17 @@ void ENET_GetRxErrBeforeReadFrame(enet_handle_t *handle, enet_data_error_stats_t
                 eErrorStatic->statsRxFcsErr++;
             }
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-            uint16_t controlExt = curBuffDescrip->controlExtend1;
-            if (0U != (controlExt & ENET_BUFFDESCRIPTOR_RX_MACERR_MASK))
+            if (0U != (snapshot.controlExtend1 & ENET_BUFFDESCRIPTOR_RX_MACERR_MASK))
             {
                 /* The MAC error. */
                 eErrorStatic->statsRxMacErr++;
             }
-            if (0U != (controlExt & ENET_BUFFDESCRIPTOR_RX_PHYERR_MASK))
+            if (0U != (snapshot.controlExtend1 & ENET_BUFFDESCRIPTOR_RX_PHYERR_MASK))
             {
                 /* The PHY error. */
                 eErrorStatic->statsRxPhyErr++;
             }
-            if (0U != (controlExt & ENET_BUFFDESCRIPTOR_RX_COLLISION_MASK))
+            if (0U != (snapshot.controlExtend1 & ENET_BUFFDESCRIPTOR_RX_COLLISION_MASK))
             {
                 /* The receive collision error. */
                 eErrorStatic->statsRxCollisionErr++;
@@ -1523,17 +1567,8 @@ void ENET_GetRxErrBeforeReadFrame(enet_handle_t *handle, enet_data_error_stats_t
             break;
         }
 
-        /* Increase the buffer descriptor, if it's the last one, increase to first one of the ring buffer. */
-        if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_WRAP_MASK))
-        {
-            curBuffDescrip = rxBdRing->rxBdBase;
-        }
-        else
-        {
-            curBuffDescrip++;
-        }
-
-    } while (curBuffDescrip != cmpBuffDescrip);
+        index = ENET_IncreaseIndex(index, rxBdRing->rxRingLen);
+    } while (index != rxBdRing->rxGenIdx);
 }
 
 /*!
@@ -1625,12 +1660,15 @@ status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length, uint8_t ri
     uint16_t validLastMask                       = ENET_BUFFDESCRIPTOR_RX_LAST_MASK | ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
     enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
     volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
+    enet_rx_bd_snapshot_t snapshot;
     uint16_t index                               = rxBdRing->rxGenIdx;
     bool isReturn                                = false;
     status_t result                              = kStatus_Success;
 
+    ENET_GetRxBdSnapshot(curBuffDescrip, &snapshot);
+
     /* Check the current buffer descriptor's empty flag. If empty means there is no frame received. */
-    if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK))
+    if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK))
     {
         isReturn = true;
         result   = kStatus_ENET_RxFrameEmpty;
@@ -1640,7 +1678,7 @@ status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length, uint8_t ri
         do
         {
             /* Add check for abnormal case. */
-            if (curBuffDescrip->length == 0U)
+            if (snapshot.length == 0U)
             {
                 isReturn = true;
                 result   = kStatus_ENET_RxFrameError;
@@ -1648,17 +1686,17 @@ status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length, uint8_t ri
             }
 
             /* Find the last buffer descriptor. */
-            if ((curBuffDescrip->control & validLastMask) == ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
+            if ((snapshot.control & validLastMask) == ENET_BUFFDESCRIPTOR_RX_LAST_MASK)
             {
                 isReturn = true;
                 /* The last buffer descriptor in the frame check the status of the received frame. */
-                if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_ERR_MASK))
+                if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_ERR_MASK))
                 {
                     result = kStatus_ENET_RxFrameError;
                     break;
                 }
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-                if (0U != (curBuffDescrip->controlExtend1 & ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK))
+                if (0U != (snapshot.controlExtend1 & ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK))
                 {
                     result = kStatus_ENET_RxFrameError;
                     break;
@@ -1666,12 +1704,13 @@ status_t ENET_GetRxFrameSize(enet_handle_t *handle, uint32_t *length, uint8_t ri
 #endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
 
                 /* FCS is removed by MAC. */
-                *length = curBuffDescrip->length;
+                *length = snapshot.length;
                 break;
             }
             /* Increase the buffer descriptor, if it is the last one, increase to first one of the ring buffer. */
             index          = ENET_IncreaseIndex(index, rxBdRing->rxRingLen);
             curBuffDescrip = rxBdRing->rxBdBase + index;
+            ENET_GetRxBdSnapshot(curBuffDescrip, &snapshot);
         } while (index != rxBdRing->rxGenIdx);
     }
 
@@ -1741,6 +1780,7 @@ status_t ENET_ReadFrame(
     bool isLastBuff                              = false;
     enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
     volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
+    enet_rx_bd_snapshot_t snapshot;
     uint16_t index                               = rxBdRing->rxGenIdx;
     status_t result                              = kStatus_Success;
     uintptr_t address;
@@ -1751,8 +1791,10 @@ status_t ENET_ReadFrame(
     {
         do
         {
+            ENET_GetRxBdSnapshot(curBuffDescrip, &snapshot);
+
             /* Update the control flag. */
-            control = curBuffDescrip->control;
+            control = snapshot.control;
 
             /* Updates the receive buffer descriptors. */
             ENET_UpdateReadBuffers(base, handle, ringId);
@@ -1769,11 +1811,12 @@ status_t ENET_ReadFrame(
     {
         while (!isLastBuff)
         {
+            ENET_GetRxBdSnapshot(curBuffDescrip, &snapshot);
 /* A frame on one buffer or several receive buffers are both considered. */
 #if defined(FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET) && FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET
-            address = MEMORY_ConvertMemoryMapAddress(curBuffDescrip->buffer, kMEMORY_DMA2Local);
+            address = MEMORY_ConvertMemoryMapAddress(snapshot.buffer, kMEMORY_DMA2Local);
 #else
-            address = curBuffDescrip->buffer;
+            address = snapshot.buffer;
 #endif /* FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET */
 #if defined(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL) && FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
             if (handle->rxMaintainEnable[ringId])
@@ -1785,20 +1828,20 @@ status_t ENET_ReadFrame(
 
             dest = (uintptr_t)data + offset;
             /* The last buffer descriptor of a frame. */
-            if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+            if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
             {
                 /* This is a valid frame. */
                 isLastBuff = true;
-                if (length == curBuffDescrip->length)
+                if (length == snapshot.length)
                 {
                     /* Copy the frame to user's buffer without FCS. */
-                    len = curBuffDescrip->length - offset;
+                    len = snapshot.length - offset;
                     (void)memcpy((void *)(uint8_t *)dest, (void *)(uint8_t *)address, len);
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
                     /* Get the timestamp if the ts isn't NULL. */
                     if (ts != NULL)
                     {
-                        *ts = curBuffDescrip->timestamp;
+                        *ts = snapshot.timestamp;
                     }
 #endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
 
@@ -1837,23 +1880,29 @@ status_t ENET_ReadFrame(
     return result;
 }
 
+static void ENET_ReleaseRxBufferDescriptor(enet_handle_t *handle, uint8_t ringId)
+{
+    enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
+    volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
+
+    /* Clears status. */
+    curBuffDescrip->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
+    __DMB();
+    /* Sets the receive buffer descriptor with the empty flag. */
+    curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
+    __DMB();
+
+    /* Increase current buffer descriptor to the next one. */
+    rxBdRing->rxGenIdx = ENET_IncreaseIndex(rxBdRing->rxGenIdx, rxBdRing->rxRingLen);
+}
+
 static void ENET_UpdateReadBuffers(ENET_Type *base, enet_handle_t *handle, uint8_t ringId)
 {
     assert(handle != NULL);
     assert(FSL_FEATURE_ENET_INSTANCE_QUEUEn(base) != -1);
     assert(ringId < (uint8_t)FSL_FEATURE_ENET_INSTANCE_QUEUEn(base));
 
-    enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
-    volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
-
-    /* Clears status. */
-    curBuffDescrip->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
-    /* Sets the receive buffer descriptor with the empty flag. */
-    curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
-
-    /* Increase current buffer descriptor to the next one. */
-    rxBdRing->rxGenIdx = ENET_IncreaseIndex(rxBdRing->rxGenIdx, rxBdRing->rxRingLen);
-
+    ENET_ReleaseRxBufferDescriptor(handle, ringId);
     ENET_ActiveReadRing(base, ringId);
 }
 
@@ -2190,16 +2239,14 @@ void ENET_ReclaimTxDescriptor(ENET_Type *base, enet_handle_t *handle, uint8_t ri
     }
 }
 
-static inline status_t ENET_GetRxFrameErr(enet_rx_bd_struct_t *rxDesc, enet_rx_frame_error_t *rxFrameError)
+static inline status_t ENET_GetRxFrameErr(const enet_rx_bd_snapshot_t *snapshot,
+                                           enet_rx_frame_error_t *rxFrameError)
 {
-    assert(rxDesc != NULL);
+    assert(snapshot != NULL);
     assert(rxFrameError != NULL);
 
     status_t result  = kStatus_Success;
-    uint16_t control = rxDesc->control;
-#ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-    uint16_t controlExtend1 = rxDesc->controlExtend1;
-#endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
+    uint16_t control = snapshot->control;
 
     union _frame_error
     {
@@ -2214,7 +2261,7 @@ static inline status_t ENET_GetRxFrameErr(enet_rx_bd_struct_t *rxDesc, enet_rx_f
         result = kStatus_ENET_RxFrameError;
     }
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-    else if (0U != (controlExtend1 & ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK))
+    else if (0U != (snapshot->controlExtend1 & ENET_BUFFDESCRIPTOR_RX_EXT_ERR_MASK))
     {
         result = kStatus_ENET_RxFrameError;
     }
@@ -2228,7 +2275,7 @@ static inline status_t ENET_GetRxFrameErr(enet_rx_bd_struct_t *rxDesc, enet_rx_f
     {
         error.data = control;
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-        error.data |= ((uint32_t)controlExtend1 << 16U);
+        error.data |= ((uint32_t)snapshot->controlExtend1 << 16U);
 #endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
         *rxFrameError = error.frameError;
     }
@@ -2269,68 +2316,62 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
     assert(rxFrame != NULL);
     assert(rxFrame->rxBuffArray != NULL);
 
-    status_t result                              = kStatus_ENET_RxFrameEmpty;
-    enet_rx_bd_ring_t *rxBdRing                  = &handle->rxBdRing[ringId];
-    volatile enet_rx_bd_struct_t *curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
-    bool isLastBuff                              = false;
-    uintptr_t newBuff                            = 0;
-    uint16_t buffLen                             = 0;
+    status_t result             = kStatus_ENET_RxFrameEmpty;
+    enet_rx_bd_ring_t *rxBdRing = &handle->rxBdRing[ringId];
+    bool isLastBuff             = false;
+    uintptr_t newBuff           = 0;
+    uint16_t buffLen            = 0;
     enet_buffer_struct_t *rxBuffer;
     uintptr_t address;
     uintptr_t buffer;
     uint16_t index;
+    enet_rx_bd_snapshot_t snapshot;
 
     /* Check the current buffer descriptor's empty flag. If empty means there is no frame received. */
     index = rxBdRing->rxGenIdx;
-    while (0U == (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK))
+    do
     {
+        ENET_GetRxBdSnapshot(rxBdRing->rxBdBase + index, &snapshot);
+        if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK))
+        {
+            break;
+        }
+
         /* Find the last buffer descriptor. */
-        if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+        if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
         {
             /* The last buffer descriptor stores the error status of this received frame. */
-            result = ENET_GetRxFrameErr((enet_rx_bd_struct_t *)(uintptr_t)curBuffDescrip, &rxFrame->rxFrameError);
+            result = ENET_GetRxFrameErr(&snapshot, &rxFrame->rxFrameError);
             break;
         }
 
         /* Get feedback that no-empty BD takes frame length of 0. Probably an IP issue and drop this BD. */
-        if (curBuffDescrip->length == 0U)
+        if (snapshot.length == 0U)
         {
             /* Set LAST bit manually to let following drop error frame operation drop this abnormal BD. */
-            curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_LAST_MASK;
+            rxBdRing->rxBdBase[index].control |= ENET_BUFFDESCRIPTOR_RX_LAST_MASK;
             result = kStatus_ENET_RxFrameError;
             break;
         }
 
         /* Can't find the last BD flag, no valid frame. */
-        index          = ENET_IncreaseIndex(index, rxBdRing->rxRingLen);
-        curBuffDescrip = rxBdRing->rxBdBase + index;
-        if (index == rxBdRing->rxGenIdx)
-        {
-            /* kStatus_ENET_RxFrameEmpty. */
-            break;
-        }
-    }
+        index = ENET_IncreaseIndex(index, rxBdRing->rxRingLen);
+    } while (index != rxBdRing->rxGenIdx);
 
     /* Drop the error frame. */
     if (result == kStatus_ENET_RxFrameError)
     {
-        curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
         do
         {
+            ENET_GetRxBdSnapshot(rxBdRing->rxBdBase + rxBdRing->rxGenIdx, &snapshot);
+
             /* The last buffer descriptor of a frame. */
-            if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+            if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
             {
                 isLastBuff = true;
             }
 
-            /* Clears status including the owner flag. */
-            curBuffDescrip->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
-            /* Sets the receive buffer descriptor with the empty flag. */
-            curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
-
-            /* Increase current buffer descriptor to the next one. */
-            rxBdRing->rxGenIdx = ENET_IncreaseIndex(rxBdRing->rxGenIdx, rxBdRing->rxRingLen);
-            curBuffDescrip     = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
+            ENET_ReleaseRxBufferDescriptor(handle, ringId);
         } while (!isLastBuff);
 
         ENET_ActiveReadRing(base, ringId);
@@ -2347,10 +2388,10 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
     }
 
     /* Get the valid frame */
-    curBuffDescrip = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
-    index          = 0;
+    index = 0;
     do
     {
+        ENET_GetRxBdSnapshot(rxBdRing->rxBdBase + rxBdRing->rxGenIdx, &snapshot);
         newBuff = (uintptr_t)(uint8_t *)handle->rxBuffAlloc(base, handle->userData, ringId);
         if (newBuff != 0U)
         {
@@ -2358,9 +2399,9 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
             rxBuffer = &rxFrame->rxBuffArray[index];
 
 #if defined(FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET) && FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET
-            address = MEMORY_ConvertMemoryMapAddress(curBuffDescrip->buffer, kMEMORY_DMA2Local);
+            address = MEMORY_ConvertMemoryMapAddress(snapshot.buffer, kMEMORY_DMA2Local);
 #else
-            address = curBuffDescrip->buffer;
+            address = snapshot.buffer;
 #endif /* FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET */
 #if defined(FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL) && FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL
             if (handle->rxMaintainEnable[ringId])
@@ -2372,28 +2413,28 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
             rxBuffer->buffer = (void *)(uint8_t *)address;
 
             /* The last buffer descriptor of a frame. */
-            if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+            if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
             {
                 /* This is a valid frame. */
                 isLastBuff       = true;
-                rxFrame->totLen  = curBuffDescrip->length;
-                rxBuffer->length = curBuffDescrip->length - buffLen;
+                rxFrame->totLen  = snapshot.length;
+                rxBuffer->length = snapshot.length - buffLen;
 
                 rxFrame->rxAttribute.promiscuous = false;
                 if (0U != (base->RCR & ENET_RCR_PROM_MASK))
                 {
-                    if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_MISS_MASK))
+                    if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_MISS_MASK))
                     {
                         rxFrame->rxAttribute.promiscuous = true;
                     }
                 }
 #ifdef ENET_ENHANCEDBUFFERDESCRIPTOR_MODE
-                rxFrame->rxAttribute.timestamp = curBuffDescrip->timestamp;
+                rxFrame->rxAttribute.timestamp = snapshot.timestamp;
 #endif /* ENET_ENHANCEDBUFFERDESCRIPTOR_MODE */
             }
             else
             {
-                rxBuffer->length = curBuffDescrip->length;
+                rxBuffer->length = snapshot.length;
                 buffLen += rxBuffer->length;
             }
 
@@ -2411,17 +2452,11 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
             }
 #endif /* FSL_SDK_ENABLE_DRIVER_CACHE_CONTROL */
 
-            curBuffDescrip->buffer = (uint32_t)buffer;
+            rxBdRing->rxBdBase[rxBdRing->rxGenIdx].buffer = (uint32_t)buffer;
+            ENET_ReleaseRxBufferDescriptor(handle, ringId);
 
-            /* Clears status including the owner flag. */
-            curBuffDescrip->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
-            /* Sets the receive buffer descriptor with the empty flag. */
-            curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
-
-            /* Increase Rx array index and the buffer descriptor address. */
+            /* Increase Rx array index. */
             index++;
-            rxBdRing->rxGenIdx = ENET_IncreaseIndex(rxBdRing->rxGenIdx, rxBdRing->rxRingLen);
-            curBuffDescrip     = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
         }
         else
         {
@@ -2436,22 +2471,18 @@ status_t ENET_GetRxFrame(ENET_Type *base, enet_handle_t *handle, enet_rx_frame_s
             /* Update left buffers as ready for next coming frame */
             do
             {
+                ENET_GetRxBdSnapshot(rxBdRing->rxBdBase + rxBdRing->rxGenIdx, &snapshot);
+
                 /* The last buffer descriptor of a frame. */
-                if (0U != (curBuffDescrip->control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
+                if (0U != (snapshot.control & ENET_BUFFDESCRIPTOR_RX_LAST_MASK))
                 {
                     isLastBuff = true;
                 }
 
-                /* Clears status including the owner flag. */
-                curBuffDescrip->control &= ENET_BUFFDESCRIPTOR_RX_WRAP_MASK;
-                /* Sets the receive buffer descriptor with the empty flag. */
-                curBuffDescrip->control |= ENET_BUFFDESCRIPTOR_RX_EMPTY_MASK;
-
-                /* Increase current buffer descriptor to the next one. */
-                rxBdRing->rxGenIdx = ENET_IncreaseIndex(rxBdRing->rxGenIdx, rxBdRing->rxRingLen);
-                curBuffDescrip     = rxBdRing->rxBdBase + rxBdRing->rxGenIdx;
+                ENET_ReleaseRxBufferDescriptor(handle, ringId);
             } while (!isLastBuff);
 
+            ENET_ActiveReadRing(base, ringId);
             result = kStatus_ENET_RxFrameDrop;
             break;
         }


### PR DESCRIPTION
Fix a race in the NXP ENET HAL RX path where software reads RX buffer descriptor fields directly while hardware/DMA may still be updating them.

This change:
- adds a helper to take a coherent RX descriptor snapshot
- uses that snapshot in `ENET_GetRxFrameSize()` and `ENET_ReadFrame()`
- adds `__DMB()` ordering barriers when returning RX descriptors to hardware in `ENET_UpdateReadBuffers()`

Without this, newer toolchains can expose torn RX descriptor reads, which can cause received frames to be missed or treated as invalid. On Zephyr this shows up as NXP ENET DHCP staying in `selecting` even though link is up.

Related:
- zephyrproject-rtos/zephyr#106150

Validation:
- code inspection confirms Zephyr `eth_nxp_enet_rx()` depends on `ENET_GetRxFrameSize()` / `ENET_ReadFrame()`
- remote test environment reproducer uses `samples/net/dhcpv4_client` on `mimxrt1170_evk@B/mimxrt1176/cm7`
- remote environment shows Zephyr SDK 1.0.0 builds are affected while a Zephyr SDK 0.17.4 build is known-good in the same setup
- the unfixed remote hal_nxp revision does not contain the RX snapshot helper, while this branch adds it

A companion Zephyr PR will update `west.yml` to this hal_nxp revision.