### PR TITLE
mcux: wifi_nxp: add register_frame support and skip offloaded probe r…

### DIFF
--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
@@ -3794,9 +3794,9 @@ int wifi_nxp_beacon_config(nxp_wifi_ap_info_t *params)
             }
             wuap_d("wlan: AP started");
 
-            (void)wifi_set_rx_mgmt_indication(MLAN_BSS_TYPE_UAP, WIFI_MGMT_AUTH | MGMT_MASK_ASSOC_REQ |
-                                                                     MGMT_MASK_REASSOC_REQ | WIFI_MGMT_DEAUTH |
-                                                                     WIFI_MGMT_ACTION | WIFI_MGMT_DIASSOC);
+            (void)wifi_set_rx_mgmt_indication(
+                MLAN_BSS_TYPE_UAP, MGMT_MASK_PROBE_REQ | WIFI_MGMT_AUTH | MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ |
+                                       WIFI_MGMT_DEAUTH | WIFI_MGMT_ACTION | WIFI_MGMT_DIASSOC);
         }
 
     done:

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -2333,6 +2333,7 @@ int wifi_nxp_wpa_supp_send_mlme(void *if_priv,
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
     const struct ieee80211_hdr *hdr;
     u16 fc, stype;
+    mlan_private *pmpriv;
 
     hdr   = (const struct ieee80211_hdr *)data;
     fc    = le_to_host16(hdr->frame_control);
@@ -2353,6 +2354,17 @@ int wifi_nxp_wpa_supp_send_mlme(void *if_priv,
     wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)if_priv;
 
     wifi_if_ctx_rtos->mgmt_tx_status = 0;
+
+    pmpriv = (mlan_private *)mlan_adap->priv[wifi_if_ctx_rtos->bss_type];
+
+    if (stype == WLAN_FC_STYPE_PROBE_RESP && GET_BSS_ROLE(pmpriv) == MLAN_BSS_ROLE_UAP)
+    {
+        /* Since we support offload probe resp, we need to skip probe
+         * resp in uAP or GO mode */
+        supp_d("%s: Skip send probe_resp in GO/UAP mode", __func__);
+        status = WM_SUCCESS;
+        goto out;
+    }
 
     status = wifi_nxp_send_mlme(wifi_if_ctx_rtos->bss_type, freq_to_chan(freq), wait_time, data, data_len);
 


### PR DESCRIPTION
…esponses

Implement register_frame callback to register management frame filters with the driver, and skip sending probe responses in uAP/GO mode since probe response offload is supported.

wpa_supplicant needs to register management frame types (probe_req) with the driver to receive them for WPS functionality. In uAP/GO mode, probe responses are offloaded to firmware, so wpa_supplicant should not send them via send_mlme.