### PR TITLE
wifi_nxp: wlcmgr: Fix missing 'WLAN_REASON_UAP_SUCCESS' event and dec…

### DIFF
--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -6164,7 +6164,6 @@ static enum cm_uap_state uap_state_machine(struct wifi_message *msg)
                 t_u8 sta_channel = mlan_adap->priv[0]->curr_bss_params.bss_descriptor.channel;
                 t_u8 uap_channel = mlan_adap->priv[1]->uap_channel;
 
-                CONNECTION_EVENT(WLAN_REASON_UAP_SUCCESS, NULL);
                 if(is_sta_connected() && uap_channel != sta_channel)
                 {
                     while(!is_uap_started())
@@ -6300,7 +6299,6 @@ static enum cm_uap_state uap_state_machine(struct wifi_message *msg)
                 (void)net_get_if_ipv6_addr((struct net_ip_config *)&network->ip, if_handle);
 #endif
                 next = CM_UAP_IP_UP;
-                CONNECTION_EVENT(WLAN_REASON_UAP_SUCCESS, NULL);
             }
             else
             {
@@ -7574,6 +7572,9 @@ static void wlcmgr_task(void *data)
 
                 wlcm_d("SM uAP %s -> %s", dbg_uap_state_name(wlan.uap_state), dbg_uap_state_name(next_uap_state));
                 wlan.uap_state = next_uap_state;
+                if (wlan.uap_state == CM_UAP_STARTED) {
+                    CONNECTION_EVENT(WLAN_REASON_UAP_SUCCESS, NULL);
+                }
 #else
                 wlcm_w("UAP feature disabled recv wlcm msg %d", msg.event);
 #endif


### PR DESCRIPTION
…ouple from L3 state

Applications waiting for the 'WIFI_STATUS_AP_SUCCESS' event from the NXP Wi-Fi driver (zephyr/drivers/wifi/nxp/nxp_wifi_drv.c) would either never receive it or experience inconsistent behavior depending on the 'CONFIG_WIFI_NM_WPA_SUPPLICANT' setting.

Prior to this commit, this was caused by two issues:
1. The 'WLAN_REASON_UAP_SUCCESS' event trigger condition arbitrarily switched between waiting for 'CM_UAP_STARTED' (L2) and 'CM_UAP_IP_UP' (L3). When 'CONFIG_WIFI_NM_WPA_SUPPLICANT' was set, the event was triggered while 'case WIFI_EVENT_UAP_STARTED:' was processed in 'uap_state_machine()'. However, when 'CONFIG_WIFI_NM_WPA_SUPPLICANT' was NOT set, it was triggered while 'case WIFI_EVENT_UAP_NET_ADDR_CONFIG:' was processed. Therefore, in L2-only uAP scenarios without 'CONFIG_WIFI_NM_WPA_SUPPLICANT', it was never triggered because no IP address is set.
2. The 'WLAN_REASON_UAP_SUCCESS' event was triggered inside 'uap_state_machine()' before the global 'wlan.uap_state' was updated. This caused the state check inside 'wlan_get_current_uap_network_ssid()' to fail, dropping the event from 'nxp_wifi_drv.c' => 'nxp_wifi_wlan_event_callback()'.

This commit fixes these issues by removing the event triggers from 'uap_state_machine()'. Instead, it unifies the trigger condition to simply wait for the 'CM_UAP_STARTED' state, ensuring consistent behavior and properly supporting IP-less setups.
It also moves the event trigger to 'wlcmgr_task()' after 'wlan.uap_state' is updated.