### PR TITLE
mcux: wifi_nxp: Fix incorrect mode after set-bandcfg command

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi-decl.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi-decl.h
@@ -605,9 +605,34 @@ typedef PACK_START struct _wifi_ed_mac_ctrl_t
     t_s16 ed_offset_5g;
 } PACK_END wifi_ed_mac_ctrl_t;
 
+typedef PACK_START struct _wifi_set_band_config_t
+{
+    /**
+     * zero: legacy (B + G + A)
+     * bit 0: 11N
+     * bit 1: 11AC
+     * bit 2: 11AX
+     */
+    /** band configuration */
+    t_u16 band_cfg;
+    /** hardware supported bands */
+    t_u16 supp_bands;
+} PACK_END wifi_set_band_config_t;
+
 /** Type definition of wifi_bandcfg_t */
 typedef PACK_START struct _wifi_bandcfg_t
 {
+    /** Band Bitmap:
+     *  bit 0: B (Not configurable) \n
+     *  bit 1: G (Not configurable)\n
+     *  bit 2: A (Not configurable)\n
+     *  bit 3: GN \n
+     *  bit 4: AN \n
+     *  bit 5: GAC \n
+     *  bit 6: AAC \n
+     *  bit 8: GAX \n
+     *  bit 9: AAX
+     */
     /** Infra band */
     t_u16 config_bands;
     /** fw supported band */

--- a/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
+++ b/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
@@ -1505,10 +1505,19 @@ typedef wifi_ds_rate wlan_ds_rate;
  * \ref wifi_ed_mac_ctrl_t
  */
 typedef wifi_ed_mac_ctrl_t wlan_ed_mac_ctrl_t;
+
+#define WLAN_BANDCFG_11N MBIT(0)
+#if CONFIG_11AC
+#define WLAN_BANDCFG_11AC MBIT(1)
+#endif
+#if CONFIG_11AX
+#define WLAN_BANDCFG_11AX MBIT(2)
+#endif
+
 /** Configuration for band from
- * \ref wifi_bandcfg_t
+ * \ref wifi_set_band_config_t
  */
-typedef wifi_bandcfg_t wlan_bandcfg_t;
+typedef wifi_set_band_config_t wlan_bandcfg_t;
 /** Configuration for CW mode parameters from
  * \ref wifi_cw_mode_ctrl_t
  */
@@ -7030,6 +7039,14 @@ int wlan_get_signal_info(wlan_rssi_info_t *signal);
 /**
  * Set band configuration.
  * \param[in] bandcfg:   band configuration
+ *
+ * \note 11AC or 11AX only mode is not supported. Supported modes are: \n
+ *   legacy (B + G + A)\n
+ *   11N only \n
+ *   11N + 11AC \n
+ *   11N + 11AX \n
+ *   11N + 11AC + 11AX\n
+ * \note B,G and A modes are enabled by default and not configurable.\n
  *
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
  */

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -2132,13 +2132,13 @@ static int do_start(struct wlan_network *network)
         if (network->channel == 14)
         {
             wlan_bandcfg_t bandcfg = {0};
-            bandcfg.config_bands &=
-                ~(BAND_AN | BAND_GN
+            bandcfg.band_cfg &=
+                ~(WLAN_BANDCFG_11N
 #if CONFIG_11AC
-                | BAND_AAC | BAND_GAC
+                | WLAN_BANDCFG_11AC
 #endif
 #if CONFIG_11AX
-                | BAND_AAX | BAND_GAX
+                | WLAN_BANDCFG_11AX
 #endif
                 );
             ret = wlan_set_bandcfg(&bandcfg);
@@ -2245,7 +2245,7 @@ static int do_stop(struct wlan_network *network)
                 wlcm_e("Unable to get bandcfg");
                 return -WM_FAIL;
             }
-            bandcfg.config_bands = bandcfg.fw_bands;
+            bandcfg.band_cfg = bandcfg.supp_bands;
             ret = wlan_set_bandcfg(&bandcfg);
             if (ret != WM_SUCCESS)
             {
@@ -15856,7 +15856,81 @@ static void wlan_uap_update_hostapd_bss(wlan_bandcfg_t *bandcfg)
 int wlan_set_bandcfg(wlan_bandcfg_t *bandcfg)
 {
     int ret = 0;
-    ret = wifi_get_set_bandcfg(bandcfg, MLAN_ACT_SET);
+    uint16_t enable_11n = bandcfg->band_cfg & WLAN_BANDCFG_11N;
+#if CONFIG_11AC
+    uint16_t enable_11ac = bandcfg->band_cfg & WLAN_BANDCFG_11AC;
+#endif
+#if CONFIG_11AX
+    uint16_t enable_11ax = bandcfg->band_cfg & WLAN_BANDCFG_11AX;
+#endif
+    wifi_bandcfg_t cfg;
+
+    if (is_sta_connected() || is_uap_started())
+    {
+        (void)PRINTF("Error: set-bandcfg command is not allowed when STA has connection or uAP is started\r\n");
+        return -WM_FAIL;
+    }
+
+#if CONFIG_11AC
+    if (enable_11ac && !enable_11n)
+    {
+        (void)PRINTF("Error! 11AC only mode is not supported! Should enable 11N, too.");
+        return -WM_FAIL;
+    }
+#endif
+#if CONFIG_11AX
+    if (enable_11ax && !enable_11n)
+    {
+        (void)PRINTF("Error! 11AX only mode is not supported! Should enable 11N, too.");
+        return -WM_FAIL;
+    }
+#endif
+
+    memset(&cfg, 0, sizeof(cfg));
+    ret = wifi_get_set_bandcfg(&cfg, MLAN_ACT_GET);
+    if (ret != WM_SUCCESS)
+    {
+        (void)PRINTF("Unable to get bandcfg\r\n");
+        return -WM_FAIL;
+    }
+
+    cfg.config_bands = 0;
+    /* Band B, G and A are not configurable. They are mandantory. */
+    cfg.config_bands |= (BAND_B | BAND_G | BAND_A);
+    if (enable_11n)
+    {
+        cfg.config_bands |= (BAND_GN | BAND_AN);
+    }
+#if CONFIG_11AC
+    if (enable_11ac)
+    {
+        uint16_t supp_11ac = cfg.fw_bands & (BAND_GAC | BAND_AAC);
+        if (supp_11ac)
+        {
+            cfg.config_bands |= (BAND_GAC | BAND_AAC);
+        }
+        else
+        {
+            (void)PRINTF("Warning: hardware doesn't support 11AC, ignore 11AC setting\r\n");
+        }
+    }
+#endif
+#if CONFIG_11AX
+    if (enable_11ax)
+    {
+        uint16_t supp_11ax = cfg.fw_bands & (BAND_GAX | BAND_AAX);
+        if (supp_11ax)
+        {
+            cfg.config_bands |= (BAND_GAX | BAND_AAX);
+        }
+        else
+        {
+            (void)PRINTF("Warning: hardware doesn't support 11AX, ignore 11AX setting\r\n");
+        }
+    }
+#endif
+
+    ret = wifi_get_set_bandcfg(&cfg, MLAN_ACT_SET);
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
     if (ret == WM_SUCCESS)
     {
@@ -15869,7 +15943,46 @@ int wlan_set_bandcfg(wlan_bandcfg_t *bandcfg)
 
 int wlan_get_bandcfg(wlan_bandcfg_t *bandcfg)
 {
-    return wifi_get_set_bandcfg(bandcfg, MLAN_ACT_GET);
+    int ret = WM_SUCCESS;
+    wifi_bandcfg_t cfg;
+
+    memset(&cfg, 0, sizeof(cfg));
+    ret = wifi_get_set_bandcfg(&cfg, MLAN_ACT_GET);
+    if (ret != WM_SUCCESS)
+    {
+        (void)PRINTF("Unable to get bandcfg\r\n");
+        return -WM_FAIL;
+    }
+
+    if (cfg.config_bands & (BAND_AN | BAND_GN))
+    {
+        bandcfg->band_cfg |= WLAN_BANDCFG_11N;
+    }
+    if (cfg.fw_bands & (BAND_AN | BAND_GN))
+    {
+        bandcfg->supp_bands |= WLAN_BANDCFG_11N;
+    }
+#if CONFIG_11AC
+    if (cfg.config_bands & (BAND_AAC | BAND_GAC))
+    {
+        bandcfg->band_cfg |= WLAN_BANDCFG_11AC;
+    }
+    if (cfg.fw_bands & (BAND_AAC | BAND_GAC))
+    {
+        bandcfg->supp_bands |= WLAN_BANDCFG_11AC;
+    }
+#endif
+#if CONFIG_11AX
+    if (cfg.config_bands & (BAND_AAX | BAND_GAX))
+    {
+        bandcfg->band_cfg |= WLAN_BANDCFG_11AX;
+    }
+    if (cfg.fw_bands & (BAND_AAX | BAND_GAX))
+    {
+        bandcfg->supp_bands |= WLAN_BANDCFG_11AX;
+    }
+#endif
+    return ret;
 }
 
 void wlan_uap_bandcfg_recfg(void)

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
@@ -6489,14 +6489,6 @@ static void test_wlan_get_signal(int argc, char **argv)
 }
 #endif
 
-#define WLAN_BANDCFG_11N MBIT(0)
-#if CONFIG_11AC
-#define WLAN_BANDCFG_11AC MBIT(1)
-#endif
-#if CONFIG_11AX
-#define WLAN_BANDCFG_11AX MBIT(2)
-#endif
-
 static void dump_wlan_bandcfg_bit_usage(void)
 {
     (void)PRINTF("        Bits in Band:\r\n");
@@ -6513,8 +6505,6 @@ static void test_wlan_get_bandcfg(int argc, char **argv)
 {
     wlan_bandcfg_t bandcfg;
     int ret = WM_SUCCESS;
-    uint32_t val = 0;
-    uint32_t hw_val = 0;
 
     (void)memset(&bandcfg, 0, sizeof(bandcfg));
 
@@ -6525,45 +6515,28 @@ static void test_wlan_get_bandcfg(int argc, char **argv)
         return;
     }
 
-    if (bandcfg.config_bands & (BAND_AN | BAND_GN))
-    {
-        val |= WLAN_BANDCFG_11N;
-    }
-    if (bandcfg.fw_bands & (BAND_AN | BAND_GN))
-    {
-        hw_val |= WLAN_BANDCFG_11N;
-    }
-#if CONFIG_11AC
-    if (bandcfg.config_bands & (BAND_AAC | BAND_GAC))
-    {
-        val |= WLAN_BANDCFG_11AC;
-    }
-    if (bandcfg.fw_bands & (BAND_AAC | BAND_GAC))
-    {
-        hw_val |= WLAN_BANDCFG_11AC;
-    }
-#endif
-#if CONFIG_11AX
-    if (bandcfg.config_bands & (BAND_AAX | BAND_GAX))
-    {
-        val |= WLAN_BANDCFG_11AX;
-    }
-    if (bandcfg.fw_bands & (BAND_AAX | BAND_GAX))
-    {
-        hw_val |= WLAN_BANDCFG_11AX;
-    }
-#endif
-
-    (void)PRINTF("\tconfig band: 0x%x\r\n", val);
-    (void)PRINTF("\tfw band: 0x%x\r\n", hw_val);
+    (void)PRINTF("\tconfig band: 0x%x\r\n", bandcfg.band_cfg);
+    (void)PRINTF("\tfw band: 0x%x\r\n", bandcfg.supp_bands);
     dump_wlan_bandcfg_bit_usage();
 }
 
 static void dump_wlan_set_bandcfg(void)
 {
-    (void)PRINTF("Usage:\r\n");
-    (void)PRINTF("    wlan-set-bandcfg <value>\r\n");
-    dump_wlan_bandcfg_bit_usage();
+    (void)PRINTF(
+        "Usage:\r\n"
+        "    wlan-set-bandcfg <value>\r\n"
+        "        value -- 0x0: legacy\r\n"
+        "                 0x1: 11N\r\n"
+#ifdef CONFIG_11AC
+        "                 0x3: 11N + 11AC\r\n"
+#endif
+#ifdef CONFIG_11AX
+        "                 0x5: 11N + 11AX\r\n"
+#endif
+#if defined(CONFIG_11AC) && defined(CONFIG_11AX)
+        "                 0x7: 11N + 11AC + 11AX\r\n"
+#endif
+    );
 }
 
 static void test_wlan_set_bandcfg(int argc, char **argv)
@@ -6585,44 +6558,16 @@ static void test_wlan_set_bandcfg(int argc, char **argv)
         return;
     }
 
-    val = a2hex_or_atoi(argv[1]);
-    (void)memset(&bandcfg, 0, sizeof(bandcfg));
-    ret = wlan_get_bandcfg(&bandcfg);
-    if (ret != WM_SUCCESS)
+    val = (uint16_t)a2hex_or_atoi(argv[1]);
+    if (val != 0 && !(val & WLAN_BANDCFG_11N))
     {
-        (void)PRINTF("Unable to get bandcfg\r\n");
+        (void)PRINTF("Error: invalid parameter <value>\r\n");
+        dump_wlan_set_bandcfg();
         return;
     }
 
-    if (!(val & WLAN_BANDCFG_11N))
-    {
-        bandcfg.config_bands &= ~(BAND_AN | BAND_GN);
-    }
-    else
-    {
-        bandcfg.config_bands |= (BAND_AN | BAND_GN);
-    }
-#if CONFIG_11AC
-    if (!(val & WLAN_BANDCFG_11AC))
-    {
-        bandcfg.config_bands &= ~(BAND_AAC | BAND_GAC);
-    }
-    else
-    {
-        bandcfg.config_bands |= (BAND_AAC | BAND_GAC);
-    }
-#endif
-#if CONFIG_11AX
-    if (!(val & WLAN_BANDCFG_11AX))
-    {
-        bandcfg.config_bands &= ~(BAND_AAX | BAND_GAX);
-    }
-    else
-    {
-        bandcfg.config_bands |= (BAND_AAX | BAND_GAX);
-    }
-#endif
-
+    (void)memset(&bandcfg, 0, sizeof(bandcfg));
+    bandcfg.band_cfg = val;
     ret = wlan_set_bandcfg(&bandcfg);
     if (ret != WM_SUCCESS)
     {


### PR DESCRIPTION
The mode of uAP is not correct if set DUT to 11ax only with set-bandcfg command. Based on driver log, 11ac or 11ax only mode is not supported. User must enable 11n with 11ac or 11ax. Added input paramter check. Show permitted input format in command usage log. Block and inform user 11ac and 11ax only mode is not supported.