### PR TITLE
Update rt pinctrl generation script

### DIFF
--- a/mcux/scripts/pinctrl/gen_soc_headers.py
+++ b/mcux/scripts/pinctrl/gen_soc_headers.py
@@ -20,6 +20,7 @@ import re
 
 # SOC configuration data support libraries
 from imx import imx_cfg_utils
+from imx import imx_fixup_pinmux
 from kinetis import kinetis_cfg_utils
 from lpc import lpc_cfg_utils
 
@@ -50,6 +51,9 @@ def parse_args():
     parser.add_argument('--controller', metavar = 'CTRL', type=str,
                         help=("SOC pin controller type."
                         "Currently supports: [IOMUX, IOCON, PORT]"))
+    parser.add_argument('--iomuxc-file', metavar = 'IOMUXC', type=str,
+                        help=('Path to fsl_iomuxc.h file for daisy register fixup. '
+                        'Required for IOMUX controller (i.MX RT 4-digit parts only)'))
 
     return parser.parse_args()
 
@@ -163,6 +167,11 @@ def main():
                 "but this is unsupported!")
             sys.exit(255)
 
+        if args.controller == 'IOMUX' and not args.iomuxc_file:
+            print("Error: --iomuxc-file is required for IOMUX controller "
+                "to fix daisy register values")
+            sys.exit(255)
+
         # Select correct config tool script for the signal file
         out_dir = args.soc_output.rstrip('/')
         if args.controller == 'IOMUX':
@@ -183,6 +192,15 @@ def main():
 
         cfg_util.write_pinctrl_defs(out_path)
         print(f"Wrote pinctrl headers to {out_path}")
+
+        if args.controller == 'IOMUX':
+            print(f"Running daisy register fixup using {args.iomuxc_file}")
+            ground_truth = imx_fixup_pinmux.parse_iomuxc_ground_truth(args.iomuxc_file)
+            error_count = imx_fixup_pinmux.fixup_pinctrl_file(out_path, ground_truth)
+            if error_count > 0:
+                print(f"Fixed {error_count} daisy register error(s) in {out_path}")
+            else:
+                print("No daisy register errors found")
 
 
 if __name__ == "__main__":

--- a/mcux/scripts/pinctrl/gen_soc_headers.py
+++ b/mcux/scripts/pinctrl/gen_soc_headers.py
@@ -28,7 +28,7 @@ from lpc import lpc_cfg_utils
 HELPSTR = """
 Processes NXP signal configuration files
 
-Given a processor data pack, generates the SOC level pinctrl DTSI defintions
+Given a processor data pack, generates the SOC level pinctrl DTSI definitions
 required for Zephyr. This tool is intended to be used with the configuration
 data downloaded from NXP's MCUXpresso SDK builder.
 """

--- a/mcux/scripts/pinctrl/imx/imx_cfg_utils.py
+++ b/mcux/scripts/pinctrl/imx/imx_cfg_utils.py
@@ -881,7 +881,7 @@ class NXPSdkUtil:
         self._logger.setLevel(log_level)
         if not cfg_path.is_dir():
             raise RuntimeError("Provided configuration path must be directory")
-        # Find all required register and signal defintions
+        # Find all required register and signal definitions
         signal_path = cfg_path / 'signal_configuration.xml'
         register_path = cfg_path / 'registers/registers.xml'
         register_dir = cfg_path / 'registers'
@@ -889,9 +889,9 @@ class NXPSdkUtil:
             and register_dir.is_dir()):
             raise RuntimeError("Required processor configuration files not present")
         try:
-            # Load the register xml defintion
+            # Load the register xml definition
             register_xml = ET.parse(str(register_path))
-            # Load the peripheral defintions
+            # Load the peripheral definitions
             self._peripheral_map = self._load_peripheral_map(register_xml, register_dir)
         except ET.ParseError:
             raise RuntimeError(f"Malformed XML tree in {register_xml}")
@@ -912,7 +912,7 @@ class NXPSdkUtil:
                         "unknown signal configuration file path", file_path)
                 # Load and parse this signal configuration file
                 signal_xml = ET.parse(str(file_path))
-            # Load the signal file defintion
+            # Load the signal file definition
             self._signal_map = self._load_signal_map(signal_xml)
         except ET.ParseError:
             logging.error("Malformed XML tree %s", signal_file)
@@ -936,8 +936,8 @@ class NXPSdkUtil:
 
     def write_gpio_mux(self, outputfile):
         """
-        Write pinctrl defintions for GPIO mux. These defintions map GPIO port
-        and pin combinations to iomuxc options. Note that these defintions are
+        Write pinctrl definitions for GPIO mux. These definitions map GPIO port
+        and pin combinations to iomuxc options. Note that these definitions are
         not indended to be used directly, and will likely need to be hand edited.
         @param outputfile file to write gpio dtsi file to
         """
@@ -1030,7 +1030,7 @@ class NXPSdkUtil:
             soc_dtsi.write(header)
             # Write documentation block
             soc_dtsi.write("/*\n"
-                    " * SOC level pinctrl defintions\n"
+                    " * SOC level pinctrl definitions\n"
                     " * These definitions define SOC level defaults for each pin,\n"
                     " * and select the pinmux for the pin. Pinmux entries are a tuple of:\n"
                     " * <mux_register mux_mode input_register input_daisy config_register>\n"
@@ -1141,7 +1141,7 @@ class NXPSdkUtil:
         """
         Generates a mapping of peripheral names to peripheral objects
         @param reg_xml: XML tree for register file
-        @param reg_dir: directory where register defintion files are stored
+        @param reg_dir: directory where register definition files are stored
         @return dict mapping peripheral names to base addresses
         """
         periph_map = {}

--- a/mcux/scripts/pinctrl/imx/imx_fixup_pinmux.py
+++ b/mcux/scripts/pinctrl/imx/imx_fixup_pinmux.py
@@ -7,33 +7,11 @@ import os
 
 HELPSTR = """
 Fix generated pinctrl defintions
-Generated RT11xx pinctrl definitions will be incorrect, because the signal
-configuration XML file itself is not correct. Fix them using fsl_iomuxc
-definitions.
+Generated i.MX RT 4-digit (RT1xxx) pinctrl definitions may be incorrect,
+because the signal configuration XML file itself is not correct. Fix them
+using fsl_iomuxc definitions. Only applies to parts with the IOMUXC IP;
+3-digit RT parts (RT5xx/RT6xx/RT7xx) use IOCON/IOPCTL and are not affected.
 """
-
-
-parser = argparse.ArgumentParser(description=HELPSTR,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.add_argument('iomuxc_file', metavar = 'IOMUXC',
-                    type=str,
-                    help='iomuxc file to use as ground truth')
-parser.add_argument('pinctrl_file', metavar = 'pinctrl',
-                    type=str,
-                    help='pinctrl file to check against iomuxc file')
-parser.add_argument('--check', action='store_true',
-                    help='do not edit pinctrl file, just check for errors')
-
-args = parser.parse_args()
-
-try:
-    iomux_file = open(args.iomuxc_file, 'r', encoding='utf8')
-except IOError:
-    print(f"Could not open {args.iomuxc_file}")
-try:
-    pinctrl_file = open(args.pinctrl_file, 'r+', encoding='utf8')
-except IOError:
-    print(f"Could not open {args.pinctrl_file}")
 
 iomuxc_re = re.compile(r'#define (IOMUXC_[\w_]+)\s+([0x]*[\dA-F]+)[U]*, ([0x]*[\dA-F]+)[U]*,'
     r' ([0x]*[\dA-F]+)[U]*, ([0x]*[\dA-F]+)[U]*, ([0x]*[\dA-F]+)[U]*\n')
@@ -42,85 +20,116 @@ pinctrl_line1_re = re.compile(r'\t/omit-if-no-ref/ [\w_]+: ([\w_]+) {\n')
 pinctrl_line2_re = re.compile(r'\t\tpinmux = <(0x[\da-f]+) '
     r'(\d+) (0x[\da-f]+) (\d+) (0x[\da-f]+)>;')
 
-ground_truth = {}
-while True:
-    line = iomux_file.readline()
-    if line == '':
-        break
-    match = iomuxc_re.match(line)
-    if match:
-        mux_reg = int(match.group(2), 0)
-        mux = int(match.group(3), 0)
-        daisy_reg = int(match.group(4), 0)
-        daisy = int(match.group(5), 0)
-        cfg_reg = int(match.group(6), 0)
-        if (mux_reg, mux, cfg_reg) in ground_truth:
-            raise RuntimeError("Duplicate mux_reg and mux value pairings")
-        ground_truth[(mux_reg, mux)] = (match.group(1), daisy_reg, daisy, cfg_reg)
 
-if not args.check:
-    tmp = tempfile.TemporaryFile(mode='r+')
-while True:
-    line = pinctrl_file.readline()
-    if line == '':
-        break
-    if not args.check:
-        if line == '&iomuxc {\n':
-            # Write a comment before dts defintions
-            tmp.write('/*\n'
-                f' * NOTE: file fixup performed by {os.path.basename(__file__)}\n'
-                " * to correct missing daisy register values\n"
-                ' */\n\n')
-        # Write back untouched line
-        tmp.write(line)
-    match = pinctrl_line1_re.match(line)
-    if match:
-        line = pinctrl_file.readline()
-        match2 = pinctrl_line2_re.match(line)
-        if match2:
-            mux_reg = int(match2.group(1), 0)
-            mux = int(match2.group(2), 0)
-            daisy_reg = int(match2.group(3), 0)
-            daisy = int(match2.group(4), 0)
-            cfg_reg = int(match2.group(5), 0)
-            name = match.group(1)
-            errors = False
-            if (mux_reg, mux) in ground_truth:
-                mux_truth = ground_truth[(mux_reg, mux)]
-                # Get the MUX daisy values
-                if mux_truth[1] != daisy_reg:
-                    print(f"Bad daisy reg on {name}")
-                    errors = True
-                if mux_truth[2] != daisy:
-                    print(f"Bad daisy value on {name}")
-                    errors = True
-                if mux_truth[3] != cfg_reg:
-                    print(f"Bad cfg value on {name}")
-                    errors = True
-                if (not args.check) and (errors):
-                    # Fix up file
-                    new_line = (f"\t\tpinmux = <0x{mux_reg:x} {mux} "
-                        f"0x{mux_truth[1]:x} {mux_truth[2]} 0x{mux_truth[3]:x}>;\n")
-                    tmp.write(new_line)
-                elif not args.check:
-                    # Write back untouched line
-                    tmp.write(line)
-            else:
-                print("WARNING: Mux name %s not preset in ground truth" % (name))
-                if not args.check:
-                    # Write back untouched line
-                    tmp.write(line)
-if not args.check:
-    # Commit operation by writing temp file to real file
-    tmp.seek(0)
-    pinctrl_file.seek(0)
-    while True:
-        tmpline = tmp.readline()
-        if tmpline == '':
-            break
-        pinctrl_file.write(tmpline)
+def parse_iomuxc_ground_truth(iomuxc_path):
+    """
+    Parse an fsl_iomuxc.h file and build a ground truth mapping.
+    @param iomuxc_path: path to fsl_iomuxc.h file
+    @return dict mapping (mux_reg, mux) to (name, daisy_reg, daisy, cfg_reg)
+    """
+    ground_truth = {}
+    with open(iomuxc_path, 'r', encoding='utf8') as iomux_file:
+        while True:
+            line = iomux_file.readline()
+            if line == '':
+                break
+            match = iomuxc_re.match(line)
+            if match:
+                mux_reg = int(match.group(2), 0)
+                mux = int(match.group(3), 0)
+                daisy_reg = int(match.group(4), 0)
+                daisy = int(match.group(5), 0)
+                cfg_reg = int(match.group(6), 0)
+                if (mux_reg, mux, cfg_reg) in ground_truth:
+                    raise RuntimeError("Duplicate mux_reg and mux value pairings")
+                ground_truth[(mux_reg, mux)] = (match.group(1), daisy_reg, daisy, cfg_reg)
+    return ground_truth
 
-iomux_file.close()
-pinctrl_file.close()
-if not args.check:
-    tmp.close()
+
+def fixup_pinctrl_file(pinctrl_path, ground_truth, check=False):
+    """
+    Fix daisy register values in a generated pinctrl file using ground truth
+    from fsl_iomuxc.h.
+    @param pinctrl_path: path to the pinctrl dtsi file to fix
+    @param ground_truth: dict from parse_iomuxc_ground_truth()
+    @param check: if True, only report errors without modifying the file
+    @return number of errors found
+    """
+    error_count = 0
+    with open(pinctrl_path, 'r+', encoding='utf8') as pinctrl_file:
+        if not check:
+            tmp = tempfile.TemporaryFile(mode='r+')
+        while True:
+            line = pinctrl_file.readline()
+            if line == '':
+                break
+            if not check:
+                if line == '&iomuxc {\n':
+                    tmp.write('/*\n'
+                        f' * NOTE: file fixup performed by {os.path.basename(__file__)}\n'
+                        " * to correct missing daisy register values\n"
+                        ' */\n\n')
+                tmp.write(line)
+            match = pinctrl_line1_re.match(line)
+            if match:
+                line = pinctrl_file.readline()
+                match2 = pinctrl_line2_re.match(line)
+                if match2:
+                    mux_reg = int(match2.group(1), 0)
+                    mux = int(match2.group(2), 0)
+                    daisy_reg = int(match2.group(3), 0)
+                    daisy = int(match2.group(4), 0)
+                    cfg_reg = int(match2.group(5), 0)
+                    name = match.group(1)
+                    errors = False
+                    if (mux_reg, mux) in ground_truth:
+                        mux_truth = ground_truth[(mux_reg, mux)]
+                        if mux_truth[1] != daisy_reg:
+                            print(f"Bad daisy reg on {name}")
+                            errors = True
+                        if mux_truth[2] != daisy:
+                            print(f"Bad daisy value on {name}")
+                            errors = True
+                        if mux_truth[3] != cfg_reg:
+                            print(f"Bad cfg value on {name}")
+                            errors = True
+                        if errors:
+                            error_count += 1
+                        if (not check) and (errors):
+                            new_line = (f"\t\tpinmux = <0x{mux_reg:x} {mux} "
+                                f"0x{mux_truth[1]:x} {mux_truth[2]} 0x{mux_truth[3]:x}>;\n")
+                            tmp.write(new_line)
+                        elif not check:
+                            tmp.write(line)
+                    else:
+                        print("WARNING: Mux name %s not preset in ground truth" % (name))
+                        if not check:
+                            tmp.write(line)
+        if not check:
+            tmp.seek(0)
+            pinctrl_file.seek(0)
+            while True:
+                tmpline = tmp.readline()
+                if tmpline == '':
+                    break
+                pinctrl_file.write(tmpline)
+            tmp.close()
+    return error_count
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=HELPSTR,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('iomuxc_file', metavar = 'IOMUXC',
+                        type=str,
+                        help='iomuxc file to use as ground truth')
+    parser.add_argument('pinctrl_file', metavar = 'pinctrl',
+                        type=str,
+                        help='pinctrl file to check against iomuxc file')
+    parser.add_argument('--check', action='store_true',
+                        help='do not edit pinctrl file, just check for errors')
+
+    args = parser.parse_args()
+
+    ground_truth = parse_iomuxc_ground_truth(args.iomuxc_file)
+    fixup_pinctrl_file(args.pinctrl_file, ground_truth, check=args.check)

--- a/mcux/scripts/pinctrl/imx/imx_fixup_pinmux.py
+++ b/mcux/scripts/pinctrl/imx/imx_fixup_pinmux.py
@@ -6,7 +6,7 @@ import re
 import os
 
 HELPSTR = """
-Fix generated pinctrl defintions
+Fix generated pinctrl definitions
 Generated i.MX RT 4-digit (RT1xxx) pinctrl definitions may be incorrect,
 because the signal configuration XML file itself is not correct. Fix them
 using fsl_iomuxc definitions. Only applies to parts with the IOMUXC IP;

--- a/mcux/scripts/pinctrl/imx/imx_gen_gpio.py
+++ b/mcux/scripts/pinctrl/imx/imx_gen_gpio.py
@@ -20,8 +20,8 @@ within Zephyr. These definitions should be copied where appropriate.
 
 This tool is intended to be used with the configuration data downloaded
 from NXP's website. One way to extract this config data is to use the
-MCUXpresso configuration tool to download processor defintions, locate
-those defintions on the disk. Alternatively, individual processor config
+MCUXpresso configuration tool to download processor definitions, locate
+those definitions on the disk. Alternatively, individual processor config
 data packs can be downloaded from the MCUXpresso SDK builder tool. Either way,
 the path to the 'processors' directory must be provided as the 'cfg-tool-root'
 parameter.

--- a/mcux/scripts/pinctrl/kinetis/kinetis_cfg_utils.py
+++ b/mcux/scripts/pinctrl/kinetis/kinetis_cfg_utils.py
@@ -328,7 +328,7 @@ class PinGroup:
         # group pins based on shared configuration
         self._pin_groups = collections.defaultdict(lambda: [])
         for pin in pins:
-            # find signal defintion for this pin
+            # find signal definition for this pin
             signal_name = pin.attrib.get('pin_signal')
             signal = signal_map[signal_name]
             if not signal:
@@ -534,7 +534,7 @@ class NXPSdkUtil:
     def write_pinctrl_defs(self, outputfile):
         """
         Writes all pin mux options into pinctrl DTSI file. Board level pin groups
-        can include this pinctrl dtsi file to access pin control defintions.
+        can include this pinctrl dtsi file to access pin control definitions.
         @param outputfile: file to write output pinctrl defs to
         """
         # Create list of all pin mux options

--- a/mcux/scripts/pinctrl/lpc/lpc_cfg_utils.py
+++ b/mcux/scripts/pinctrl/lpc/lpc_cfg_utils.py
@@ -405,7 +405,7 @@ class PinGroup:
         # group pins based on shared configuration
         self._pin_groups = collections.defaultdict(lambda: [])
         for pin in pins:
-            # find signal defintion for this pin
+            # find signal definition for this pin
             signal_name = pin.attrib.get('pin_signal')
             if not signal_name in signal_map:
                 logging.warning('Signal name %s not present in mapping', signal_name)
@@ -668,7 +668,7 @@ class NXPSdkUtil:
         """
         Writes all pin mux options into pinctrl header file. Board level pin
         groups can include this pinctrl header file to access pin control
-        defintions.
+        definitions.
         @param outputfile: file to write output pinctrl defs to
         """
         file_header = ("/*\n"


### PR DESCRIPTION
- Integrate imx_fixup_pinmux into gen_soc_headers.py so RT 4-digit NPI updates cannot skip the daisy register fixup step. Require `--iomuxc-file` when IOMUX controller is used; the script errors out if missing rather than silently generating incorrect pinctrl files. Refactor imx_fixup_pinmux.py into reusable functions while preserving its CLI.
- Correct misspelling of "defintions" to "definitions" in docstrings, comments, help text, and generated file headers across the pinctrl generation scripts.

