### PR TITLE
mcux: mimx8ml8: clock: Add missing media display clock root definitions

### DIFF
--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML8/drivers/fsl_clock.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML8/drivers/fsl_clock.h
@@ -745,6 +745,11 @@ typedef enum _clock_root_control
 
     kCLOCK_RootPdm = (uintptr_t)CCM_BASE + offsetof(CCM_Type, ROOT[132].TARGET_ROOT), /*!< PDM Clock control name.*/
 
+    kCLOCK_RootMediaMipiPhy1Ref =
+        (uintptr_t)CCM_BASE + offsetof(CCM_Type, ROOT[123].TARGET_ROOT), /*!< MEDIA MIPI_PHY1 control name.*/
+    kCLOCK_RootMediaDisp1Pix =
+        (uintptr_t)CCM_BASE + offsetof(CCM_Type, ROOT[124].TARGET_ROOT), /*!< MEDIA DISP1 control name.*/
+
 } clock_root_control_t;
 
 /*! @brief ccm clock root used to get clock frequency. */


### PR DESCRIPTION
# Summary

Add two missing `clock_root_control_t` entries for MIMX8ML8 (i.MX8MP):

- `kCLOCK_RootMediaMipiPhy1Ref` — ROOT[123], MIPI DPHY PLL reference clock
- `kCLOCK_RootMediaDisp1Pix` — ROOT[124], LCDIF1 pixel clock

# Justification

These clock roots are listed in the i.MX8MP Reference Manual (IMX8MPRM) Table 5-1 "Clock Root Table" but are absent from the SDK enum. Any display pipeline using LCDIF1 + MIPI DSI on this SoC requires these roots. Currently, users must define them manually.

# Change

Two enum entries added after `kCLOCK_RootMediaApb`, using the same encoding pattern as all existing entries. No functional change to existing code.