### PR TITLE
hal_nxp: middleware: Fix BLE build failure on W23

### DIFF
--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-bluetooth-controller/src/snps/sdk_integration/ble_controller.c
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-bluetooth-controller/src/snps/sdk_integration/ble_controller.c
@@ -1,4 +1,4 @@
-/* Copyright 2021-2025 NXP
+/* Copyright 2021-2026 NXP
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -381,7 +381,7 @@ blec_result_t BLEController_Init(blecHostHciRecvCallback_t callback,
     const int ll_irq_prio = NVIC_GetPriority(BLE_LL_IRQn);
 
     /* Make sure LL interrupt has the highest priority (only check enabled interrupts). This is a prerequisite of the system. */
-    for (int irq = 0; irq <= WAKE_PAD_IRQn; irq++)
+    for (int irq = 0; irq <= CDOG_IRQn; irq++)
     {
         if(NVIC_GetEnableIRQ(irq) &&
                 irq != BLE_LL_IRQn &&


### PR DESCRIPTION
Failure introduced after hal_nxp update to sdk
26.06.00-pvw1. This a temporary patch to fix BLE
builds on W23, until connectivity modules are
updated to the latest SDK version