### PR TITLE
mcux: drivers: hashcrypt: fix BUILD_ASSERT

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/hashcrypt/fsl_hashcrypt.c
+++ b/mcux/mcux-sdk-ng/drivers/hashcrypt/fsl_hashcrypt.c
@@ -75,7 +75,7 @@ static hashcrypt_hash_ctx_t *s_ctx;
 
 /*!< macro for checking build time condition. It is used to assure the hashcrypt_sha_ctx_internal_t can fit into
  * hashcrypt_hash_ctx_t */
-#define BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
+#define HASHCRYPT_BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
 
 /*******************************************************************************
  * Code
@@ -955,7 +955,7 @@ status_t HASHCRYPT_SHA_Init(HASHCRYPT_Type *base, hashcrypt_hash_ctx_t *ctx, has
 
     hashcrypt_sha_ctx_internal_t *ctxInternal;
     /* compile time check for the correct structure size */
-    BUILD_ASSERT(sizeof(hashcrypt_hash_ctx_t) >= sizeof(hashcrypt_sha_ctx_internal_t), hashcrypt_hash_ctx_t_size);
+    HASHCRYPT_BUILD_ASSERT(sizeof(hashcrypt_hash_ctx_t) >= sizeof(hashcrypt_sha_ctx_internal_t), hashcrypt_hash_ctx_t_size);
 
     status = hashcrypt_sha_check_input_args(base, ctx, algo);
     if (status != kStatus_Success)


### PR DESCRIPTION
BUILD_ASSERT may have different implementation in different environment. Changing the name to more specific one in driver.