### PR TITLE
mcux: wifi_nxp: remain on channel enhancement

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
@@ -138,6 +138,12 @@ typedef struct wifi_uap_client_disassoc
     t_u8 sta_addr[MLAN_MAC_ADDR_LENGTH];
 } wifi_uap_client_disassoc_t;
 
+typedef struct wifi_remain_channel_info
+{
+    t_u8 cancel_channel;
+    t_u8 bss_type;
+} wifi_remain_channel_info;
+
 /**
  * Initialize Wi-Fi driver module.
  *

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
@@ -6461,6 +6461,7 @@ int wifi_send_mgmt_auth_request(const t_u8 channel,
 {
     mlan_private *pmpriv = (mlan_private *)mlan_adap->priv[0];
     int ret;
+    int status = -WM_FAIL;
 
     if ((pmpriv->auth_alg != WLAN_AUTH_SAE) && (pmpriv->auth_flag & HOST_MLME_AUTH_PENDING))
     {
@@ -6479,7 +6480,21 @@ int wifi_send_mgmt_auth_request(const t_u8 channel,
     {
         wifi_set_rx_mgmt_indication(MLAN_BSS_TYPE_STA, WIFI_MGMT_AUTH | WIFI_MGMT_DEAUTH | WIFI_MGMT_DIASSOC);
 
-        wifi_remain_on_channel(true, channel, 2400);
+        if (wifi_is_remain_on_channel() == MTRUE)
+        {
+            status = wifi_remain_on_channel(pmpriv->bss_type, false, 0, 0);
+            if (status != WM_SUCCESS)
+            {
+                wifi_w("%s: Failed to cancel remain on channel", __func__);
+            }
+        }
+
+        status = wifi_remain_on_channel(pmpriv->bss_type, true, channel, 2400);
+        if (status != WM_SUCCESS)
+        {
+            wifi_e("%s: Failed to set remain on channel", __func__);
+            return status;
+        }
     }
 
     pmpriv->curr_bss_params.host_mlme = 1;
@@ -6492,7 +6507,14 @@ int wifi_send_mgmt_auth_request(const t_u8 channel,
     if (ret != WM_SUCCESS)
     {
         wifi_set_rx_mgmt_indication(MLAN_BSS_TYPE_STA, 0);
-        wifi_remain_on_channel(false, 0, 0);
+        if (wifi_is_remain_on_channel() == MTRUE)
+        {
+            status = wifi_remain_on_channel(pmpriv->bss_type, false, 0, 0);
+            if (status != WM_SUCCESS)
+            {
+                wifi_w("%s: Failed to cancel remain on channel", __func__);
+            }
+        }
 
         pmpriv->curr_bss_params.host_mlme = 0;
         pmpriv->auth_flag                 = 0;

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
@@ -2944,7 +2944,14 @@ int wifi_nxp_send_assoc(nxp_wifi_assoc_info_t *assoc_info)
         priv->auth_flag = HOST_MLME_AUTH_DONE;
     }
 
-    wifi_remain_on_channel(false, 0, 0);
+    if (wifi_is_remain_on_channel() == MTRUE)
+    {
+        ret = wifi_remain_on_channel(priv->bss_type, false, 0, 0);
+        if (ret != WM_SUCCESS)
+        {
+             wifi_w("%s: Failed to cancel remain on channel", __func__);
+        }
+    }
 
     if (priv->auth_flag && !(priv->auth_flag & HOST_MLME_AUTH_DONE))
     {
@@ -5002,26 +5009,37 @@ int wifi_process_cmd_response(HostCmd_DS_COMMAND *resp)
 #if CONFIG_WPA_SUPP
             case HostCmd_CMD_802_11_REMAIN_ON_CHANNEL:
             {
-                const HostCmd_DS_REMAIN_ON_CHANNEL *remain_channel = &resp->params.remain_on_chan;
-#if !CONFIG_MEM_POOLS
-                t_u8 *cancel_channel = (t_u8 *)OSA_MemoryAllocate(sizeof(t_u8));
-#else
-                t_u8 *cancel_channel = (t_u8 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
-#endif
-                if (cancel_channel != NULL)
+                if (resp->result == HostCmd_RESULT_OK)
                 {
-                    *cancel_channel              = remain_channel->action == HostCmd_ACT_GEN_REMOVE ? MTRUE : MFALSE;
-                    mlan_adap->remain_on_channel = remain_channel->action == HostCmd_ACT_GEN_REMOVE ? MFALSE : MTRUE;
-                    if (wifi_event_completion(WIFI_EVENT_REMAIN_ON_CHANNEL, WIFI_EVENT_REASON_SUCCESS,
-                                              (void *)cancel_channel) != WM_SUCCESS)
-                    {
+                    const HostCmd_DS_REMAIN_ON_CHANNEL *remain_channel = &resp->params.remain_on_chan;
 #if !CONFIG_MEM_POOLS
-                        OSA_MemoryFree(cancel_channel);
+                    wifi_remain_channel_info *remain_channel_info =
+                            (wifi_remain_channel_info *)OSA_MemoryAllocate(sizeof(wifi_remain_channel_info));
 #else
-                        OSA_MemoryPoolFree(buf_32_MemoryPool, cancel_channel);
+                    wifi_remain_channel_info *remain_channel_info =
+                            (wifi_remain_channel_info *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
 #endif
-                        cancel_channel = NULL;
+                    if (remain_channel_info != NULL)
+                    {
+                        remain_channel_info->cancel_channel = remain_channel->action == HostCmd_ACT_GEN_REMOVE ? MTRUE : MFALSE;
+                        remain_channel_info->bss_type       = bss_type;
+                        mlan_adap->remain_on_channel        = remain_channel->action == HostCmd_ACT_GEN_REMOVE ? MFALSE : MTRUE;
+                        if (wifi_event_completion(WIFI_EVENT_REMAIN_ON_CHANNEL, WIFI_EVENT_REASON_SUCCESS,
+                                                  (void *)remain_channel_info) != WM_SUCCESS)
+                        {
+#if !CONFIG_MEM_POOLS
+                            OSA_MemoryFree(remain_channel_info);
+#else
+                            OSA_MemoryPoolFree(buf_32_MemoryPool, remain_channel_info);
+#endif
+                            remain_channel_info = NULL;
+                        }
                     }
+                    wm_wifi.cmd_resp_status = WM_SUCCESS;
+                }
+                else
+                {
+                    wm_wifi.cmd_resp_status = -WM_FAIL;
                 }
             }
             break;
@@ -7003,22 +7021,25 @@ int wifi_handle_fw_event(struct bus_message *msg)
             {
                 mlan_adap->remain_on_channel = MFALSE;
 #if !CONFIG_MEM_POOLS
-                t_u8 *cancel_channel = (t_u8 *)OSA_MemoryAllocate(sizeof(t_u8));
+                wifi_remain_channel_info *remain_channel_info =
+                    (wifi_remain_channel_info *)OSA_MemoryAllocate(sizeof(wifi_remain_channel_info));
 #else
-                t_u8 *cancel_channel = (t_u8 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
+                wifi_remain_channel_info *remain_channel_info =
+                    (wifi_remain_channel_info *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
 #endif
-                if (cancel_channel != NULL)
+                if (remain_channel_info != NULL)
                 {
-                    *cancel_channel = MTRUE;
+                    remain_channel_info->cancel_channel = MTRUE;
+                    remain_channel_info->bss_type       = pmpriv->bss_type;
                     if (wifi_event_completion(WIFI_EVENT_REMAIN_ON_CHANNEL, WIFI_EVENT_REASON_SUCCESS,
-                        (void *)cancel_channel) != WM_SUCCESS)
+                        (void *)remain_channel_info) != WM_SUCCESS)
                     {
 #if !CONFIG_MEM_POOLS
-                        OSA_MemoryFree(cancel_channel);
+                        OSA_MemoryFree(remain_channel_info);
 #else
-                        OSA_MemoryPoolFree(buf_32_MemoryPool, cancel_channel);
+                        OSA_MemoryPoolFree(buf_32_MemoryPool, remain_channel_info);
 #endif
-                        cancel_channel = NULL;
+                        remain_channel_info = NULL;
                     }
                 }
             }

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-internal.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-internal.h
@@ -453,7 +453,7 @@ int wifi_setup_he_cap(nxp_wifi_he_capabilities *he_cap, t_u8 band);
 int wifi_nxp_send_assoc(nxp_wifi_assoc_info_t *assoc_info);
 int wifi_nxp_init_ap(nxp_wifi_ap_info_t *params);
 int wifi_nxp_send_mlme(unsigned int bss_type, int channel, unsigned int wait_time, const t_u8 *data, size_t data_len);
-int wifi_remain_on_channel(const bool status, const uint8_t channel, const uint32_t duration);
+int wifi_remain_on_channel(const enum wlan_bss_type bss_type, const bool status, const uint8_t channel, const uint32_t duration);
 int wifi_nxp_beacon_config(nxp_wifi_ap_info_t *params);
 int wifi_set_uap_rts(int rts_threshold);
 int wifi_set_uap_frag(int frag_threshold);

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
@@ -3486,7 +3486,7 @@ int wifi_nxp_beacon_config(nxp_wifi_ap_info_t *params)
     if (wifi_is_remain_on_channel() && remain_priv)
     {
         wuap_d("Cancel Remain on Channel before Starting AP");
-        wifi_remain_on_channel(false, 0, 0);
+        wifi_remain_on_channel(priv->bss_type, false, 0, 0);
     }
 
     if (params->beacon_set)

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -4625,27 +4625,12 @@ size_t wifi_remove_he_ies(const t_u8 *data, size_t data_len)
 
 int wifi_nxp_send_mlme(unsigned int bss_type, int channel, unsigned int wait_time, const t_u8 *data, size_t data_len)
 {
-    mlan_private *pmpriv              = (mlan_private *)mlan_adap->priv[bss_type];
     wlan_mgmt_pkt *pmgmt_pkt_hdr      = MNULL;
     wlan_802_11_header *pieee_pkt_hdr = MNULL;
     t_u8 buf[1580];
 
     // dump_hex(data, data_len);
     memset(buf, 0x00, sizeof(buf));
-
-    if ((bss_type == BSS_TYPE_STA) && (pmpriv->media_connected == MFALSE))
-    {
-        if (wifi_is_remain_on_channel())
-        {
-            wifi_remain_on_channel(false, 0, 0);
-        }
-
-        if (wait_time == 0)
-        {
-            wait_time = 1000;
-        }
-        wifi_remain_on_channel(true, channel, wait_time);
-    }
 
     pmgmt_pkt_hdr = (wlan_mgmt_pkt *)&buf[0];
 
@@ -4678,7 +4663,7 @@ bool wifi_is_remain_on_channel(void)
     return (mlan_adap->remain_on_channel ? true : false);
 }
 
-int wifi_remain_on_channel(const bool status, const uint8_t channel, const uint32_t duration)
+int wifi_remain_on_channel(const enum wlan_bss_type bss_type, const bool status, const uint8_t channel, const uint32_t duration)
 {
     wifi_remain_on_channel_t roc;
 
@@ -4721,7 +4706,7 @@ int wifi_remain_on_channel(const bool status, const uint8_t channel, const uint3
     }
 #endif
 
-    return wifi_send_remain_on_channel_cmd(MLAN_BSS_TYPE_STA, &roc);
+    return wifi_send_remain_on_channel_cmd(bss_type, &roc);
 }
 
 #ifdef RW610

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -866,14 +866,14 @@ int wifi_nxp_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
         goto out;
     }
 
-    if (wifi_is_remain_on_channel())
+    if (wifi_if_ctx_rtos->remain_on_channel == true)
     {
-        status = wifi_remain_on_channel(false, 0, 0);
+        status = wifi_remain_on_channel(wifi_if_ctx_rtos->bss_type, false, 0, 0);
         if (status == WM_SUCCESS)
         {
             wifi_if_ctx_rtos->remain_on_channel = false;
         }
-           else
+        else
         {
             supp_e("%s: Cancel remain on channel failed", __func__);
         }
@@ -1653,6 +1653,11 @@ int wifi_nxp_wpa_supp_authenticate(void *if_priv, struct wpa_driver_auth_params 
         supp_d("%s:Authentication request sent successfully", __func__);
         ret = 0;
     }
+
+    if (wifi_if_ctx_rtos->remain_on_channel == true)
+    {
+        wifi_if_ctx_rtos->remain_on_channel_freq = params->freq;
+    }
 out:
     return ret;
 }
@@ -1760,6 +1765,7 @@ int wifi_nxp_wpa_supp_associate(void *if_priv, struct wpa_driver_associate_param
         supp_d("%s: Association request sent successfully", __func__);
         ret = 0;
     }
+    wifi_if_ctx_rtos->remain_on_channel = mlan_adap->remain_on_channel;
     OSA_MemoryFree((void *)assoc_params);
 
 out:
@@ -2341,7 +2347,7 @@ int wifi_nxp_wpa_supp_send_mlme(void *if_priv,
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
     const struct ieee80211_hdr *hdr;
     u16 fc, stype;
-    mlan_private *pmpriv;
+    unsigned int bss_type = 0;
 
     hdr   = (const struct ieee80211_hdr *)data;
     fc    = le_to_host16(hdr->frame_control);
@@ -2363,15 +2369,38 @@ int wifi_nxp_wpa_supp_send_mlme(void *if_priv,
 
     wifi_if_ctx_rtos->mgmt_tx_status = 0;
 
-    pmpriv = (mlan_private *)mlan_adap->priv[wifi_if_ctx_rtos->bss_type];
-
-    if (stype == WLAN_FC_STYPE_PROBE_RESP && GET_BSS_ROLE(pmpriv) == MLAN_BSS_ROLE_UAP)
+    bss_type = wifi_if_ctx_rtos->bss_type;
+    if (stype == WLAN_FC_STYPE_PROBE_RESP && bss_type == MLAN_BSS_ROLE_UAP)
     {
         /* Since we support offload probe resp, we need to skip probe
          * resp in uAP or GO mode */
         supp_d("%s: Skip send probe_resp in GO/UAP mode", __func__);
         status = WM_SUCCESS;
         goto out;
+    }
+
+    if (stype == WLAN_FC_STYPE_ACTION && bss_type != BSS_TYPE_UAP)
+    {
+        if (wifi_if_ctx_rtos->remain_on_channel == true)
+        {
+            status = wifi_remain_on_channel(bss_type, false, 0, 0);
+            if (status != WM_SUCCESS)
+            {
+                supp_e("%s: Failed to cancel remain on channel", __func__);
+            }
+            wifi_if_ctx_rtos->remain_on_channel = false;
+        }
+        if (wait_time == 0)
+        {
+            wait_time = 1000;
+        }
+        status = wifi_remain_on_channel(bss_type, true, freq_to_chan(freq), wait_time);
+        if (status == WM_SUCCESS)
+        {
+            wifi_if_ctx_rtos->remain_on_channel = true;
+            wifi_if_ctx_rtos->remain_on_channel_freq = freq;
+            wifi_if_ctx_rtos->remain_on_channel_duration = wait_time;
+        }
     }
 
     status = wifi_nxp_send_mlme(wifi_if_ctx_rtos->bss_type, freq_to_chan(freq), wait_time, data, data_len);
@@ -2719,52 +2748,55 @@ out:
 int wifi_nxp_wpa_supp_remain_on_channel(void *if_priv, unsigned int freq, unsigned int duration, u64 host_cookie)
 {
     int status                                 = -WM_FAIL;
-    int ret                                    = -1;
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
     int channel;
 
-    if (!if_priv)
+    if (!if_priv || !freq)
     {
         supp_e("%s: Invalid params", __func__);
         goto out;
     }
     wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)if_priv;
-    if (freq)
+    /* If previous remain on channel is in progress on different channel, cancel it first */
+    if (wifi_if_ctx_rtos->remain_on_channel &&
+        wifi_if_ctx_rtos->remain_on_channel_freq != freq)
     {
-        wifi_if_ctx_rtos->remain_on_channel_freq = freq;
+        status = wifi_remain_on_channel(wifi_if_ctx_rtos->bss_type, false, 0, 0);
+        if (status != WM_SUCCESS)
+        {
+            supp_e("%s: Cancel remain on channel failed", __func__);
+            goto out;
+        }
+        wifi_if_ctx_rtos->remain_on_channel_cookie = 0;
+        wifi_if_ctx_rtos->remain_on_channel = false;
     }
+
+    wifi_if_ctx_rtos->remain_on_channel_freq     = freq;
     wifi_if_ctx_rtos->remain_on_channel_duration = duration;
-
     channel = freq_to_chan(wifi_if_ctx_rtos->remain_on_channel_freq);
-
     wifi_if_ctx_rtos->remain_on_channel_cookie   = (u64)(OSA_Rand() | host_cookie);
-    if (wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn != NULL)
-    {
-        wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn(wifi_if_ctx_rtos);
-    }
 
-    status                                       = wifi_remain_on_channel(true, channel, duration);
+    status = wifi_remain_on_channel(wifi_if_ctx_rtos->bss_type, true, channel, duration);
 
     if (status != WM_SUCCESS)
     {
         supp_e("%s: Remain on channel cmd failed", __func__);
-        wifi_if_ctx_rtos->remain_on_channel = false;
-        ret = -1;
+        wifi_if_ctx_rtos->remain_on_channel_cookie   = 0;
+        wifi_if_ctx_rtos->remain_on_channel_freq     = 0;
+        wifi_if_ctx_rtos->remain_on_channel_duration = 0;
+        goto out;
     }
-    else
-    {
-        supp_d("%s:Remain on channel sent successfully", __func__);
-        wifi_if_ctx_rtos->remain_on_channel = true;
-        ret = 0;
-    }
+
+    supp_d("%s:Remain on channel sent successfully", __func__);
+    wifi_if_ctx_rtos->remain_on_channel = true;
+
 out:
-    return ret;
+    return status;
 }
 
 int wifi_nxp_wpa_supp_cancel_remain_on_channel(void *if_priv, u64 rpu_cookie)
 {
     int status                                 = -WM_FAIL;
-    int ret                                    = -1;
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
 
     if (!if_priv)
@@ -2776,25 +2808,26 @@ int wifi_nxp_wpa_supp_cancel_remain_on_channel(void *if_priv, u64 rpu_cookie)
     if (wifi_if_ctx_rtos->remain_on_channel == false)
     {
         supp_d("%s:Already canceled, ignore it", __func__);
-        ret = 0;
+        status = WM_SUCCESS;
         goto out;
     }
 
-    status                                       = wifi_remain_on_channel(false, 0, 0);
+    status = wifi_remain_on_channel(wifi_if_ctx_rtos->bss_type, false, 0, 0);
 
     if (status != WM_SUCCESS)
     {
         supp_e("%s: Cancel on channel cmd failed", __func__);
-        ret = -1;
     }
     else
     {
         supp_d("%s:Cancel on channel sent successfully", __func__);
-        wifi_if_ctx_rtos->remain_on_channel = false;
-        ret = 0;
+        wifi_if_ctx_rtos->remain_on_channel          = false;
+        wifi_if_ctx_rtos->remain_on_channel_freq     = 0;
+        wifi_if_ctx_rtos->remain_on_channel_duration = 0;
+        status = WM_SUCCESS;
     }
 out:
-    return ret;
+    return status;
 }
 
 void wifi_nxp_wpa_supp_event_proc_remain_on_channel(void *if_priv, int cancel_channel)
@@ -3818,6 +3851,7 @@ bool wifi_nxp_wpa_get_modes(void *if_priv)
 void wifi_nxp_wpa_supp_cancel_action_wait(void *if_priv)
 {
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
+    int ret = -1;
 
     if (!if_priv)
     {
@@ -3828,7 +3862,18 @@ void wifi_nxp_wpa_supp_cancel_action_wait(void *if_priv)
     wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)if_priv;
     if (wifi_if_ctx_rtos->bss_type == BSS_TYPE_STA)
     {
-        (void)wifi_remain_on_channel(false, 0, 0);
+        if (wifi_if_ctx_rtos->remain_on_channel == true)
+        {
+            ret = wifi_remain_on_channel(wifi_if_ctx_rtos->bss_type, false, 0, 0);
+            if (ret != WM_SUCCESS)
+            {
+                supp_e("%s: Cancel remain on channel failed", __func__);
+            }
+            else
+            {
+                wifi_if_ctx_rtos->remain_on_channel = false;
+            }
+        }
     }
 
 out:

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
@@ -109,6 +109,7 @@ void wifi_scan_done(struct wifi_message *msg)
 void wifi_process_remain_on_channel(struct wifi_message *msg)
 {
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)wm_wifi.if_priv;
+    wifi_remain_channel_info *remain_channel_info = (wifi_remain_channel_info *)msg->data;
 
     if (!wifi_if_ctx_rtos || !wm_wifi.supp_if_callbk_fns)
        return;
@@ -116,20 +117,35 @@ void wifi_process_remain_on_channel(struct wifi_message *msg)
     if ((msg->reason == WIFI_EVENT_REASON_SUCCESS) &&
         (wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn != NULL))
     {
-        if (*(t_u8 *)(msg->data) == true)
+        if (remain_channel_info->cancel_channel == true)
         {
-            wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 1);
+            wifi_if_ctx_rtos->remain_on_channel          = false;
+            wifi_if_ctx_rtos->remain_on_channel_freq     = 0;
+            wifi_if_ctx_rtos->remain_on_channel_duration = 0;
+            if (wifi_if_ctx_rtos->remain_on_channel_cookie != 0)
+            {
+                wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 1);
+                wifi_if_ctx_rtos->remain_on_channel_cookie = 0;
+            }
         }
         else
         {
-            wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 0);
+            wifi_if_ctx_rtos->remain_on_channel = true;
+            if (wifi_if_ctx_rtos->remain_on_channel_cookie != 0)
+            {
+                if (wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn != NULL)
+                {
+                    wm_wifi.supp_if_callbk_fns->cookie_rsp_callbk_fn(wifi_if_ctx_rtos);
+                }
+                wm_wifi.supp_if_callbk_fns->remain_on_channel_callbk_fn(wifi_if_ctx_rtos, 0);
+            }
         }
     }
-    if (msg->data)
-    {
-        OSA_MemoryFree(msg->data);
-        msg->data = NULL;
-    }
+#if !CONFIG_MEM_POOLS
+    OSA_MemoryFree(msg->data);
+#else
+    OSA_MemoryPoolFree(buf_32_MemoryPool, msg->data);
+#endif
 }
 
 void wifi_process_mgmt_tx_status(struct wifi_message *msg)


### PR DESCRIPTION
Remain on channel enhancement in wifi driver. Cancel previous on-going remain on channel before issuing new one. For the remain on channel initiated by wifi driver, do not set cookie so that the remain on channel expire event will not be uploaded to wpa_supplicant.