### PR TITLE
mcux-sdk-ng: Fix SCTIMER event creation for H timer

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/sctimer/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/drivers/sctimer/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_MCUX_COMPONENT_driver.sctimer)
-    mcux_component_version(2.5.3)
+    mcux_component_version(2.5.4)
 
     mcux_add_source(SOURCES fsl_sctimer.h fsl_sctimer.c)
 

--- a/mcux/mcux-sdk-ng/drivers/sctimer/doxygen/ChangeLog_sctimer.md
+++ b/mcux/mcux-sdk-ng/drivers/sctimer/doxygen/ChangeLog_sctimer.md
@@ -1,5 +1,11 @@
 # SCTIMER
 
+## [2.5.4]
+
+- Bug Fixes
+  - Fixed SCTIMER_CreateAndScheduleEvent setting EV[n].CTRL[HEVENT] no longer exclusively for
+    match-based events.
+
 ## [2.5.3]
 
 - Bug Fixes

--- a/mcux/mcux-sdk-ng/drivers/sctimer/fsl_sctimer.c
+++ b/mcux/mcux-sdk-ng/drivers/sctimer/fsl_sctimer.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2023, 2025 NXP
+ * Copyright 2016-2023, 2025-2026 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -498,6 +498,12 @@ status_t SCTIMER_CreateAndScheduleEvent(SCT_Type *base,
         return kStatus_InvalidArgument;
     }
 
+    if ((kSCTIMER_Counter_H == whichCounter) && (0U == (base->CONFIG & SCT_CONFIG_UNIFY_MASK)))
+    {
+        /* Use Counter_H bits if user wants to setup the High counter */
+        currentCtrlVal |= SCT_EV_CTRL_HEVENT(1U);
+    }
+
     if (s_currentEvent < (uint32_t)FSL_FEATURE_SCT_NUMBER_OF_EVENTS)
     {
         if (2U == combMode)
@@ -535,8 +541,6 @@ status_t SCTIMER_CreateAndScheduleEvent(SCT_Type *base,
                 if (s_currentMatchhigh < (uint32_t)FSL_FEATURE_SCT_NUMBER_OF_MATCH_CAPTURE)
                 {
                     currentCtrlVal |= SCT_EV_CTRL_MATCHSEL(s_currentMatchhigh);
-                    /* Use Counter_H bits if user wants to setup the High counter */
-                    currentCtrlVal |= SCT_EV_CTRL_HEVENT(1U);
                     temp                               = base->MATCH_ACCESS16BIT[s_currentMatchhigh].MATCHL;
                     base->MATCH[s_currentMatchhigh]    = temp | (matchValue << 16U);
                     temp                               = base->MATCHREL_ACCESS16BIT[s_currentMatchhigh].MATCHRELL;

--- a/mcux/mcux-sdk-ng/drivers/sctimer/fsl_sctimer.h
+++ b/mcux/mcux-sdk-ng/drivers/sctimer/fsl_sctimer.h
@@ -23,7 +23,7 @@
 
 /*! @name Driver version */
 /*! @{ */
-#define FSL_SCTIMER_DRIVER_VERSION (MAKE_VERSION(2, 5, 3)) /*!< Version */
+#define FSL_SCTIMER_DRIVER_VERSION (MAKE_VERSION(2, 5, 4)) /*!< Version */
 /*! @} */
 
 #ifndef SCT_EV_STATE_STATEMSKn


### PR DESCRIPTION
Fixed SCTIMER_CreateAndScheduleEvent setting EV[n].CTRL[HEVENT] no longer exclusively for match-based events.

Follow-up for closed PR #723 . This time it's based off a separate branch (not 'master' as before).
Includes all your previous suggestions. Feel free to modify if necessary.

