### PR TITLE
mcux: wifi_nxp: Add Wi-Fi SLIM feature support

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
@@ -31,7 +31,6 @@ extern "C" {
 #define CONFIG_UAP_AMPDU_RX       1
 #define CONFIG_WIFIDRIVER_PS_LOCK 1
 #define CONFIG_WNM_PS             0
-#define CONFIG_SCAN_CHANNEL_GAP   1
 #define CONFIG_COMBO_SCAN         1
 #define CONFIG_BG_SCAN            1
 #define CONFIG_HOST_MLME          1
@@ -40,6 +39,10 @@ extern "C" {
 
 #if CONFIG_NXP_WIFI_SHELL
 #define CONFIG_WIFI_SHELL 1
+#endif
+
+#if CONFIG_NXP_WIFI_SCAN_CHANNEL_GAP
+#define CONFIG_SCAN_CHANNEL_GAP   1
 #endif
 
 #if CONFIG_NXP_WIFI_MAX_AP_ENTRIES

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -6422,20 +6422,28 @@ static void wlcm_request_scan(struct wifi_message *msg, enum cm_sta_state *next)
         return;
     }
 
-    memcpy(ssid+ssid_off, wlan_scan_param->ssid[0], strlen(wlan_scan_param->ssid[0]));
+#if CONFIG_COMBO_SCAN
+    memcpy(ssid + ssid_off, wlan_scan_param->ssid[0], strlen(wlan_scan_param->ssid[0]));
     ssid_off += strlen(wlan_scan_param->ssid[0]);
     ssid[ssid_off] = '\0';
     ssid_off++;
     ssid_num++;
-#if CONFIG_COMBO_SCAN
+
     if (strlen(wlan_scan_param->ssid[1]))
     {
-        memcpy(ssid+ssid_off, wlan_scan_param->ssid[1], strlen(wlan_scan_param->ssid[1]));
+        memcpy(ssid + ssid_off, wlan_scan_param->ssid[1], strlen(wlan_scan_param->ssid[1]));
         ssid_off += strlen(wlan_scan_param->ssid[1]);
         ssid[ssid_off] = '\0';
         ssid_num++;
     }
+#else
+    memcpy(ssid + ssid_off, wlan_scan_param->ssid, strlen(wlan_scan_param->ssid));
+    ssid_off += strlen(wlan_scan_param->ssid);
+    ssid[ssid_off] = '\0';
+    ssid_off++;
+    ssid_num++;
 #endif
+
 #if CONFIG_SCAN_CHANNEL_GAP
     if (is_uap_started() || is_sta_connected())
         wlan_scan_param->scan_chan_gap = scan_channel_gap;
@@ -13080,19 +13088,26 @@ void wlan_rrm_request_scan(wlan_scan_params_v2_t *wlan_scan_param, wlan_rrm_scan
 {
     char ssid[(MLAN_MAX_SSID_LENGTH + 1) * MRVDRV_MAX_SSID_LIST_LENGTH]  = {0};
     uint8_t ssid_num = 0, ssid_off = 0;
-    memcpy(ssid+ssid_off, wlan_scan_param->ssid[0], strlen(wlan_scan_param->ssid[0]));
+#if CONFIG_COMBO_SCAN
+    memcpy(ssid + ssid_off, wlan_scan_param->ssid[0], strlen(wlan_scan_param->ssid[0]));
     ssid_off += strlen(wlan_scan_param->ssid[0]);
     ssid[ssid_off] = '\0';
     ssid_off++;
     ssid_num++;
-#if CONFIG_COMBO_SCAN
+
     if (strlen(wlan_scan_param->ssid[1]))
     {
-        memcpy(ssid+ssid_off, wlan_scan_param->ssid[1], strlen(wlan_scan_param->ssid[1]));
+        memcpy(ssid + ssid_off, wlan_scan_param->ssid[1], strlen(wlan_scan_param->ssid[1]));
         ssid_off += strlen(wlan_scan_param->ssid[1]);
         ssid[ssid_off] = '\0';
         ssid_num++;
     }
+#else
+    memcpy(ssid + ssid_off, wlan_scan_param->ssid, strlen(wlan_scan_param->ssid));
+    ssid_off += strlen(wlan_scan_param->ssid);
+    ssid[ssid_off] = '\0';
+    ssid_off++;
+    ssid_num++;
 #endif
 
     if (wlan_scan_param == NULL || scan_cb_param == NULL)


### PR DESCRIPTION
Guard CONFIG_SCAN_CHANNEL_GAP with Kconfig options CONFIG_NXP_WIFI_SCAN_CHANNEL_GAP.
 Add #else branch for non-COMBO_SCAN case in scan request functions.