### PR TITLE
mcux-sdk-ng: feat: add EZH IRQ and input mux

### DIFF
--- a/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/LPC55S69_cm33_core0_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/LPC55S69_cm33_core0_COMMON.h
@@ -114,7 +114,7 @@ typedef enum IRQn {
   USB0_NEEDCLK_IRQn            = 27,               /**< USB Activity Wake-up Interrupt */
   USB0_IRQn                    = 28,               /**< USB device */
   RTC_IRQn                     = 29,               /**< RTC alarm and wake-up interrupts */
-  Reserved46_IRQn              = 30,               /**< Reserved interrupt */
+  EZH_IRQn                     = 30,               /**< EZH interrupt */
   MAILBOX_IRQn                 = 31,               /**< WAKEUP,Mailbox interrupt (present on selected devices) */
   PIN_INT4_IRQn                = 32,               /**< Pin interrupt 4 or pattern match engine slice 4 int */
   PIN_INT5_IRQn                = 33,               /**< Pin interrupt 5 or pattern match engine slice 5 int */

--- a/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/LPC55S69_cm33_core1_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/LPC/LPC5500/LPC55S69/LPC55S69_cm33_core1_COMMON.h
@@ -114,7 +114,7 @@ typedef enum IRQn {
   USB0_NEEDCLK_IRQn            = 27,               /**< USB Activity Wake-up Interrupt */
   USB0_IRQn                    = 28,               /**< USB device */
   RTC_IRQn                     = 29,               /**< RTC alarm and wake-up interrupts */
-  Reserved46_IRQn              = 30,               /**< Reserved interrupt */
+  EZH_IRQn                     = 30,               /**< EZH interrupt */
   MAILBOX_IRQn                 = 31,               /**< WAKEUP,Mailbox interrupt (present on selected devices) */
   PIN_INT4_IRQn                = 32,               /**< Pin interrupt 4 or pattern match engine slice 4 int */
   PIN_INT5_IRQn                = 33,               /**< Pin interrupt 5 or pattern match engine slice 5 int */

--- a/mcux/mcux-sdk-ng/devices/LPC/LPC5500/periph/PERI_INPUTMUX.h
+++ b/mcux/mcux-sdk-ng/devices/LPC/LPC5500/periph/PERI_INPUTMUX.h
@@ -129,6 +129,7 @@
 #define INPUTMUX_TIMER0CAPTSEL_COUNT              4u
 #define INPUTMUX_TIMER1CAPTSEL_COUNT              4u
 #define INPUTMUX_TIMER2CAPTSEL_COUNT              4u
+#define INPUTMUX_EZH_COUNT                        8u
 #define INPUTMUX_PINTSEL_COUNT                    8u
 #define INPUTMUX_DMA0_ITRIG_INMUX_COUNT           23u
 #define INPUTMUX_DMA0_OTRIG_INMUX_COUNT           4u
@@ -147,7 +148,8 @@ typedef struct {
   __IO uint32_t TIMER1CAPTSEL[INPUTMUX_TIMER1CAPTSEL_COUNT]; /**< Capture select registers for TIMER1 inputs, array offset: 0x40, array step: 0x4 */
        uint8_t RESERVED_2[16];
   __IO uint32_t TIMER2CAPTSEL[INPUTMUX_TIMER2CAPTSEL_COUNT]; /**< Capture select registers for TIMER2 inputs, array offset: 0x60, array step: 0x4 */
-       uint8_t RESERVED_3[80];
+       uint8_t RESERVED_3[48];
+  __IO uint32_t EZH_SLICE_INMUX[INPUTMUX_EZH_COUNT];        /**< Input mux registers for EZH inputs, array offset: 0xA0, array step: 0x4 */
   __IO uint32_t PINTSEL[INPUTMUX_PINTSEL_COUNT];   /**< Pin interrupt select register, array offset: 0xC0, array step: 0x4 */
   __IO uint32_t DMA0_ITRIG_INMUX[INPUTMUX_DMA0_ITRIG_INMUX_COUNT]; /**< Trigger select register for DMA0 channel, array offset: 0xE0, array step: 0x4 */
        uint8_t RESERVED_4[36];


### PR DESCRIPTION
Add definition of IRQ and INPUTMUX registers for the EZH (SmartDMA) peripheral.

This is only to show what's needed. The affected registers are certainly not maintained manually, but rather generated by a script.