### PR TITLE
hal_nxp: fix MIPI_DSI_BASE for IMX8MP chip

### DIFF
--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML2/MIMX8ML2_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML2/MIMX8ML2_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML3/MIMX8ML3_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML3/MIMX8ML3_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML4/MIMX8ML4_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML4/MIMX8ML4_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML5/MIMX8ML5_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML5/MIMX8ML5_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML6/MIMX8ML6_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML6/MIMX8ML6_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */

--- a/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML8/MIMX8ML8_cm7_COMMON.h
+++ b/mcux/mcux-sdk-ng/devices/i.MX/i.MX8MP/MIMX8ML8/MIMX8ML8_cm7_COMMON.h
@@ -1021,7 +1021,7 @@ typedef enum IRQn {
 
 /* MIPI_DSI - Peripheral instance base addresses */
 /** Peripheral MIPI_DSI base address */
-#define MIPI_DSI_BASE                            (0x32E10000u)
+#define MIPI_DSI_BASE                            (0x32E60000u)
 /** Peripheral MIPI_DSI base pointer */
 #define MIPI_DSI                                 ((MIPI_DSI_Type *)MIPI_DSI_BASE)
 /** Array initializer of MIPI_DSI peripheral base addresses */


### PR DESCRIPTION
The MIPI_DSI_BASE address defined in the HAL does not match the address specified in the i.MX 8M Plus Applications Processor Reference Manual (IMX8MPRM). The address in the HAL (0x32E1_0000) actually corresponds to the i.MX 8M Nano (IMX8MNRM), suggesting the wrong device's memory map was used.

Fix the address definition on all chip variants to the right address (0x32E6_0000).

This problem have a closed and merged issues on the [nxp-mcuxpresso/mcuxsdk-manifests](https://github.com/nxp-mcuxpresso/mcuxsdk-manifests) available [here](https://github.com/nxp-mcuxpresso/mcuxsdk-manifests/issues/19). 