### PR TITLE
mcux: wifi_nxp: add IR OOB reset GPIO support for MCXN947

### DIFF
--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -109,6 +109,14 @@
 #define IR_OUTBAND_TRIGGER_GPIO_PIN   	(12U)
 #define IR_OUTBAND_TRIGGER_GPIO_NAME  	"GPIO5"
 
+#elif defined(CONFIG_SOC_PART_NUMBER_MCXN947VDF) // For FRDM-MCXN947
+#if defined(IW610)
+/* IR OUT-BAND TRIGGER GPIO */
+#define IR_OUTBAND_TRIGGER_GPIO         GPIO1
+#define IR_OUTBAND_TRIGGER_GPIO_PIN     (22U)
+#define IR_OUTBAND_TRIGGER_GPIO_NAME    "GPIO1"
+#endif
+
 #endif /* (defined(CONFIG_SOC_PART_NUMBER_MIMXRT1062DVL6A) */
 #endif
 
@@ -8407,7 +8415,11 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
 
 #if CONFIG_WIFI_IND_OOB_RESET
 #ifdef IR_OUTBAND_TRIGGER_GPIO
+#if defined(CONFIG_SOC_PART_NUMBER_MCXN947VDF)
+    gpio_pin_config_t out_config = {kGPIO_DigitalOutput, 1};
+#else
     gpio_pin_config_t out_config = {kGPIO_DigitalOutput, 1, kGPIO_NoIntmode};
+#endif
 
 #if defined(IOMUXC_GPIO_IR_OUTBAND_TRIGGER)
     IOMUXC_SetPinMux(IOMUXC_GPIO_IR_OUTBAND_TRIGGER, /* GPIO_AD_B0_10 is configured as GPIO1_IO10 */


### PR DESCRIPTION
Add IR_OUTBAND_TRIGGER_GPIO definitions for MCXN947 (GPIO1, pin 22) when IW610 is used, following the same pattern as RT1060 and RT1170.

Also handle the gpio_pin_config_t initialization difference on MCXN947, which uses Kinetis-style GPIO (fsl_gpio) with a 2-field struct that does not include an interrupt mode field.