### PR TITLE
hal_nxp: fsl_sai: Remove stray #endif

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/esai/fsl_esai.c
+++ b/mcux/mcux-sdk-ng/drivers/esai/fsl_esai.c
@@ -1239,7 +1239,6 @@ void ESAI_CommonDriverIRQHandler(uint32_t instance)
     }
     SDK_ISR_EXIT_BARRIER;
 }
-#endif
 
 #ifdef AUDIO__ESAI0
 #define ESAI AUDIO__ESAI0


### PR DESCRIPTION
This causes compilation errors for samples using FSL SAI HAL implementation.

Fixes 275a59534315d ("mcux: sdk-ng: update drivers to 26.06.00 pvw2")