### PR TITLE
device: RW: power: fix GDET disableCount corruption on PM3 entry failure

### DIFF
--- a/mcux/mcux-sdk-ng/devices/Wireless/RW/RW610/drivers/fsl_power.c
+++ b/mcux/mcux-sdk-ng/devices/Wireless/RW/RW610/drivers/fsl_power.c
@@ -882,13 +882,6 @@ AT_QUICKACCESS_SECTION_CODE(static bool POWER_PostPowerMode(uint32_t mode))
         s_gdetSensorContext.disableCount--;
     }
 
-    if ((mode == 3U) && (PMU->PWR_MODE_STATUS != 2U))
-    {
-        /* Failed resumed from PM3, GDET is not enabled by ROM. */
-        assert(s_gdetSensorContext.disableCount > 0);
-        s_gdetSensorContext.disableCount = 0;
-    }
-
     SysTick->CTRL = s_systickContext.CTRL;
     SysTick->LOAD = s_systickContext.LOAD;
 

--- a/mcux/mcux-sdk-ng/devices/Wireless/RW/RW612/drivers/fsl_power.c
+++ b/mcux/mcux-sdk-ng/devices/Wireless/RW/RW612/drivers/fsl_power.c
@@ -882,13 +882,6 @@ AT_QUICKACCESS_SECTION_CODE(static bool POWER_PostPowerMode(uint32_t mode))
         s_gdetSensorContext.disableCount--;
     }
 
-    if ((mode == 3U) && (PMU->PWR_MODE_STATUS != 2U))
-    {
-        /* Failed resumed from PM3, GDET is not enabled by ROM. */
-        assert(s_gdetSensorContext.disableCount > 0);
-        s_gdetSensorContext.disableCount = 0;
-    }
-
     SysTick->CTRL = s_systickContext.CTRL;
     SysTick->LOAD = s_systickContext.LOAD;
 


### PR DESCRIPTION
When PM3 entry fails (PMU->PWR_MODE_STATUS != 2), PostPowerMode() resets s_gdetSensorContext.disableCount to 0, since ROM never ran, GDET is still disabled from PrePowerMode().

This causes disableCount to underflow (0xFFFFFFFF) if POWER_EnableGDetVSensors() is called later (e.g., during Wi-Fi FW download), and subsequent POWER_DisableGDetVSensors() restores it to 0. The next PM2/PM3 entry then hits the assert in POWER_PrePowerMode() because disableCount == 0.