### PR TITLE
wifi_nxp: support raw scan result IEs

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
@@ -548,6 +548,22 @@ int wifi_unregister_event_queue(osa_msgq_handle_t event_queue);
 int wifi_get_scan_result(unsigned int index, struct wifi_scan_result2 **desc);
 
 /**
+ * Get a reconstructed raw 802.11 beacon frame for a scan result entry.
+ * The frame includes MAC header (24B) + fixed fields (12B) + IEs.
+ *
+ * @param[in] index      Index into scan table
+ * @param[out] buf       Buffer to write frame into
+ * @param[in] buf_len    Size of buffer
+ * @param[out] frame_len Actual total frame length (may exceed buf_len)
+ * @param[out] freq      Frequency in MHz
+ * @param[out] rssi      RSSI in dBm (negative value)
+ *
+ * @return WM_SUCCESS on success or error code.
+ */
+int wifi_get_scan_raw_frame(unsigned int index, uint8_t *buf, size_t buf_len,
+                            size_t *frame_len, uint32_t *freq, int8_t *rssi);
+
+/**
  * Get the count of elements in the scan list
  *
  * @param[in,out] count Pointer to a variable which will hold the count after

--- a/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
+++ b/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
@@ -3187,6 +3187,22 @@ int wlan_scan_with_opt(wlan_scan_params_v2_t t_wlan_scan_param);
  */
 int wlan_get_scan_result(unsigned int index, struct wlan_scan_result *res);
 
+/**
+ * Get a reconstructed raw 802.11 beacon frame for a scan result entry.
+ * The frame includes MAC header (24B) + fixed fields (12B) + IEs.
+ *
+ * @param[in] index      Index into scan table
+ * @param[out] buf       Buffer to write frame into
+ * @param[in] buf_len    Size of buffer
+ * @param[out] frame_len Actual total frame length (may exceed buf_len)
+ * @param[out] freq      Frequency in MHz
+ * @param[out] rssi      RSSI in dBm (negative value)
+ *
+ * @return WM_SUCCESS on success or error code.
+ */
+int wlan_get_scan_raw_frame(unsigned int index, uint8_t *buf, size_t buf_len,
+                            size_t *frame_len, uint32_t *freq, int8_t *rssi);
+
 #ifdef WLAN_LOW_POWER_ENABLE
 /**
  * Enable low power mode in Wi-Fi Firmware.
@@ -7257,6 +7273,14 @@ int wlan_stop_cloud_keep_alive(wlan_cloud_keep_alive_t *cloud_keep_alive);
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
  */
 int wlan_set_country_code(const char *alpha2);
+
+/** Get current country code.
+ *
+ * \param[out] alpha2  Buffer to store the 2-character country code.
+ *
+ * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
+ */
+int wlan_get_country_code(char *alpha2);
 
 /** Set ignore region code.
  *

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ieee.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ieee.h
@@ -2540,12 +2540,10 @@ typedef struct _BSSDescriptor_t
     /** Max allocated size for updated scan response */
     t_u32 beacon_buf_size_max;
 
-#if CONFIG_WPA_SUPP
-    /** Pointer to the returned scan response */
+    /** IEs */
     t_u8 *ies;
-    /** Length of the stored scan response */
+    /** IEs length */
     t_u32 ies_len;
-#endif
 
     /* Added for WMSDK */
 

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
@@ -5115,24 +5115,24 @@ int wifi_get_bgscan_results(mlan_private *pmpriv)
 {
     mlan_adapter *pmadapter = pmpriv->adapter;
     int ret                 = 0;
-#if CONFIG_WPA_SUPP
     BSSDescriptor_t *bss_entry = NULL;
     int i;
-#endif
 
     ENTER();
 
 #if CONFIG_WPA_SUPP
     pmadapter->wpa_supp_scan_triggered = MTRUE;
+#endif
+
     for (i = 0; i < pmadapter->num_in_scan_table; i++)
     {
         bss_entry = &pmadapter->pscan_table[i];
         if (bss_entry && bss_entry->ies != NULL)
         {
             OSA_MemoryFree(bss_entry->ies);
+            bss_entry->ies = NULL;
         }
     }
-#endif
 
     memset(pmadapter->pscan_table, 0x00, sizeof(BSSDescriptor_t) * MRVDRV_MAX_BSSID_LIST);
     pmadapter->num_in_scan_table = 0;

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
@@ -86,7 +86,6 @@ mlan_status wlan_allocate_adapter(pmlan_adapter pmadapter)
 
 void wlan_clear_scan_bss(void)
 {
-#if CONFIG_WPA_SUPP
     BSSDescriptor_t *bss_entry = NULL;
     int i;
 
@@ -96,9 +95,9 @@ void wlan_clear_scan_bss(void)
         if (bss_entry && bss_entry->ies != NULL)
         {
             OSA_MemoryFree(bss_entry->ies);
+            bss_entry->ies = NULL;
         }
     }
-#endif
     (void)__memset(MNULL, &BSS_List, 0x00, sizeof(BSS_List));
 }
 

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
@@ -963,25 +963,22 @@ static mlan_status wlan_scan_channel_list(IN mlan_private *pmpriv,
 
         if (wlan_get_abort_split_scan())
         {
-#if CONFIG_WPA_SUPP
             BSSDescriptor_t *bss_entry = NULL;
             int i;
-#endif
             wlan_set_abort_split_scan(false);
             wlan_set_split_scan_status(false);
-#if CONFIG_WPA_SUPP
             for (i = 0; i < pmadapter->num_in_scan_table; i++)
             {
                 bss_entry = &pmadapter->pscan_table[i];
                 if (bss_entry && bss_entry->ies != NULL)
                 {
                     OSA_MemoryFree(bss_entry->ies);
+                    bss_entry->ies = NULL;
                 }
             }
 
             pmadapter->num_in_scan_table = 0;
             ret                          = MLAN_STATUS_FAILURE;
-#endif
             break;
         }
     }
@@ -1649,12 +1646,14 @@ static mlan_status wlan_interpret_bss_desc_with_ie(IN pmlan_adapter pmadapter,
 
     HEXDUMP("InterpretIE: IE info", (t_u8 *)pcurrent_ptr, bytes_left_for_current_beacon);
 
-#if CONFIG_WPA_SUPP
-    /* Store IE pointer and len for wpa supplicant scan result, no need to process each IE below*/
+#if CONFIG_WPA_SUPP || CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+#if CONFIG_WPA_SUPP && !CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
     if (pmadapter->wpa_supp_scan_triggered == MTRUE)
+#endif
     {
+        /* Store raw IEs for scan result consumers (wpa_supplicant, raw scan results, etc.) */
         wifi_d("Alloc ies for BSS");
-        pbss_entry->ies = (u8 *)OSA_MemoryAllocate(bytes_left_for_current_beacon);
+        pbss_entry->ies = (t_u8 *)OSA_MemoryAllocate(bytes_left_for_current_beacon);
         if (pbss_entry->ies == MNULL)
         {
             wifi_d("Failed to alloc memory for BSS ies");
@@ -2715,7 +2714,6 @@ mlan_status wlan_scan_networks(IN mlan_private *pmpriv,
 
     if (keep_previous_scan == MFALSE)
     {
-#if CONFIG_WPA_SUPP
         BSSDescriptor_t *bss_entry = NULL;
         int i;
 
@@ -2725,9 +2723,9 @@ mlan_status wlan_scan_networks(IN mlan_private *pmpriv,
             if (bss_entry && bss_entry->ies != NULL)
             {
                 OSA_MemoryFree(bss_entry->ies);
+                bss_entry->ies = NULL;
             }
         }
-#endif
         (void)__memset(pmadapter, pmadapter->pscan_table, 0x00, sizeof(BSSDescriptor_t) * MRVDRV_MAX_BSSID_LIST);
         pmadapter->num_in_scan_table = 0;
     }
@@ -2883,12 +2881,10 @@ static void adjust_pointers_to_internal_buffers(BSSDescriptor_t *pbss_entry, BSS
         pbss_entry->prsnxo_ie = &pbss_entry->rsnxo_ie_saved;
     }
 #endif
-#if CONFIG_WPA_SUPP
     if (pbss_new_entry->ies != NULL)
     {
         pbss_entry->ies = pbss_new_entry->ies;
     }
-#endif
 }
 
 #if !(CONFIG_EXT_SCAN_SUPPORT) || (CONFIG_BG_SCAN)
@@ -3100,7 +3096,6 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                     bss_new_entry->mac_address[1], bss_new_entry->mac_address[2], bss_new_entry->mac_address[3],
                     bss_new_entry->mac_address[4], bss_new_entry->mac_address[5]);
 
-#if CONFIG_WPA_SUPP
 #if CONFIG_WPA_SUPP_WPS
             if (pmpriv->wps.session_enable == MTRUE)
             {
@@ -3115,7 +3110,6 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                 }
             }
 #endif /* CONFIG_WPA_SUPP_WPS */
-#endif
 
             /*
              * Search the scan table for the same bssid
@@ -3174,13 +3168,11 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                     (bss_new_entry->rssi > pmadapter->pscan_table[bss_idx].rssi))
                 {
                     wscan_d("skip update the duplicate entry with low rssi");
-#if CONFIG_WPA_SUPP
                     if (bss_new_entry->ies != NULL)
                     {
                         OSA_MemoryFree(bss_new_entry->ies);
                         bss_new_entry->ies = NULL;
                     }
-#endif
                     continue;
                 }
             }
@@ -3241,7 +3233,6 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                                        sizeof(pmadapter->pscan_table[0]));
                         adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[0], bss_new_entry);
                     }
-#if CONFIG_WPA_SUPP
                     /* If the scan table is full, free ies of the new entry with lowest rssi, which won't be added into
                      * table */
                     else
@@ -3252,7 +3243,6 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                             bss_new_entry->ies = NULL;
                         }
                     }
-#endif
                     num_in_table--;
                     continue;
                 }
@@ -3275,7 +3265,6 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                                    sizeof(pmadapter->pscan_table[lowest_rssi_index]));
                     adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[lowest_rssi_index], bss_new_entry);
                 }
-#if CONFIG_WPA_SUPP
                 /* If the scan table is full, free ies of the new entry with lowest rssi, which won't be added into
                  * table */
                 else
@@ -3286,18 +3275,15 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
                         bss_new_entry->ies = NULL;
                     }
                 }
-#endif
             }
             else
             {
-#if CONFIG_WPA_SUPP
                 /* Free ies of the old entry if it's duplicate entry */
                 if (pmadapter->pscan_table[bss_idx].ies != NULL)
                 {
                     OSA_MemoryFree(pmadapter->pscan_table[bss_idx].ies);
                     pmadapter->pscan_table[bss_idx].ies = NULL;
                 }
-#endif
 
                 /* Copy the locally created bss_new_entry to the scan table */
                 (void)__memcpy(pmadapter, &pmadapter->pscan_table[bss_idx], bss_new_entry,
@@ -3309,13 +3295,11 @@ mlan_status wlan_ret_802_11_scan(IN mlan_private *pmpriv, IN HostCmd_DS_COMMAND 
         {
             /* Error parsing/interpreting the scan response, skipped */
             PRINTM(MERROR, "SCAN_RESP: wlan_interpret_bss_desc_with_ie returned error\n");
-#if CONFIG_WPA_SUPP
             if (bss_new_entry->ies != NULL)
             {
                 OSA_MemoryFree(bss_new_entry->ies);
                 bss_new_entry->ies = NULL;
             }
-#endif
         }
         idx++;
     }
@@ -3865,11 +3849,13 @@ static t_void wlan_parse_non_trans_bssid_profile(mlan_private *pmpriv,
         (void)__memcpy(pmadapter, &bss_new_entry->cap_info, &pcap->cap,
                        MIN(sizeof(IEEEtypes_CapInfo_t), sizeof(IEEEtypes_CapInfo_t)));
         bss_new_entry->multi_bssid_ap = MULTI_BSSID_SUB_AP;
-#if CONFIG_WPA_SUPP
+#if CONFIG_WPA_SUPP || CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+#if CONFIG_WPA_SUPP && !CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
         if (pmadapter->wpa_supp_scan_triggered == MTRUE)
+#endif
         {
             wifi_d("Alloc ies for Multi BSS. ies_len=%d", bss_new_entry->beacon_buf_size);
-            bss_new_entry->ies = (u8 *)OSA_MemoryAllocate(bss_new_entry->beacon_buf_size - BEACON_FIX_SIZE);
+            bss_new_entry->ies = (t_u8 *)OSA_MemoryAllocate(bss_new_entry->beacon_buf_size - BEACON_FIX_SIZE);
             if (bss_new_entry->ies == MNULL)
             {
                 wifi_d("Failed to alloc memory for Multi BSS ies");
@@ -3877,7 +3863,7 @@ static t_void wlan_parse_non_trans_bssid_profile(mlan_private *pmpriv,
             }
             (void)__memcpy(pmadapter, bss_new_entry->ies, bss_new_entry->pbeacon_buf + BEACON_FIX_SIZE,
                            bss_new_entry->beacon_buf_size - BEACON_FIX_SIZE);
-            bss_new_entry->ies_len = bss_new_entry->beacon_buf_size;
+            bss_new_entry->ies_len = bss_new_entry->beacon_buf_size - BEACON_FIX_SIZE;
         }
 #endif
         /*add to scan table*/
@@ -3931,7 +3917,6 @@ static t_void wlan_parse_non_trans_bssid_profile(mlan_private *pmpriv,
                                sizeof(pmadapter->pscan_table[lowest_rssi_index]));
                 adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[lowest_rssi_index], bss_new_entry);
             }
-#if CONFIG_WPA_SUPP
             /* If the scan table is full, free ies of the new entry with lowest rssi, which won't be added into table */
             else
             {
@@ -3941,18 +3926,15 @@ static t_void wlan_parse_non_trans_bssid_profile(mlan_private *pmpriv,
                     bss_new_entry->ies = NULL;
                 }
             }
-#endif
         }
         else
         {
             /* Copy the locally created bss_new_entry to the scan table */
-#if CONFIG_WPA_SUPP
             if (pmadapter->pscan_table[bss_idx].ies != NULL)
             {
                 OSA_MemoryFree(pmadapter->pscan_table[bss_idx].ies);
                 pmadapter->pscan_table[bss_idx].ies = NULL;
             }
-#endif
             (void)__memcpy(pmadapter, &pmadapter->pscan_table[bss_idx], bss_new_entry,
                            sizeof(pmadapter->pscan_table[bss_idx]));
             adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[bss_idx], bss_new_entry);
@@ -4225,7 +4207,6 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
                    bss_new_entry->mac_address[1], bss_new_entry->mac_address[2], bss_new_entry->mac_address[3],
                    bss_new_entry->mac_address[4], bss_new_entry->mac_address[5]);
 
-#if CONFIG_WPA_SUPP
 #if CONFIG_WPA_SUPP_WPS
             if (pmpriv->wps.session_enable == MTRUE)
             {
@@ -4240,7 +4221,6 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
                 }
             }
 #endif /* CONFIG_WPA_SUPP_WPS */
-#endif
 
             band = BAND_G;
             /*
@@ -4295,13 +4275,11 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
 
                 if (idx2 == NELEMENTS(pmpriv->filter_ssid))
                 {
-#if CONFIG_WPA_SUPP
                     if (bss_new_entry->ies != NULL)
                     {
                         OSA_MemoryFree(bss_new_entry->ies);
                         bss_new_entry->ies = NULL;
                     }
-#endif
                     continue;
                 }
             }
@@ -4363,13 +4341,11 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
                     (bss_new_entry->rssi > pmadapter->pscan_table[bss_idx].rssi))
                 {
                     PRINTM(MCMND, "skip update the duplicate entry with low rssi\n");
-#if CONFIG_WPA_SUPP
                     if (bss_new_entry->ies != NULL)
                     {
                         OSA_MemoryFree(bss_new_entry->ies);
                         bss_new_entry->ies = NULL;
                     }
-#endif
                     continue;
                 }
             }
@@ -4378,18 +4354,15 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
             {
                 if (pmadapter->pscan_table[lowest_rssi_index].rssi > bss_new_entry->rssi)
                 {
-#if CONFIG_WPA_SUPP
                     if (pmadapter->pscan_table[lowest_rssi_index].ies != NULL)
                     {
                         OSA_MemoryFree(pmadapter->pscan_table[lowest_rssi_index].ies);
                         pmadapter->pscan_table[lowest_rssi_index].ies = NULL;
                     }
-#endif
                     (void)__memcpy(pmadapter, &pmadapter->pscan_table[lowest_rssi_index], bss_new_entry,
                                    sizeof(pmadapter->pscan_table[lowest_rssi_index]));
                     adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[lowest_rssi_index], bss_new_entry);
                 }
-#if CONFIG_WPA_SUPP
                 /* If the scan table is full, free ies of the new entry with lowest rssi, which won't be added into
                  * table */
                 else
@@ -4400,18 +4373,15 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
                         bss_new_entry->ies = NULL;
                     }
                 }
-#endif
             }
             else
             {
                 /* Copy the locally created bss_new_entry to the scan table */
-#if CONFIG_WPA_SUPP
                 if (pmadapter->pscan_table[bss_idx].ies != NULL)
                 {
                     OSA_MemoryFree(pmadapter->pscan_table[bss_idx].ies);
                     pmadapter->pscan_table[bss_idx].ies = NULL;
                 }
-#endif
                 (void)__memcpy(pmadapter, &pmadapter->pscan_table[bss_idx], bss_new_entry,
                                sizeof(pmadapter->pscan_table[bss_idx]));
                 adjust_pointers_to_internal_buffers(&pmadapter->pscan_table[bss_idx], bss_new_entry);
@@ -4421,13 +4391,11 @@ static mlan_status wlan_parse_ext_scan_result(IN mlan_private *pmpriv,
         {
             /* Error parsing/interpreting the scan response, skipped */
             PRINTM(MERROR, "EXT_SCAN: wlan_interpret_bss_desc_with_ie returned error\n");
-#if CONFIG_WPA_SUPP
             if (bss_new_entry->ies != NULL)
             {
                 OSA_MemoryFree(bss_new_entry->ies);
                 bss_new_entry->ies = NULL;
             }
-#endif
         }
     }
 

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -984,6 +984,84 @@ int wifi_get_scan_result(unsigned int index, struct wifi_scan_result2 **desc)
     return WM_SUCCESS;
 }
 
+/* 24B MAC header + 12B fixed fields */
+#define RAW_SCAN_FRAME_HDR_LEN 36
+
+int wifi_get_scan_raw_frame(unsigned int index, uint8_t *buf, size_t buf_len,
+                            size_t *frame_len, uint32_t *freq, int8_t *rssi)
+{
+#if CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+    BSSDescriptor_t *bss_entry;
+    uint8_t *pos;
+    size_t ies_len;
+    size_t total_len;
+    size_t copy_len;
+
+    if (buf == NULL || frame_len == NULL || freq == NULL || rssi == NULL)
+    {
+        return -WM_E_INVAL;
+    }
+
+    if (index >= mlan_adap->num_in_scan_table)
+    {
+        return -WM_FAIL;
+    }
+
+    bss_entry = &mlan_adap->pscan_table[index];
+
+    if (bss_entry->ies == NULL || bss_entry->ies_len == 0)
+    {
+        return -WM_FAIL;
+    }
+
+    ies_len = (size_t)bss_entry->ies_len;
+    total_len = RAW_SCAN_FRAME_HDR_LEN + ies_len;
+
+    *frame_len = total_len;
+    *freq = bss_entry->freq;
+    *rssi = -(int8_t)bss_entry->rssi;
+
+    copy_len = (total_len > buf_len) ? buf_len : total_len;
+
+    if (buf_len < RAW_SCAN_FRAME_HDR_LEN)
+    {
+        /* Buffer too small for frame header */
+        return -WM_FAIL;
+    }
+
+    pos = buf;
+
+    /* 802.11 MAC header (24 bytes) */
+    *pos++ = 0x80;
+    *pos++ = 0x00;
+    *pos++ = 0x00;
+    *pos++ = 0x00;
+    (void)memset(pos, 0xff, MLAN_MAC_ADDR_LENGTH);
+    pos += MLAN_MAC_ADDR_LENGTH;
+    (void)memcpy(pos, bss_entry->mac_address, MLAN_MAC_ADDR_LENGTH);
+    pos += MLAN_MAC_ADDR_LENGTH;
+    (void)memcpy(pos, bss_entry->mac_address, MLAN_MAC_ADDR_LENGTH);
+    pos += MLAN_MAC_ADDR_LENGTH;
+    *pos++ = 0x00;
+    *pos++ = 0x00;
+
+    /* Fixed fields (12 bytes) */
+    (void)memcpy(pos, bss_entry->time_stamp, 8);
+    pos += 8;
+    *pos++ = (uint8_t)(bss_entry->beacon_period & 0xff);
+    *pos++ = (uint8_t)((bss_entry->beacon_period >> 8) & 0xff);
+    (void)memcpy(pos, &bss_entry->cap_info, 2);
+    pos += 2;
+
+    /* IEs */
+    (void)memcpy(pos, bss_entry->ies, copy_len - RAW_SCAN_FRAME_HDR_LEN);
+
+    return WM_SUCCESS;
+#else
+    return -WM_FAIL;
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+}
+
 int wifi_register_event_queue(osa_msgq_handle_t event_queue)
 {
     if (event_queue == MNULL)

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -11041,6 +11041,12 @@ int wlan_get_scan_result(unsigned int index, struct wlan_scan_result *res)
     return WM_SUCCESS;
 }
 
+int wlan_get_scan_raw_frame(unsigned int index, uint8_t *buf, size_t buf_len,
+                            size_t *frame_len, uint32_t *freq, int8_t *rssi)
+{
+    return wifi_get_scan_raw_frame(index, buf, buf_len, frame_len, freq, rssi);
+}
+
 void wlan_set_cal_data(const uint8_t *cal_data, const unsigned int cal_data_size)
 {
     if (cal_data_size > 1)
@@ -16133,6 +16139,11 @@ int wlan_set_country_code(const char *alpha2)
 #endif
 
     return ret;
+}
+
+int wlan_get_country_code(char *alpha2)
+{
+    return wifi_get_country_code(alpha2);
 }
 
 int wlan_set_country_ie_ignore(uint8_t *ignore)


### PR DESCRIPTION
Remove CONFIG_WPA_SUPP guard from IEs storage in scan results.
Store raw IEs conditionally based on CONFIG_WPA_SUPP or
CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS. Add wifi_get_scan_raw_frame()
API to provide reconstructed 802.11 beacon frames to the Zephyr
NXP WiFi driver.

Signed-off-by: Maochen Wang <maochen.wang@nxp.com>

---
_Generated by WChat AI Agent_