### PR TITLE
wifi_nxp: upgrade wifi version to v1.3.r54.z_up.p2

### DIFF
--- a/mcux/middleware/wifi_nxp/CMakeLists.txt
+++ b/mcux/middleware/wifi_nxp/CMakeLists.txt
@@ -353,10 +353,10 @@ endif()
 zephyr_code_relocate(FILES
                      ${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/drivers/flexspi/fsl_flexspi.c
                      ${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/flash/mflash/${drv_folder}/mflash_drv.c
-                     LOCATION ${QUICK_ACCESS_CODE_AREA_2} NOKEEP)
+                     LOCATION RAM_TEXT NOKEEP)
 endif()
 
-if(CONFIG_SPEED_OPTIMIZATIONS OR CONFIG_SIZE_OPTIMIZATIONS)
+if(CONFIG_SPEED_OPTIMIZATIONS)
 # critical path code relocated to SRAM
 zephyr_code_relocate(FILES port/osa/osa.c
                      FILTER ".*\\.OSA_RWLockReadLock|.*\\.OSA_RWLockReadUnlock"
@@ -379,7 +379,8 @@ string(JOIN "" NXP_WIFIDRIVER_WIFI_FILTER
        ".*\\.wifi_drv_tx_task|"
        ".*\\.wifi_add_to_bypassq|"
        ".*\\.wifi_low_level_output|"
-       ".*\\.wifi_get_outbuf"
+       ".*\\.wifi_get_outbuf|"
+       ".*\\.wifi_wmm_get_packet_cnt"
 )
 
 zephyr_code_relocate(FILES wifidriver/wifi.c
@@ -476,17 +477,56 @@ string(JOIN "" NXP_WIFIDRIVER_WIFI_SDIO_FILTER
        ".*\\.sg_data_total_len_tx|"
        ".*\\.sg_data_tx_prepare|"
        ".*\\.wifi_send_fw_data_sg|"
-       ".*\\.wlan_xmit_pkt_sg"
+       ".*\\.wlan_xmit_pkt_sg|"
+       ".*\\.wlan_xmit_bypass_pkt|"
+       ".*\\.wifi_send_fw_data"
 )
 
 zephyr_code_relocate(FILES wifidriver/wifi-sdio.c
                      FILTER "${NXP_WIFIDRIVER_WIFI_SDIO_FILTER}"
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
 
-zephyr_code_relocate(FILES
-                     sdio_nxp_abs/mlan_sdio.c
-                     ${MCUX_SDK_DIR}/drivers/usdhc/fsl_usdhc.c
+string(JOIN "" NXP_WIFIDRIVER_SDIO_FILTER
+       ".*\\.calculate_sdio_write_params"
+)
+zephyr_code_relocate(FILES wifidriver/sdio.c
+                     FILTER "${NXP_WIFIDRIVER_SDIO_FILTER}"
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
+
+string(JOIN "" NXP_MLAN_SDIO_FILTER
+       ".*\\.sdio_drv_read|"
+       ".*\\.sdio_drv_write|"
+       ".*\\.sg_to_net_buf|"
+       ".*\\.sdio_drv_request_sg|"
+       ".*\\.sdio_drv_read_sg|"
+       ".*\\.sdio_drv_write_sg|"
+       ".*\\.sdio_irq_handler|"
+       ".*\\.sdio_drv_creg_read|"
+       ".*\\.sdio_drv_creg_write"
+)
+
+zephyr_code_relocate(FILES sdio_nxp_abs/mlan_sdio.c
+                     FILTER "${NXP_MLAN_SDIO_FILTER}"
+                     LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
+
+string(JOIN "" NXP_FSL_USDHC_FILTER
+       ".*\\.USDHC_SetDataConfig|"
+       ".*\\.USDHC_TransferNonBlocking|"
+       ".*\\.USDHC_TransferHandleIRQ|"
+       ".*\\.USDHC_TransferHandleCommand|"
+       ".*\\.USDHC_TransferHandleData|"
+       ".*\\.USDHC_SetTransferConfig|"
+       ".*\\.USDHC_SendCommand|"
+       ".*\\.USDHC_ReceiveCommandResponse|"
+       ".*\\.USDHC_SetAdmaTableConfig|"
+       ".*\\.USDHC_SetADMA2Descriptor|"
+       ".*\\.USDHC_SetInternalDmaConfig"
+)
+
+zephyr_code_relocate(FILES ${MCUX_SDK_DIR}/drivers/usdhc/fsl_usdhc.c
+                     FILTER "${NXP_FSL_USDHC_FILTER}"
+                     LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
+
 endif()
 
 if(CONFIG_NXP_RW610)

--- a/mcux/middleware/wifi_nxp/firmware_dnld/firmware_dnld.c
+++ b/mcux/middleware/wifi_nxp/firmware_dnld/firmware_dnld.c
@@ -204,7 +204,7 @@ int32_t firmware_download(const uint8_t *fw_start_addr, const size_t size, void 
         }
     }
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
     if ((fw_reload != 0) && (intf->intf_s.fwdnld_intf_check_reload))
     {
         ret = intf->intf_s.fwdnld_intf_check_reload(intf, fw_reload);

--- a/mcux/middleware/wifi_nxp/fwdnld_intf_abs/fwdnld_intf_abs.h
+++ b/mcux/middleware/wifi_nxp/fwdnld_intf_abs/fwdnld_intf_abs.h
@@ -51,7 +51,7 @@ typedef struct intf_elems
                                           uint32_t *transferred_len);
     fwdnld_intf_ret_t (*fwdnld_intf_prepare)(struct fwdnldintf *intf, void *params);
     fwdnld_intf_ret_t (*fwdnld_intf_check_ready)(struct fwdnldintf *intf, void *params);
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
     fwdnld_intf_ret_t (*fwdnld_intf_check_reload)(struct fwdnldintf *intf, uint8_t fw_reload);
 #endif
     /* interface values to be stored */
@@ -72,7 +72,7 @@ typedef struct fwdnldintf
 #define GET_INTF_OUTBUF(x)    ((x)->intf_s.outbuf)
 #define GET_INTF_OUTBUFLEN(x) ((x)->intf_s.outbuf_len)
 
-#if CONFIG_WIFI_IND_DNLD
+#if CONFIG_WIFI_IND_RESET
 /** driver initial the fw reset */
 #define FW_RELOAD_SDIO_INBAND_RESET 1
 /** out band reset trigger reset, no interface re-emulation */

--- a/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
@@ -329,10 +329,6 @@ extern "C" {
 #endif /* RW610 */
 #endif /* CONFIG_NXP_OVERRIDE_CALIBRATION_DATA */
 
-#if CONFIG_NXP_WIFI_EU_VALIDATION
-#define CONFIG_EU_VALIDATION 1
-#endif
-
 #if CONFIG_NXP_WIFI_WMM
 #define CONFIG_WMM 1
 #endif

--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi-decl.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi-decl.h
@@ -2015,7 +2015,7 @@ typedef PACK_START struct _wifi_csi_config_params_t
 } PACK_END wifi_csi_config_params_t;
 #endif /* CSI_SUPPORT */
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /** Wi-Fi independent reset config */
 typedef PACK_START struct
 {

--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi.h
@@ -160,7 +160,7 @@ typedef struct wifi_remain_channel_info
  */
 int wifi_init(const uint8_t *fw_start_addr, const size_t size);
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /**
  * Re-initialize Wi-Fi driver module.
  *
@@ -171,12 +171,14 @@ int wifi_init(const uint8_t *fw_start_addr, const size_t size);
  *
  * \param[in] fw_start_addr address of stored Wi-Fi Firmware.
  * \param[in] size Size of Wi-Fi Firmware.
- * \param[in] fw_reload Type of Firmware reset.
  *
  * \return WM_SUCCESS on success or -WM_FAIL on error.
  *
  */
-int wifi_reinit(const uint8_t *fw_start_addr, const size_t size, uint8_t fw_reload);
+int wifi_reinit(const uint8_t *fw_start_addr, const size_t size);
+
+void wifi_reset_mode_set(uint8_t mode);
+uint8_t wifi_reset_mode_get(void);
 #endif
 
 /**
@@ -246,11 +248,6 @@ void wifi_set_tx_status(t_u8 status);
  *
  */
 void wifi_set_rx_status(t_u8 status);
-
-/**
- * This API can be used to reset mgmt_ie_index_bitmap.
- */
-void reset_ie_index();
 
 /**
  * Register Data callback function with Wi-Fi Driver to receive
@@ -496,11 +493,13 @@ int wifi_set_tx_pert(void *cfg, mlan_bss_type bss_type);
 #endif
 
 #if CONFIG_TX_RX_HISTOGRAM
-int wifi_set_txrx_histogram(void *cfg, t_u8 *data);
+int wifi_set_txrx_histogram(int bss_type, void *cfg, t_u8 *data);
 #endif
 
 #if CONFIG_ROAMING
-int wifi_config_roaming(const int enable, uint8_t *rssi_low);
+int wifi_config_roaming(const int enable, uint8_t rssi_low);
+int wifi_roaming_subscribe_event(uint8_t bitmap, uint8_t rssi_low, uint8_t snr_low);
+int wifi_roaming_clear_subscribe(void);
 #endif
 #if CONFIG_BG_SCAN
 int wifi_config_bgscan_and_rssi(const char *ssid);
@@ -780,12 +779,20 @@ int wifi_get_antenna(t_u32 *ant_mode, t_u16 *evaluate_time, t_u8 *evaluate_mode,
 void wifi_process_hs_cfg_resp(t_u8 *cmd_res_buffer);
 enum wifi_event_reason wifi_process_ps_enh_response(t_u8 *cmd_res_buffer, t_u16 *ps_event, t_u16 *action);
 
+enum wifi_csu_target_type {
+    MLAN_CSU_TARGET_CAU = 1,
+    MLAN_CSU_TARGET_PSU,
+};
+
 typedef enum
 {
     REG_MAC = 1,
     REG_BBP,
     REG_RF,
-    REG_CAU
+    REG_CAU,
+    REG_PSU,
+    REG_BCA,
+    REG_CIU = 8
 } wifi_reg_t;
 
 int wifi_mem_access(uint16_t action, uint32_t addr, uint32_t *value);
@@ -1258,8 +1265,6 @@ typedef struct _wlan_nlist_report_param
 } wlan_nlist_report_param;
 #endif
 
-int wifi_clear_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t index, int mgmt_bitmap_index);
-
 #if CONFIG_UAP_STA_MAC_ADDR_FILTER
 int wifi_set_sta_mac_filter(int filter_mode, int mac_count, unsigned char *mac_addr);
 #endif
@@ -1290,6 +1295,7 @@ int wifi_set_11ax_tx_omi(const mlan_bss_type bss_type,
                          const t_u16 tx_omi,
                          const t_u8 tx_option,
                          const t_u8 num_data_pkts);
+int wifi_set_11ax_htc(const mlan_bss_type bss_type, const t_u8 enable);
 int wifi_set_11ax_tol_time(const t_u32 tol_time);
 int wifi_set_11ax_rutxpowerlimit(const void *rutx_pwr_cfg, uint32_t rutx_pwr_cfg_len);
 int wifi_set_11ax_rutxpowerlimit_legacy(const wifi_rutxpwrlimit_t *ru_pwr_cfg);
@@ -1498,8 +1504,6 @@ t_u8 wifi_wmm_get_packet_cnt(void);
 void wifi_handle_event_data_pause(void *data);
 void wifi_wmm_tx_stats_dump(int bss_type);
 #endif /* CONFIG_WMM */
-
-int wifi_set_rssi_low_threshold(uint8_t *low_rssi);
 
 #if CONFIG_HEAP_DEBUG
 /**
@@ -1886,13 +1890,9 @@ int wifi_single_ant_duty_cycle(t_u16 enable, t_u16 nbTime, t_u16 wlanTime);
 int wifi_dual_ant_duty_cycle(t_u16 enable, t_u16 nbTime, t_u16 wlanTime, t_u16 wlanBlockTime);
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 int wifi_set_indrst_cfg(const wifi_indrst_cfg_t *indrst_cfg, mlan_bss_type bss_type);
 int wifi_get_indrst_cfg(wifi_indrst_cfg_t *indrst_cfg, mlan_bss_type bss_type);
-int wifi_trigger_inband_indrst();
-#if CONFIG_WIFI_IND_OOB_RESET
-int wifi_trigger_oob_indrst();
-#endif
 #endif
 
 #if CONFIG_WIFI_BOOT_SLEEP
@@ -2072,4 +2072,8 @@ void wifi_uap_client_deauth(t_u8 *sta_addr);
 #endif
 #endif /* UAP_SUPPORT */
 void wifi_get_fw_info(mlan_bss_type type, t_u16 *fw_bands);
+
+#if !defined(RW610) && CONFIG_WIFI_RECOVERY
+void wlan_reset_async(void);
+#endif
 #endif /* __WIFI_H__ */

--- a/mcux/middleware/wifi_nxp/incl/wifidriver/wifi_events.h
+++ b/mcux/middleware/wifi_nxp/incl/wifidriver/wifi_events.h
@@ -63,6 +63,8 @@ enum wifi_event
     WIFI_EVENT_LINK_LOSS,
     /* WiFi RSSI Low Event */
     WIFI_EVENT_RSSI_LOW,
+    /* WiFi SNR Low Event */
+    WIFI_EVENT_SNR_LOW,
     /** Firmware Hang event */
     WIFI_EVENT_FW_HANG,
     /** Firmware Reset event */
@@ -70,8 +72,6 @@ enum wifi_event
 #if CONFIG_SUBSCRIBE_EVENT_SUPPORT
     /* WiFi RSSI High Event */
     WIFI_EVENT_RSSI_HIGH,
-    /* WiFi SRN Low Event */
-    WIFI_EVENT_SNR_LOW,
     /* WiFi SNR High Event */
     WIFI_EVENT_SNR_HIGH,
     /* WiFi Max Fail Event */
@@ -188,6 +188,8 @@ enum wifi_event
 #if CONFIG_WIFI_CHANNEL_LOAD
     WIFI_EVENT_CHAN_LOAD,
 #endif
+    /** Roaming trigger event */
+    WIFI_EVENT_ROAMING_TRIGGER,
     /** Event to indicate end of Wi-Fi events */
     WIFI_EVENT_LAST,
     /* other events can be added after this, however this must

--- a/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
+++ b/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
@@ -19,7 +19,7 @@
 #include <wifi_events.h>
 #include <wifi.h>
 
-#define WLAN_DRV_VERSION "v1.3.r53.z_up.p9"
+#define WLAN_DRV_VERSION "v1.3.r54.z_up.p2"
 
 #if CONFIG_WPA2_ENTP
 #include <wm_mbedtls_helper_api.h>
@@ -1440,6 +1440,17 @@ struct wifi_scan_params_t
 /** Wi-Fi firmware stat from \ref wifi_pkt_stats_t
  */
 typedef wifi_pkt_stats_t wlan_pkt_stats_t;
+
+/** Wi-Fi diagnostic statistics */
+struct wlan_diag
+{
+    /** Number of hardware exceptions detected by the Wi-Fi driver; reserved, always 0 */
+    uint32_t hw_exception_count;
+    /** Number of disconnection events since driver initialization */
+    uint32_t disconnection_count;
+    /** Duration in seconds that the Wi-Fi interface has been in disconnected state */
+    uint32_t disconnection_dur_sec;
+};
 #endif
 
 /** Configuration for Wi-Fi scan channel list from
@@ -1634,7 +1645,7 @@ typedef wifi_net_monitor_t wlan_net_monitor_t;
 typedef wifi_host_tx_frame_params_t wlan_host_tx_frame_params_t;
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /** Configuration for GPIO independent reset
  * \ref wifi_indrst_cfg_t
  */
@@ -3402,11 +3413,12 @@ void wlan_set_tx_pert(struct wlan_tx_pert_info *tx_pert, mlan_bss_type bss_type)
 /** Set TX RX histogram config.
  * This function can be called to set TX RX histogram config.
  *
+ * \param[in] bss_type: 0: STA, 1: uAP
  * \param[in] txrx_histogram: User configured parameters of TX RX histogram.
  *            including enable and action.
  * \param[out] data: TX RX histogram data from FW.
  */
-void wlan_set_txrx_histogram(struct wlan_txrx_histogram_info *txrx_histogram, t_u8 *data);
+void wlan_set_txrx_histogram(int bss_type, struct wlan_txrx_histogram_info *txrx_histogram, t_u8 *data);
 #endif
 
 #if CONFIG_ROAMING
@@ -3434,13 +3446,16 @@ void wlan_set_txrx_histogram(struct wlan_txrx_histogram_info *txrx_histogram, t_
  * \ref wlan_set_rssi_low_threshold API to set RSSI low
  * threshold again.
  *
- * \param[in] enable: Enable/Disable roaming.
+ * \param[in] bitmap: Roaming event bitmap (0=disable, bit0=RSSI_LOW, bit1=SNR_LOW)
  * \param[in] rssi_low_threshold: RSSI low threshold value
+ * \param[in] snr_low_threshold: SNR low threshold value
  *
  * \return WM_SUCCESS if the call was successful.
  * \return -WM_FAIL if failed.
  */
-int wlan_set_roaming(const int enable, const uint8_t rssi_low_threshold);
+int wlan_set_roaming(const uint8_t bitmap,
+                    const uint8_t rssi_low_threshold,
+                    const uint8_t snr_low_threshold);
 
 /** Get the roaming status.
  *
@@ -3448,10 +3463,6 @@ int wlan_set_roaming(const int enable, const uint8_t rssi_low_threshold);
  * \return 0 if roaming is disbled.
  */
 int wlan_get_roaming_status(void);
-
-/** Subscribe RSSI low event in firmware if roaming is enabled.
- */
-void wlan_subscribe_rssi_low_event(void);
 #endif
 
 #if CONFIG_HOST_SLEEP
@@ -4187,6 +4198,16 @@ int wlan_get_log(wlan_pkt_stats_t *stats);
  * \return -WM_FAIL if command fails.
  */
 int wlan_uap_get_log(wlan_pkt_stats_t *stats);
+
+/**
+ * Get Wi-Fi diagnostic statistics.
+ *
+ * \param[out] diag  Pointer to \ref wlan_diag to store the result.
+ *
+ * \return WM_SUCCESS if successful.
+ * \return -WM_E_INVAL if a NULL pointer is passed.
+ */
+int wlan_get_diag(struct wlan_diag *diag);
 #endif
 
 /** Get station interface power save mode.
@@ -4596,35 +4617,6 @@ int wlan_set_wwsm_txpwrlimit(void);
 const char *wlan_get_wlan_region_code(void);
 #endif
 
-/**
- * Get Management IE for given BSS type (interface) and index.
- *
- * \param[in] bss_type: 0: STA, 1: uAP
- * \param[in] index: IE index.
- *
- * \param[out] buf: Buffer to store requested IE data.
- * \param[out] buf_len: Length of IE data.
- *
- * \return WM_SUCCESS if successful.
- * \return -WM_FAIL if unsuccessful.
- *
- */
-int wlan_get_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t index, void *buf, unsigned int *buf_len);
-
-/**
- * Set management IE for given BSS type (interface) and index.
- *
- * \param[in] bss_type: 0: STA, 1: uAP
- * \param[in] id: Type/ID of Management IE.
- * \param[in] buf: Buffer containing IE data.
- * \param[in] buf_len: Length of IE data.
- *
- * \return Management IE index if successful.
- * \return -WM_FAIL if unsuccessful.
- *
- */
-int wlan_set_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t id, void *buf, unsigned int buf_len);
-
 #ifdef SD8801
 /**
  * Get external radio coex statistics.
@@ -4648,19 +4640,6 @@ int wlan_get_ext_coex_stats(wlan_ext_coex_stats_t *ext_coex_stats);
  */
 int wlan_set_ext_coex_config(const wlan_ext_coex_config_t ext_coex_config);
 #endif
-
-/**
- * Clear management IE for given BSS type (interface) and index.
- *
- * \param[in] bss_type: 0: STA, 1: uAP
- * \param[in] index: IE index.
- * \param[in] mgmt_bitmap_index: management bitmap index.
- *
- * \return WM_SUCCESS if successful.
- * \return -WM_FAIL if unsuccessful.
- *
- */
-int wlan_clear_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t index, int mgmt_bitmap_index);
 
 /**
  * Get current status of 802.11d support.
@@ -6902,19 +6881,6 @@ void wlan_start_stop_ami(uint8_t start);
 #endif
 #endif
 
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_11R) || (CONFIG_ROAMING)
-/**
- * Use this API to set the RSSI threshold value for low RSSI event subscription.
- * When RSSI falls below this threshold firmware can generate the low RSSI event to driver.
- * This low RSSI event is used when either of CONFIG_11R, CONFIG_11K, CONFIG_11V or CONFIG_ROAMING is enabled.
- * \note By default RSSI low threshold is set at -70 dbm.
- *
- * \param[in]     threshold:     Threshold RSSI value to be set
- *
- */
-void wlan_set_rssi_low_threshold(uint8_t threshold);
-#endif
-
 #if CONFIG_WPA_SUPP
 #if CONFIG_WPA_SUPP_WPS
 /**
@@ -7392,7 +7358,7 @@ int wlan_imd3_cfg(t_u8 imd3_value);
 int wlan_host_set_sta_mac_filter(int filter_mode, int mac_count, unsigned char *mac_addr);
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /**
  * Set GPIO independent reset configuration
  *
@@ -7409,17 +7375,6 @@ int wlan_set_indrst_cfg(const wifi_indrst_cfg_t *indrst_cfg);
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
  */
 int wlan_get_indrst_cfg(wifi_indrst_cfg_t *indrst_cfg);
-
-/** Test independent firmware reset
- *
- * This function can either send command that can cause timeout in firmware or
- * send GPIO pulse that can cause out of band reset in firmware as per configuration
- * int earlier \ref wlan_set_indrst_cfg API.
- *
- * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
- */
-int wlan_independent_reset(void);
-
 #endif
 
 int wlan_set_network_ip_byname(char *name, struct wlan_ip_config *ip);

--- a/mcux/middleware/wifi_nxp/port/osa/mem_pool_config.c
+++ b/mcux/middleware/wifi_nxp/port/osa/mem_pool_config.c
@@ -20,7 +20,7 @@
 #define POOL_ID0_BUF0_CNT 1
 
 /* Buffer descriptor size already part of TX size so don't add again */
-#define POOL_ID0_BUF0_SZ 1500
+#define POOL_ID0_BUF0_SZ 2000
 
 // Pool 0 total buffer size calculation
 #define POOL_ID0_SZ (POOL_ID0_BUF0_SZ * POOL_ID0_BUF0_CNT)

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/fwdnld_sdio.c
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/fwdnld_sdio.c
@@ -71,30 +71,7 @@ bool wlan_sdio_check_fw_status(t_u32 card_poll)
     return false;
 }
 
-#if CONFIG_WIFI_IND_DNLD
-#if 0
-/**  @brief This function disables the host interrupts mask.
- *
- *  @param pmadapter    A pointer to mlan_adapter structure
- *  @param mask         the interrupt mask
- *  @return             MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
- */
-static int32_t wlan_sdio_disable_host_int_mask()
-{
-    uint32_t host_int_mask = 0;
-    uint32_t resp;
-
-    (void)sdio_drv_creg_read(HOST_INT_MASK_REG, 1, &host_int_mask);
-
-    /* Update with the mask and write back to the register */
-    host_int_mask &= ~HIM_DISABLE;
-
-    (void)sdio_drv_creg_write(HOST_INT_MASK_REG, 1, host_int_mask, &resp);
-
-    return FWDNLD_INTF_SUCCESS;
-}
-#endif
-
+#if CONFIG_WIFI_IND_RESET
 /**
  *  @brief This function probes the driver
  *
@@ -223,7 +200,7 @@ static fwdnld_intf_ret_t sdio_post_fwdnld_check_conn_ready(fwdnld_intf_t *intf, 
     }
 }
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 static fwdnld_intf_ret_t sdio_fwdnld_check_reload(fwdnld_intf_t *intf, uint8_t fw_reload)
 {
     t_u32 poll_num = 10;
@@ -365,7 +342,7 @@ fwdnld_intf_t *sdio_init_interface(void *settings)
     sdio_intf_g.intf_s.fwdnld_intf_send        = sdio_interface_send;
     sdio_intf_g.intf_s.fwdnld_intf_prepare     = sdio_prep_for_fwdnld;
     sdio_intf_g.intf_s.fwdnld_intf_check_ready = sdio_post_fwdnld_check_conn_ready;
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
     sdio_intf_g.intf_s.fwdnld_intf_check_reload = sdio_fwdnld_check_reload;
 #endif
     sdio_intf_g.intf_s.outbuf        = wifi_get_sdio_outbuf(&sdio_intf_g.intf_s.outbuf_len);

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio.h
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio.h
@@ -131,7 +131,10 @@ t_void wlan_interrupt(mlan_adapter *pmadapter);
 /* wmsdk */
 /* mlan_status wlan_process_int_status(mlan_adapter * pmadapter); */
 
-#if CONFIG_WIFI_IND_DNLD
+#if CONFIG_WIFI_IND_RESET
 mlan_status wlan_reset_fw(pmlan_adapter pmadapter);
+#if CONFIG_WIFI_IND_OOB_RESET
+void sdio_oob_reset(void);
+#endif
 #endif
 #endif /* _MLAN_SDIO_H */

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio_defs.h
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/incl/mlan_sdio_defs.h
@@ -283,7 +283,7 @@ Change log:
 /** Rx unit register (SCRATCH0_3) */
 #define CARD_RX_UNIT_REG 0xeb
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 #if defined(SD8978) || defined(SD8987) || defined(SD9177) || defined(IW610)
 /** Firmware reset register */
 #define CARD_FW_RESET_REG 0xEE
@@ -356,7 +356,7 @@ Change log:
 /** Rx unit register (SCRATCH0_3) */
 #define CARD_RX_UNIT_REG    0x63
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /** Firmware reset register */
 #define CARD_FW_RESET_REG 0x64
 /** Firmware reset register */

--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
@@ -12,6 +12,7 @@
 #include <mlan_sdio_defs.h>
 #include <osa.h>
 #include <zephyr/sd/sdio.h>
+#include <zephyr/drivers/gpio.h>
 
 #define SDIO_CMD_TIMEOUT 2000
 
@@ -299,3 +300,23 @@ void sdio_drv_deinit(void)
 {
     // SDIO_Deinit(&wm_g_sd);
 }
+
+#if CONFIG_WIFI_IND_RESET && CONFIG_WIFI_IND_OOB_RESET
+#define DT_DRV_COMPAT nxp_wifi
+void sdio_oob_reset(void)
+{
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sd_gpios)
+    int err = 0;
+    struct gpio_dt_spec oob_reset = GPIO_DT_SPEC_GET(DT_DRV_INST(0), sd_gpios);
+
+    err = gpio_pin_set_dt(&oob_reset, 0);
+    if (err) {
+        return;
+    }
+
+    OSA_TimeDelay(10);
+
+    (void)gpio_pin_set_dt(&oob_reset, 1);
+#endif
+}
+#endif

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_api.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_api.h
@@ -53,6 +53,8 @@
 #if CONFIG_11K
 #include "mlan_11k.h"
 #endif
+
+#include "mlan_mgmt_ie.h"
 /* #define CONFIG_WIFI_DEBUG */
 
 static inline void panic(const char *msg)
@@ -242,6 +244,11 @@ bool wmsdk_is_11N_enabled(void);
  */
 void wlan_abort_split_scan(void);
 
+void wlan_set_split_scan_status(bool in_progress);
+bool wlan_get_split_scan_status(void);
+void wlan_set_abort_split_scan(bool abort);
+bool wlan_get_abort_split_scan(void);
+
 void wlan_scan_process_results(IN mlan_private *pmpriv);
 bool wlan_use_non_default_ht_vht_cap(IN BSSDescriptor_t *pbss_desc);
 bool check_for_wpa2_entp_ie(bool *wpa2_entp_IE_exist, const void *element_data, unsigned element_len);
@@ -307,9 +314,7 @@ int wifi_nxp_deauthenticate(unsigned int bss_type, const uint8_t *bssid, uint16_
 void wifi_get_scan_table(mlan_private *pmpriv, mlan_scan_resp *pscan_resp);
 #endif
 int wifi_get_eeprom_data(uint32_t offset, uint32_t byte_count, uint8_t *buf);
-int wifi_get_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t index, void *buf, unsigned int *buf_len);
 int wifi_send_remain_on_channel_cmd(unsigned int bss_type, wifi_remain_on_channel_t *remain_on_channel);
-int wifi_set_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t id, void *buf, unsigned int buf_len);
 #ifdef SD8801
 int wifi_get_ext_coex_stats(wifi_ext_coex_stats_t *ext_coex_stats);
 int wifi_set_ext_coex_config(const wifi_ext_coex_config_t *ext_coex_config);
@@ -505,15 +510,6 @@ extern t_u8 g_csi_event_for_wls;
 void wifi_process_csi_data(void *p_data);
 #endif
 
-#if UAP_SUPPORT
-int wifi_set_custom_ie(custom_ie *beacon_ies_data,
-                       custom_ie *beacon_wps_ies_data,
-                       custom_ie *proberesp_ies_data,
-                       custom_ie *assocresp_ies_data);
-#endif
-
-unsigned int get_ie_index();
-
 #if CONFIG_11K
 /**
  * rrm scan callback function to process scan results
@@ -587,10 +583,6 @@ int wrapper_bssdesc_second_set(int bss_index,
                                bool *mbo_assoc_disallowed
 #endif
 );
-
-int wifi_get_mgmt_ie2(mlan_bss_type bss_type, void *buf, unsigned int *buf_len);
-int wifi_set_mgmt_ie2(mlan_bss_type bss_type, unsigned short mask, void *buf, unsigned int buf_len);
-int wifi_clear_mgmt_ie2(mlan_bss_type bss_type, int mgmt_bitmap_index);
 
 int wifi_get_mgmt_ie_by_index(mlan_bss_type bss_type, void *buffer, unsigned int *ie_len, int index);
 

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_decl.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_decl.h
@@ -315,7 +315,7 @@ typedef t_u8 mlan_802_11_mac_addr[MLAN_MAC_ADDR_LENGTH];
 /** Default memory allocation flag */
 #define MLAN_MEM_DEF 0U
 
-#if CONFIG_WIFI_IND_DNLD
+#if CONFIG_WIFI_IND_RESET
 /** driver initial the fw reset */
 #define FW_RELOAD_SDIO_INBAND_RESET 1
 /** out band reset trigger reset, no interface re-emulation */
@@ -499,7 +499,7 @@ typedef struct _mlan_fw_image
     t_u8 *pfw_buf;
     /** Firmware image length */
     t_u32 fw_len;
-#if CONFIG_WIFI_IND_DNLD
+#if CONFIG_WIFI_IND_RESET
     /** Firmware reload flag */
     t_u8 fw_reload;
 #endif
@@ -731,6 +731,34 @@ typedef MLAN_PACK_START struct
 /** Max Ie length */
 #define MAX_IE_SIZE 256U
 
+/** custom IE header */
+typedef MLAN_PACK_START struct _custom_ie_hdr
+{
+    /** IE Index */
+    t_u16 ie_index;
+    /** Mgmt Subtype Mask */
+    t_u16 mgmt_subtype_mask;
+    /** IE Length */
+    t_u16 ie_length;
+    /** dirty flag, 1: modified, not yet committed to FW */
+    t_u8 dirty;
+    /** IE buffer */
+    t_u8 *ie_buf;
+} MLAN_PACK_END custom_ie_hdr;
+
+/** Driver custom IE control entry */
+typedef MLAN_PACK_START struct _custom_ie_entry
+{
+    /** BSS type (STA/UAP/WIFIDIRECT) this IE belongs to */
+    mlan_bss_type bss_type;
+    /** Pointer to custom IE header */
+    custom_ie_hdr *cust_ie;
+    /** Offset of this IE within the shared IE buffer */
+    t_u16 ie_offset;
+    /** Length of this IE data in bytes */
+    t_u16 cur_ie_len;
+} MLAN_PACK_END custom_ie_entry;
+
 /** custom IE */
 typedef MLAN_PACK_START struct _custom_ie
 {
@@ -757,8 +785,10 @@ typedef MLAN_PACK_START struct _tlvbuf_custom_ie
 
 /** Max IE index to FW */
 #define MAX_MGMT_IE_INDEX_TO_FW 4U
-/** Max IE index per BSS */
-#define MAX_MGMT_IE_INDEX 16
+/** Max IE index supported by FW */
+#define MAX_MGMT_IE_FW_INDEX 16
+/** Max IE index maintained by DRV */
+#define MAX_MGMT_IE_DRV_INDEX 20
 
 /** custom IE info */
 typedef MLAN_PACK_START struct _custom_ie_info
@@ -779,7 +809,7 @@ typedef MLAN_PACK_START struct _tlvbuf_max_mgmt_ie
     /** No of tuples */
     t_u16 count;
     /** custom IE info tuples */
-    custom_ie_info info[MAX_MGMT_IE_INDEX];
+    custom_ie_info info[MAX_MGMT_IE_FW_INDEX];
 } MLAN_PACK_END tlvbuf_max_mgmt_ie;
 
 /** TLV buffer : custom IE */

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_fw.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_fw.h
@@ -1323,6 +1323,9 @@ typedef MLAN_PACK_START struct _MrvlIEtypes_fw_cap_info_t
 #define HostCmd_CMD_LOW_POWER_MODE 0x0128
 #endif /* WLAN_LOW_POWER_ENABLE */
 
+/** Host Command ID : Target device access */
+#define HostCmd_CMD_TARGET_ACCESS 0x12a
+
 #define HOST_CMD_SMART_MODE_CFG 0x012d
 
 #define HostCmd_CMD_AUTO_RECONNECT 0x0115
@@ -1362,10 +1365,16 @@ typedef MLAN_PACK_START struct _MrvlIEtypes_fw_cap_info_t
 /** Host Command ID : GET TBTT Offset stats */
 #define HostCmd_CMD_TBTT_OFFSET 0x0268
 
+/** Host Command ID: BCA device access */
+#define HostCmd_CMD_BCA_REG_ACCESS 0x272
+
 #if (CONFIG_IPS)
 /** Host Command ID : IPS Config */
 #define HostCmd_CMD_IPS_CONFIG 0x0279
 #endif
+
+/** Host Command ID: register device access */
+#define HostCmd_CMD_REG_ACCESS 0x27c
 
 #if CONFIG_RX_ABORT_CFG
 #define HostCmd_CMD_RX_ABORT_CFG 0x0261
@@ -3501,8 +3510,14 @@ typedef MLAN_PACK_START struct _HostCmd_DS_GET_HW_SPEC
 #else
      t_u32 reserved_2;
 #endif
+    /** Count of small size mgmt IE buffers available in FW */
+    t_u8 mgmt_buf_cnt_sm;
+    /** Count of medium size mgmt IE buffers available in FW */
+    t_u8 mgmt_buf_cnt_md;
+    /** Count of large size mgmt IE buffers available in FW */
+    t_u8 mgmt_buf_cnt_lg;
     /** Reserved field */
-    t_u32 reserved_3;
+    t_u8 reserved_3;
     /** FW/HW Capability */
     t_u32 fw_cap_info;
     /** 802.11n Device Capabilities */
@@ -3596,7 +3611,7 @@ typedef MLAN_PACK_START struct _HostCmd_DS_MAC_CONTROL
     t_u32 action;
 } MLAN_PACK_END HostCmd_DS_MAC_CONTROL;
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /** HostCmd_DS_IND_RST */
 typedef MLAN_PACK_START struct _HostCmd_DS_IND_RST
 {
@@ -5760,6 +5775,42 @@ typedef MLAN_PACK_START struct _HostCmd_DS_MEM_ACCESS
     /** Value */
     t_u32 value;
 } MLAN_PACK_END HostCmd_DS_MEM_ACCESS;
+
+/** HostCmd_DS_TARGET_ACCESS */
+typedef MLAN_PACK_START struct _HostCmd_DS_TARGET_ACCESS {
+    /** Action */
+    t_u16 action;
+    /** CSU Target Device. 1: CSU, 2: PSU */
+    t_u16 csu_target;
+    /** Target Device Address */
+    t_u16 address;
+    /** Data */
+    t_u8 data;
+} MLAN_PACK_END HostCmd_DS_TARGET_ACCESS;
+
+/** HostCmd_CMD_BCA_REG_ACCESS */
+typedef MLAN_PACK_START struct _HostCmd_DS_BCA_REG_ACCESS {
+    /** Action */
+    t_u16 action;
+    /** BCA register offset */
+    t_u16 offset;
+    /** BCA register value */
+    t_u32 value;
+} MLAN_PACK_END HostCmd_DS_BCA_REG_ACCESS;
+
+/** HostCmd_CMD_REG_ACCESS */
+typedef MLAN_PACK_START struct _HostCmd_DS_REG_ACCESS {
+    /** Action */
+    t_u16 action;
+    /** reg type */
+    t_u16 reg_type;
+    /** reserved */
+    t_u16 reserved;
+    /** register offset */
+    t_u16 offset;
+    /** register value */
+    t_u32 value;
+} MLAN_PACK_END HostCmd_DS_REG_ACCESS;
 
 /** HostCmd_DS_AUTO_RECONNECT */
 typedef MLAN_PACK_START struct _HostCmd_DS_AUTO_RECONNECT
@@ -7974,7 +8025,7 @@ typedef MLAN_PACK_START struct _HostCmd_DS_COMMAND
         HostCmd_DS_802_11_CFG_DATA cfg_data;
         /** MAC control */
         HostCmd_DS_MAC_CONTROL mac_ctrl;
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
         /** Test Independent reset */
         HostCmd_DS_IND_RST ind_rst;
         /** GPIO Independent reset configure */
@@ -8131,6 +8182,12 @@ typedef MLAN_PACK_START struct _HostCmd_DS_COMMAND
         HostCmd_DS_802_11_EEPROM_ACCESS eeprom;
         /** Memory access */
         HostCmd_DS_MEM_ACCESS mem;
+        /** Target device access */
+        HostCmd_DS_TARGET_ACCESS target;
+        /** BCA register access */
+        HostCmd_DS_BCA_REG_ACCESS bca_reg;
+        /** register access */
+        HostCmd_DS_REG_ACCESS reg;
         /** Bridge mode */
         HostCmd_BRIDGE_MODE bridge_mode;
         /** Auto Reconnect */

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ioctl.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ioctl.h
@@ -240,7 +240,7 @@ typedef enum _mlan_ioctl_req_id
 #if CONFIG_ECSA
     MLAN_OID_MISC_OPER_CLASS = 0x00200038,
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
     MLAN_OID_MISC_IND_RST_CFG = 0x00200040,
 #endif
 #if CONFIG_ECSA
@@ -4269,7 +4269,7 @@ typedef struct _mlan_ds_misc_gtk_rekey_data
 } mlan_ds_misc_gtk_rekey_data;
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 typedef struct _mlan_ds_ind_rst_cfg
 {
     /** Set or Get */
@@ -4377,7 +4377,7 @@ typedef struct _mlan_ds_misc_cfg
         /** GTK rekey data */
         mlan_ds_misc_gtk_rekey_data gtk_rekey;
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
         mlan_ds_ind_rst_cfg ind_rst_cfg;
 #endif
     } param;

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_main.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_main.h
@@ -1191,7 +1191,7 @@ typedef struct
 {
     /** WPS IE */
     IEEEtypes_VendorSpecific_t wps_ie;
-    int wps_mgmt_bitmap_index;
+    t_u16 wps_mgmt_bitmap_index;
     /** Session enable flag */
     t_u8 session_enable;
 } wps_t;
@@ -1589,7 +1589,7 @@ struct _mlan_private
 #endif
 #if CONFIG_11K
     t_u8 enable_host_11k;
-    int rrm_mgmt_bitmap_index;
+    t_u16 rrm_mgmt_bitmap_index;
     t_u8 neighbor_rep_token;
 #endif
 #if CONFIG_11V
@@ -1644,18 +1644,23 @@ struct _mlan_private
 #endif
 #if CONFIG_DRIVER_MBO
     t_u8 enable_mbo;
-    int mbo_mgmt_bitmap_index;
+    t_u16 mbo_index;
 #endif
     /** tx_seq_num */
     t_u32 tx_seq_num;
 #if CONFIG_WPA_SUPP
-    int probe_req_index;
+    t_u16 probe_req_index;
 #if CONFIG_WPA_SUPP_AP
-    int beacon_vendor_index;
-    int beacon_index;
-    int proberesp_index;
-    int assocresp_index;
-    int beacon_wps_index;
+    /** beacon ie index */
+    t_u16 beacon_index;
+    /** proberesp ie index */
+    t_u16 proberesp_index;
+    /** assocresp ie index */
+    t_u16 assocresp_index;
+    /** beacon wps index for mgmt ie */
+    t_u16 beacon_wps_index;
+    /** beacon/proberesp vendor ie index */
+    t_u16 beacon_vendor_index;
 #endif
 #endif
     /** uAP started or not */
@@ -2423,8 +2428,18 @@ struct _mlan_adapter
     /** 802.11ax 2.4G HE capability */
     t_u8 hw_2g_he_cap[54];
 #endif
-    /** max mgmt IE index in device */
-    t_u16 max_mgmt_ie_index;
+    /** max mgmt IE index in FW */
+    t_u16 max_mgmt_buf_count;
+    /** Mgmt IE table maintained by driver */
+    custom_ie_entry mgmt_ie[MAX_MGMT_IE_DRV_INDEX];
+    /** Count of small size mgmt IE buffers available in FW */
+    t_u8 mgmt_ie_cnt_sm;
+    /** Count of medium size mgmt IE buffers available in FW */
+    t_u8 mgmt_ie_cnt_md;
+    /** Count of large size mgmt IE buffers available in FW */
+    t_u8 mgmt_ie_cnt_lg;
+    /** Mgmt IE buffer mapped to FW IE slots */
+    custom_ie_hdr mgmt_buffer[MAX_MGMT_IE_FW_INDEX];
 #ifdef OTP_CHANINFO
     otp_region_info_t *otp_region;
     chan_freq_power_t *cfp_otp_bg;

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_mgmt_ie.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_mgmt_ie.h
@@ -1,0 +1,222 @@
+/** @file mlan_mgmt_ie.h
+ *
+ *  @brief This file contains MGMT IE information related
+ *  definitions used in MLAN module.
+ *
+ *  Copyright 2026 NXP
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+/******************************************************
+Change log:
+    05/11/2026: initial version
+******************************************************/
+
+#ifndef _MLAN_MGMT_IE_H_
+#define _MLAN_MGMT_IE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(RW610)
+/** Small buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_SM_CNT     4
+/** Medium buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_MD_CNT     4
+/** Large buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_LG_CNT     2
+#else
+/** Small buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_SM_CNT     6
+/** Medium buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_MD_CNT     5
+/** Large buffer count in MGMT IE pool */
+#define MLAN_MGMT_BUF_LG_CNT     2
+#endif
+
+/** Small buffer size for MGMT IE buffer pool */
+#define MLAN_MGMT_BUF_SM_SIZE    64
+/** Medium buffer size for MGMT IE buffer pool */
+#define MLAN_MGMT_BUF_MD_SIZE    192
+/** Large buffer size for MGMT IE buffer pool */
+#define MLAN_MGMT_BUF_LG_SIZE    256
+
+/** MGMT IE mask for invalid index */
+#define MLAN_MGMT_IE_INVALID_IDX    (0xFFFF)
+/** MGMT IE mask indicating no valid mask */
+#define MLAN_MGMT_IE_INVALID_MASK   (0xFFFF)
+/** Flag indicating MGMT IE has been updated */
+#define MLAN_MGMT_IE_UPDATED        (MBIT(7))
+
+/** Magic number used to validate a buffer block */
+#define MLAN_BUF_MAGIC 0xCAFEBABE
+
+typedef struct _mlan_buf_block {
+    struct _mlan_buf_block *next;
+    t_u8  class_id;
+    t_u32 magic;
+    t_u8  data[];
+} mlan_buf_block, *pmlan_buf_block;
+
+typedef struct _mlan_buf_class {
+    struct _mlan_buf_block *free_list;
+    t_u16 buf_size;
+    t_u16 total;
+    t_u8  class_id;
+    t_u8 *base;
+} mlan_buf_class, *pmlan_buf_class;
+
+typedef struct _mlan_buf_handle {
+    t_u8 *mem_base;
+    t_u32 mem_size;
+    struct _mlan_buf_class *classes;
+    t_u8 class_num;
+    void *(*malloc_fn)(t_u32);
+    void  (*free_fn)(void *);
+} mlan_buf_handle, *pmlan_buf_handle;
+
+typedef struct _mlan_buf_cfg {
+    t_u16 buf_size;
+    t_u8  buf_cnt;
+} mlan_buf_cfg, *pmlan_buf_cfg;
+
+/** Operation type for a batch IE request entry */
+typedef enum {
+    MGMT_IE_BATCH_SET,    /**< Set (add or update) an IE */
+    MGMT_IE_BATCH_CLEAR,  /**< Clear an IE */
+} mgmt_ie_batch_op;
+
+/**
+ * @brief Describes a single IE operation within a batch request.
+ *
+ * For MGMT_IE_BATCH_SET:   ie_mask, ie_buf, ie_len must be valid.
+ * For MGMT_IE_BATCH_CLEAR: ie_mask/ie_buf/ie_len are ignored;
+ *                          *index must not be MLAN_MGMT_IE_INVALID_IDX.
+ */
+typedef struct _mgmt_ie_batch_req {
+    mgmt_ie_batch_op  op;   /**< Operation: SET or CLEAR */
+    t_u16 *index;           /**< IN/OUT */
+    t_u16  ie_mask;         /**< Management frame type mask */
+    t_u16  ie_len;          /**< IE data length */
+    t_u8  *ie_buf;          /**< IE data pointer */
+} mgmt_ie_batch_req, *pmgmt_ie_batch_req;
+
+/**
+ * @brief Initialize MGMT IE parameters in the mlan adapter.
+ *
+ * Sets up the internal MGMT IE state within the given mlan adapter
+ * instance. Must be called during adapter initialization.
+ *
+ * @param pmadapter    Pointer to the mlan adapter structure
+ */
+void wlan_init_mgmt_ie_param(pmlan_adapter pmadapter);
+
+/**
+ * @brief Initialize the MGMT IE buffer pool and IE mutex.
+ *
+ * Allocates and sets up the internal buffer pool used for MGMT IE
+ * operations. Must be called before any MGMT IE API is used.
+ *
+ * @return     MLAN_STATUS_SUCCESS on success, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_init(void);
+
+/**
+ * @brief Deinitialize the MGMT IE buffer pool and IE mutex.
+ *
+ * Frees all resources associated with the MGMT IE buffer pool.
+ * Should be called during driver de-initialization.
+ */
+void wifi_mgmt_ie_deinit(void);
+
+/**
+ * @brief Set a Management IE for a given private interface.
+ *
+ * Stores the provided IE buffer into the MGMT IE table of the given
+ * interface, associated with the specified IE mask. The index at which
+ * the IE is stored is returned via the @p index parameter.
+ *
+ * @param priv         Pointer to the mlan private interface structure
+ * @param ie_mask      Mask indicating the frame type(s) this IE applies to
+ * @param ie_buf       Pointer to the IE data buffer
+ * @param ie_len       Length of the IE data (in bytes)
+ * @param index        Output pointer to store the assigned IE table index
+ *
+ * @return             MLAN_STATUS_SUCCESS on success, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_set(mlan_private *priv, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index);
+
+/**
+ * @brief Set multiple Management IEs in a batch operation.
+ *
+ * @param priv         Pointer to the mlan private interface structure
+ * @param reqs         Pointer to the array of batch IE requests
+ * @param req_cnt      Number of requests in the array
+ *
+ * @return             MLAN_STATUS_SUCCESS on success, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_set_batch(mlan_private *priv, mgmt_ie_batch_req *reqs, t_u8 req_cnt);
+
+/**
+ * @brief Clear a Management IE entry by index.
+ *
+ * Removes the IE stored at the given index from the MGMT IE table of the
+ * specified interface. The index is set to MLAN_MGMT_IE_INVALID_IDX on
+ * successful removal.
+ *
+ * @param priv         Pointer to the mlan private interface structure
+ * @param index        Pointer to the IE table index to clear
+ *
+ * @return             MLAN_STATUS_SUCCESS on success, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_clear(mlan_private *priv, t_u16 *index);
+
+/**
+ * @brief Replace a specific IE element within stored MGMT IEs.
+ *
+ * Searches the MGMT IE table for an existing IE matching the given IE ID
+ * (and optionally OUI for vendor-specific IEs) and replaces it with the
+ * new IE buffer provided.
+ *
+ * @param priv         Pointer to the mlan private interface structure
+ * @param ie_buf       Pointer to the new IE data buffer
+ * @param ie_len       Length of the new IE data (in bytes)
+ * @param ie_id        IEEE element ID of the IE to replace
+ * @param oui          Pointer to the OUI (used for vendor-specific IEs),
+ *                     or NULL if not applicable
+ *
+ * @return             MLAN_STATUS_SUCCESS on success, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_replace_elem(mlan_private *priv, t_u8 *ie_buf, t_u16 ie_len, IEEEtypes_ElementId_e ie_id, t_u8 *oui);
+
+/**
+ * @brief Fill a single mgmt_ie_batch_req entry.
+ *
+ * @param req      Pointer to the batch request entry to fill
+ * @param index    IN/OUT: pointer to the IE index stored in priv
+ * @param ie_mask  Management frame type mask
+ * @param ie_buf   IE data buffer
+ * @param ie_len   IE data length
+ *
+ * @return         MLAN_STATUS_SUCCESS if a request was filled, error status otherwise
+ */
+mlan_status wifi_mgmt_ie_req_fill(mgmt_ie_batch_req *req, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index);
+
+/**
+ * @brief Dump all MGMT IE entries for debugging purposes.
+ *
+ * Prints the contents of the MGMT IE table for all interfaces managed by
+ * the given mlan adapter. Intended for debug use only.
+ *
+ * @param pmadapter    Pointer to the mlan adapter structure
+ */
+void wifi_mgmt_ie_dump(pmlan_adapter pmadapter);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MLAN_MGMT_IE_H_ */

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_util.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_util.h
@@ -539,4 +539,10 @@ static INLINE t_u8 util_scalar_conditional_write(t_void *pmoal_handle,
     return (update) ? MTRUE : MFALSE;
 }
 
+#define util_offsetof(struct_type, member_name) \
+    ((t_ptr)&((struct_type *)0)->member_name)
+
+#define util_container_of(ptr, struct_type, member_name) \
+    ((struct_type *)((t_u8 *)(ptr) - util_offsetof(struct_type, member_name)))
+
 #endif /* !_MLAN_UTIL_H_ */

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_11ax.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_11ax.c
@@ -630,6 +630,7 @@ mlan_status wlan_cmd_11ax_cmd(pmlan_private pmpriv, HostCmd_DS_COMMAND *cmd, t_u
 {
     HostCmd_DS_11AX_CMD_CFG *axcmd        = &cmd->params.axcmd;
     mlan_ds_11ax_cmd_cfg *ds_11ax_cmd     = (mlan_ds_11ax_cmd_cfg *)pdata_buf;
+    mlan_ds_11ax_htc_cmd *htc_cmd         = (mlan_ds_11ax_htc_cmd *)&ds_11ax_cmd->param;
     mlan_ds_11ax_txomi_cmd *txomi_cmd     = (mlan_ds_11ax_txomi_cmd *)&ds_11ax_cmd->param;
     mlan_ds_11ax_toltime_cmd *toltime_cmd = (mlan_ds_11ax_toltime_cmd *)&ds_11ax_cmd->param;
 
@@ -641,6 +642,10 @@ mlan_status wlan_cmd_11ax_cmd(pmlan_private pmpriv, HostCmd_DS_COMMAND *cmd, t_u
     axcmd->sub_id = wlan_cpu_to_le16(ds_11ax_cmd->sub_id);
     switch (ds_11ax_cmd->sub_id)
     {
+        case MLAN_11AXCMD_HTC_SUBID:
+            axcmd->val[0] = htc_cmd->value;
+            cmd->size += sizeof(t_u8);
+            break;
         case MLAN_11AXCMD_TXOMI_SUBID:
             (void)__memcpy(pmpriv->adapter, axcmd->val, txomi_cmd, sizeof(mlan_ds_11ax_txomi_cmd));
             cmd->size += sizeof(mlan_ds_11ax_txomi_cmd);

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
@@ -47,8 +47,6 @@
 static const char driver_version_format[] = "SD878x-%s-%s-WM";
 static const char driver_version[]        = "702.1.0";
 
-static unsigned int mgmt_ie_index_bitmap = 0x0000000F;
-
 #if (CONFIG_11MC) || (CONFIG_11AZ) || (CONFIG_CSI)
 #if (CONFIG_11MC) || (CONFIG_11AZ)
 ftm_start_param ftm_param;
@@ -249,6 +247,7 @@ int wifi_reg_access(wifi_reg_t reg_type, uint16_t action, uint32_t offset, uint3
     mlan_ds_reg_rw reg_rw;
     reg_rw.offset = offset;
     reg_rw.value  = *value;
+    reg_rw.type = (t_u32)reg_type;
     uint16_t hostcmd;
     int ret = WM_SUCCESS;
     switch (reg_type)
@@ -264,6 +263,15 @@ int wifi_reg_access(wifi_reg_t reg_type, uint16_t action, uint32_t offset, uint3
             break;
         case REG_CAU:
             hostcmd = HostCmd_CMD_CAU_REG_ACCESS;
+            break;
+        case REG_PSU:
+            hostcmd = HostCmd_CMD_TARGET_ACCESS;
+            break;
+        case REG_BCA:
+            hostcmd = HostCmd_CMD_BCA_REG_ACCESS;
+            break;
+        case REG_CIU:
+            hostcmd = HostCmd_CMD_REG_ACCESS;
             break;
         default:
             wifi_e("Incorrect register type");
@@ -2675,26 +2683,22 @@ int wifi_send_sched_scan_cmd(nxp_wifi_trigger_sched_scan_t *params)
         }
     }
 
-    if (pmpriv->probe_req_index != -1)
+    if (pmpriv->probe_req_index != MLAN_MGMT_IE_INVALID_IDX && params->extra_ies.ie_len == 0U)
     {
-        ret = wifi_clear_mgmt_ie2(MLAN_BSS_TYPE_STA, pmpriv->probe_req_index);
-
+        ret = wifi_mgmt_ie_clear(pmpriv, &pmpriv->probe_req_index);
         if (ret != WM_SUCCESS)
         {
-            wifi_e("Clear probe req IE failed");
+            wuap_e("Clear probereq IE failed");
             return -WM_FAIL;
         }
-        pmpriv->probe_req_index = -1;
     }
 
-    if (params->extra_ies.ie_len)
+    if (params->extra_ies.ie_len != 0U)
     {
-        pmpriv->probe_req_index = wifi_set_mgmt_ie2(MLAN_BSS_TYPE_STA, MGMT_MASK_PROBE_REQ,
-                                                    (void *)params->extra_ies.ie, params->extra_ies.ie_len);
-
-        if (pmpriv->probe_req_index == -1)
+        ret = wifi_mgmt_ie_set(pmpriv, MGMT_MASK_PROBE_REQ, (t_u8 *)params->extra_ies.ie, params->extra_ies.ie_len, &pmpriv->probe_req_index);
+        if (ret != WM_SUCCESS)
         {
-            wifi_e("Set probe req IE failed");
+            wifi_e("Set probereq IE failed");
             return -WM_FAIL;
         }
     }
@@ -3922,36 +3926,6 @@ bool wifi_is_ecsa_enabled(void)
     return mlan_adap->ecsa_enable;
 }
 
-static int get_free_mgmt_ie_index(unsigned int *mgmt_ie_index)
-{
-    unsigned int idx;
-
-    for (idx = 0; idx < 32; idx++)
-    {
-        if ((mgmt_ie_index_bitmap & MBIT((t_u32)idx)) == 0U)
-        {
-            *mgmt_ie_index = idx;
-            return WM_SUCCESS;
-        }
-    }
-    return -WM_FAIL;
-}
-
-static void set_ie_index(unsigned int index)
-{
-    mgmt_ie_index_bitmap |= (MBIT(index));
-}
-
-static void clear_ie_index(unsigned int index)
-{
-    mgmt_ie_index_bitmap &= ~(MBIT(index));
-}
-
-unsigned int get_ie_index()
-{
-    return mgmt_ie_index_bitmap;
-}
-
 #ifdef SD8801
 static int wifi_config_ext_coex(int action,
                                 const wifi_ext_coex_config_t *ext_coex_config,
@@ -3995,354 +3969,6 @@ static int wifi_config_ext_coex(int action,
     return ret;
 }
 #endif
-
-static bool ie_index_is_set(unsigned int index)
-{
-    return (mgmt_ie_index_bitmap & (MBIT(index))) ? MTRUE : MFALSE;
-}
-
-void reset_ie_index()
-{
-    mgmt_ie_index_bitmap = 0x0000000F;
-}
-
-static int wifi_config_mgmt_ie(mlan_bss_type bss_type,
-                               t_u16 action,
-                               IEEEtypes_ElementId_t index,
-                               void *buffer,
-                               unsigned int *ie_len,
-                               int mgmt_bitmap_index)
-{
-    uint8_t *buf, *pos;
-    IEEEtypes_Header_t *ptlv_header = NULL;
-    uint16_t buf_len                = 0;
-    tlvbuf_custom_ie *tlv           = NULL;
-    custom_ie *ie_ptr               = NULL;
-    unsigned int mgmt_ie_index      = -1;
-    int total_len =
-        sizeof(tlvbuf_custom_ie) + 2U * (sizeof(custom_ie) - MAX_IE_SIZE) + sizeof(IEEEtypes_Header_t) + *ie_len;
-    int ret = WM_SUCCESS;
-
-#if !CONFIG_MEM_POOLS
-    buf = (uint8_t *)OSA_MemoryAllocate(total_len);
-#else
-    buf = OSA_MemoryPoolAllocate(buf_512_MemoryPool);
-#endif
-    if (buf == MNULL)
-    {
-        wifi_e("Cannot allocate memory");
-        return -WM_FAIL;
-    }
-
-    (void)memset(buf, 0, total_len);
-
-    tlv       = (tlvbuf_custom_ie *)(void *)buf;
-    tlv->type = MRVL_MGMT_IE_LIST_TLV_ID;
-
-    /* Locate headers */
-    ie_ptr = (custom_ie *)(tlv->ie_data);
-    /* Set TLV fields */
-    buf_len = sizeof(tlvbuf_custom_ie);
-
-    if (action == HostCmd_ACT_GEN_SET)
-    {
-        if (*ie_len == 0U)
-        {
-            /*
-               MGMT_WPA_IE = MGMT_VENDOR_SPECIFIC_221
-               MGMT_WPS_IE = MGMT_VENDOR_SPECIFIC_221
-               */
-
-            if (!ie_index_is_set(mgmt_bitmap_index))
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree(buf);
-#else
-                OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-                return -WM_FAIL;
-            }
-
-            ie_ptr->mgmt_subtype_mask = MGMT_MASK_CLEAR;
-            ie_ptr->ie_length         = 0;
-            ie_ptr->ie_index          = (t_u16)mgmt_bitmap_index;
-
-            tlv->length = sizeof(custom_ie) - MAX_IE_SIZE;
-            buf_len += tlv->length;
-            clear_ie_index(mgmt_bitmap_index);
-        }
-        else
-        {
-            ret = get_free_mgmt_ie_index(&mgmt_ie_index);
-
-            if (WM_SUCCESS != ret)
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree(buf);
-#else
-                OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-                return -WM_FAIL;
-            }
-
-            pos         = ie_ptr->ie_buffer;
-            ptlv_header = (IEEEtypes_Header_t *)(void *)pos;
-            pos += sizeof(IEEEtypes_Header_t);
-
-            ptlv_header->element_id = (IEEEtypes_ElementId_e)index;
-            ptlv_header->len        = *ie_len;
-            if (bss_type == MLAN_BSS_TYPE_UAP)
-            {
-                ie_ptr->mgmt_subtype_mask =
-                    MGMT_MASK_BEACON | MGMT_MASK_PROBE_RESP | MGMT_MASK_ASSOC_RESP | MGMT_MASK_REASSOC_RESP;
-            }
-            else if (bss_type == MLAN_BSS_TYPE_STA)
-            {
-                ie_ptr->mgmt_subtype_mask = MGMT_MASK_PROBE_REQ | MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ;
-            }
-            else
-            { /* Do Nothing */
-            }
-
-            tlv->length       = sizeof(custom_ie) + sizeof(IEEEtypes_Header_t) + *ie_len - MAX_IE_SIZE;
-            ie_ptr->ie_length = sizeof(IEEEtypes_Header_t) + *ie_len;
-            ie_ptr->ie_index  = mgmt_ie_index;
-
-            buf_len += tlv->length;
-
-            (void)memcpy((void *)pos, (const void *)buffer, *ie_len);
-        }
-    }
-    else if (action == HostCmd_ACT_GEN_GET)
-    {
-        /* Get WPS IE */
-        tlv->length = 0;
-    }
-    else
-    { /* Do Nothing */
-    }
-
-    mlan_status rv = wrapper_wlan_cmd_mgmt_ie(bss_type, buf, buf_len, action);
-
-    if (rv != MLAN_STATUS_SUCCESS && rv != MLAN_STATUS_PENDING)
-    {
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
-    }
-
-    if (action == HostCmd_ACT_GEN_GET)
-    {
-        if (wm_wifi.cmd_resp_status != 0)
-        {
-            wifi_w("Unable to get mgmt ie buffer");
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree(buf);
-#else
-            OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-            return wm_wifi.cmd_resp_status;
-        }
-        ie_ptr = (custom_ie *)(void *)(buf);
-        (void)memcpy((void *)buffer, (const void *)ie_ptr->ie_buffer, ie_ptr->ie_length);
-        *ie_len = ie_ptr->ie_length;
-    }
-#if !CONFIG_MEM_POOLS
-    OSA_MemoryFree(buf);
-#else
-    OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-
-    if ((action == HostCmd_ACT_GEN_SET) && *ie_len)
-    {
-        set_ie_index(mgmt_ie_index);
-        return mgmt_ie_index;
-    }
-    else
-    {
-        return WM_SUCCESS;
-    }
-}
-
-int wifi_get_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t index, void *buf, unsigned int *buf_len)
-{
-    return wifi_config_mgmt_ie(bss_type, HostCmd_ACT_GEN_GET, index, buf, buf_len, 0);
-}
-
-int wifi_set_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t id, void *buf, unsigned int buf_len)
-{
-    unsigned int data_len = buf_len;
-
-    return wifi_config_mgmt_ie(bss_type, HostCmd_ACT_GEN_SET, id, buf, &data_len, 0);
-}
-
-int wifi_clear_mgmt_ie(mlan_bss_type bss_type, IEEEtypes_ElementId_t index, int mgmt_bitmap_index)
-{
-    unsigned int data_len = 0;
-    return wifi_config_mgmt_ie(bss_type, HostCmd_ACT_GEN_SET, index, NULL, &data_len, mgmt_bitmap_index);
-}
-
-static int wifi_config_mgmt_ie2(
-    mlan_bss_type bss_type, t_u16 action, t_u16 mask, void *buffer, unsigned int *ie_len, int mgmt_bitmap_index)
-{
-    uint8_t *buf;
-    uint16_t buf_len           = 0;
-    tlvbuf_custom_ie *tlv      = NULL;
-    custom_ie *ie_ptr          = NULL;
-    unsigned int mgmt_ie_index = -1;
-    int total_len              = sizeof(tlvbuf_custom_ie) + (sizeof(custom_ie) - MAX_IE_SIZE) + *ie_len;
-    int ret                    = WM_SUCCESS;
-
-#if !CONFIG_MEM_POOLS
-    buf = (uint8_t *)OSA_MemoryAllocate(total_len);
-#else
-    buf = OSA_MemoryPoolAllocate(buf_512_MemoryPool);
-#endif
-    if (buf == MNULL)
-    {
-        wifi_e("Cannot allocate memory");
-        return -WM_FAIL;
-    }
-
-    (void)memset(buf, 0, total_len);
-
-    tlv       = (tlvbuf_custom_ie *)(void *)buf;
-    tlv->type = MRVL_MGMT_IE_LIST_TLV_ID;
-
-    /* Locate headers */
-    ie_ptr = (custom_ie *)(tlv->ie_data);
-    /* Set TLV fields */
-    buf_len = sizeof(tlvbuf_custom_ie);
-
-    if (action == HostCmd_ACT_GEN_SET)
-    {
-        if (*ie_len == 0U)
-        {
-            /*
-               MGMT_WPA_IE = MGMT_VENDOR_SPECIFIC_221
-               MGMT_WPS_IE = MGMT_VENDOR_SPECIFIC_221
-               */
-
-            if (!ie_index_is_set(mgmt_bitmap_index))
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree(buf);
-#else
-                OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-                return -WM_FAIL;
-            }
-
-            ie_ptr->mgmt_subtype_mask = MGMT_MASK_CLEAR;
-            ie_ptr->ie_length         = 0;
-            ie_ptr->ie_index          = (t_u16)mgmt_bitmap_index;
-
-            tlv->length = sizeof(custom_ie) - MAX_IE_SIZE;
-            buf_len += tlv->length;
-            clear_ie_index(mgmt_bitmap_index);
-        }
-        else
-        {
-            ret = get_free_mgmt_ie_index(&mgmt_ie_index);
-
-            if (WM_SUCCESS != ret)
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree(buf);
-#else
-                OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-                return -WM_FAIL;
-            }
-
-            tlv->length      = (sizeof(custom_ie) - MAX_IE_SIZE) + *ie_len;
-            ie_ptr->ie_index = mgmt_ie_index;
-
-            ie_ptr->mgmt_subtype_mask = mask;
-
-            ie_ptr->ie_length = *ie_len;
-
-            buf_len += tlv->length;
-
-            (void)memcpy((void *)&ie_ptr->ie_buffer, (const void *)buffer, *ie_len);
-        }
-    }
-    else if (action == HostCmd_ACT_GEN_GET)
-    {
-        /* Get WPS IE */
-        tlv->length = 0;
-    }
-    else
-    { /* Do Nothing */
-    }
-
-    mlan_status rv = wrapper_wlan_cmd_mgmt_ie(bss_type, buf, buf_len, action);
-
-    if (rv != MLAN_STATUS_SUCCESS && rv != MLAN_STATUS_PENDING)
-    {
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
-    }
-
-    if (action == HostCmd_ACT_GEN_GET)
-    {
-        if (wm_wifi.cmd_resp_status != 0)
-        {
-            wifi_w("Unable to get mgmt ie buffer");
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree(buf);
-#else
-            OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-            return wm_wifi.cmd_resp_status;
-        }
-        ie_ptr = (custom_ie *)(void *)(buf);
-        (void)memcpy((void *)buffer, (const void *)ie_ptr->ie_buffer, ie_ptr->ie_length);
-        *ie_len = ie_ptr->ie_length;
-    }
-
-#if !CONFIG_MEM_POOLS
-    OSA_MemoryFree(buf);
-#else
-    OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-
-    if ((action == HostCmd_ACT_GEN_SET) && *ie_len)
-    {
-        set_ie_index(mgmt_ie_index);
-        return mgmt_ie_index;
-    }
-    else
-    {
-        return WM_SUCCESS;
-    }
-}
-
-int wifi_get_mgmt_ie2(mlan_bss_type bss_type, void *buf, unsigned int *buf_len)
-{
-    return wifi_config_mgmt_ie2(bss_type, HostCmd_ACT_GEN_GET, 0, buf, buf_len, 0);
-}
-
-int wifi_set_mgmt_ie2(mlan_bss_type bss_type, unsigned short mask, void *buf, unsigned int buf_len)
-{
-    unsigned int data_len = buf_len;
-
-    return wifi_config_mgmt_ie2(bss_type, HostCmd_ACT_GEN_SET, mask, buf, &data_len, 0);
-}
-
-int wifi_clear_mgmt_ie2(mlan_bss_type bss_type, int mgmt_bitmap_index)
-{
-    unsigned int data_len = 0;
-
-    return wifi_config_mgmt_ie2(bss_type, HostCmd_ACT_GEN_SET, 0, NULL, &data_len, mgmt_bitmap_index);
-}
 
 int wifi_get_mgmt_ie_by_index(mlan_bss_type bss_type, void *buf, unsigned int *buf_len, int index)
 {
@@ -4417,92 +4043,6 @@ int wifi_set_ext_coex_config(const wifi_ext_coex_config_t *ext_coex_config)
 #endif
 
 #if CONFIG_WPA_SUPP
-#if UAP_SUPPORT
-int wifi_set_custom_ie(custom_ie *beacon_ies_data,
-                       custom_ie *beacon_wps_ies_data,
-                       custom_ie *proberesp_ies_data,
-                       custom_ie *assocresp_ies_data)
-{
-    mlan_ds_misc_custom_ie *pcustom_ie = NULL;
-    t_u8 *pos                          = NULL;
-    t_u16 len                          = 0;
-    mlan_status status                 = MLAN_STATUS_SUCCESS;
-    t_u32 remain_len                   = 0;
-    HostCmd_DS_COMMAND *cmd            = NULL;
-
-    ENTER();
-
-    pcustom_ie = OSA_MemoryAllocate(sizeof(mlan_ds_misc_custom_ie));
-    if (!pcustom_ie)
-    {
-        PRINTM(MERROR, "Fail to allocate custome_ie\n");
-        status = MLAN_STATUS_FAILURE;
-        goto done;
-    }
-
-    pcustom_ie->type = TLV_TYPE_MGMT_IE;
-
-    pos        = (t_u8 *)pcustom_ie->ie_data_list;
-    remain_len = sizeof(pcustom_ie->ie_data_list);
-    if (beacon_ies_data)
-    {
-        len = sizeof(*beacon_ies_data) - MAX_IE_SIZE + beacon_ies_data->ie_length;
-        memcpy(pos, beacon_ies_data, len);
-        pos += len;
-        remain_len -= len;
-        pcustom_ie->len += len;
-    }
-
-    if (beacon_wps_ies_data)
-    {
-        len = sizeof(*beacon_wps_ies_data) - MAX_IE_SIZE + beacon_wps_ies_data->ie_length;
-        memcpy(pos, beacon_wps_ies_data, len);
-        pos += len;
-        remain_len -= len;
-        pcustom_ie->len += len;
-    }
-
-    if (proberesp_ies_data)
-    {
-        len = sizeof(*proberesp_ies_data) - MAX_IE_SIZE + proberesp_ies_data->ie_length;
-        memcpy(pos, proberesp_ies_data, len);
-        pos += len;
-        remain_len -= len;
-        pcustom_ie->len += len;
-    }
-
-    if (assocresp_ies_data)
-    {
-        len = sizeof(*assocresp_ies_data) - MAX_IE_SIZE + assocresp_ies_data->ie_length;
-        memcpy(pos, assocresp_ies_data, len);
-        pos += len;
-        remain_len -= len;
-        pcustom_ie->len += len;
-    }
-
-    (void)wifi_get_command_lock();
-
-    cmd = wifi_get_command_buffer();
-
-    (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
-
-    cmd->seq_num = HostCmd_SET_SEQ_NO_BSS_INFO(0U /* seq_num */, 0U /* bss_num */, MLAN_BSS_TYPE_UAP);
-
-    cmd->result = 0x0;
-
-    status = wlan_ops_uap_prepare_cmd((mlan_private *)mlan_adap->priv[1], HOST_CMD_APCMD_SYS_CONFIGURE,
-                                      HostCmd_ACT_GEN_SET, 0, NULL, (void *)pcustom_ie, cmd);
-
-    (void)wifi_wait_for_cmdresp(NULL);
-
-    OSA_MemoryFree(pcustom_ie);
-
-done:
-    LEAVE();
-    return status;
-}
-#endif
-
 void wifi_get_scan_table(mlan_private *pmpriv, mlan_scan_resp *pscan_resp)
 {
     mlan_adapter *pmadapter = pmpriv->adapter;
@@ -5060,11 +4600,14 @@ int wifi_host_11k_cfg(int enable_11k)
 #if !CONFIG_WPA_SUPP
     if (enable_11k == 1)
     {
-        if (pmpriv->rrm_mgmt_bitmap_index != -1)
+        if (pmpriv->rrm_mgmt_bitmap_index != MLAN_MGMT_IE_INVALID_IDX)
         {
-            ret = wifi_clear_mgmt_ie(MLAN_BSS_TYPE_STA, MGMT_RRM_ENABLED_CAP, pmpriv->rrm_mgmt_bitmap_index);
-
-            pmpriv->rrm_mgmt_bitmap_index = -1;
+            ret = wifi_mgmt_ie_clear(pmpriv, &pmpriv->rrm_mgmt_bitmap_index);
+            if (ret != (int)MLAN_STATUS_SUCCESS)
+            {
+                wifi_e("Failed to clear RRM IE");
+                return ret;
+            }
         }
         rrmCap.element_id = (t_u8)MGMT_RRM_ENABLED_CAP;
         rrmCap.len        = (t_u8)sizeof(IEEEtypes_RrmEnabledCapabilities_t);
@@ -5133,14 +4676,21 @@ int wifi_host_mbo_cfg(int enable_mbo)
         pos                       = wlan_add_mbo_cellular_cap(pos);
         meas_vend_hdr_len         = pos - mboie.vend_hdr.oui;
         mboie.vend_hdr.len        = (t_u8)meas_vend_hdr_len;
-        pmpriv->mbo_mgmt_bitmap_index =
-            wifi_set_mgmt_ie(MLAN_BSS_TYPE_STA, MGMT_MBO_IE, (void *)&(mboie.vend_hdr.oui), mboie.vend_hdr.len);
+        ret = wifi_mgmt_ie_set(pmpriv, MGMT_MASK_PROBE_REQ | MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ,
+                               (t_u8 *)&mboie, meas_vend_hdr_len + sizeof(IEEEtypes_Header_t), &pmpriv->mbo_index);
     }
     else
     {
-        ret = wifi_clear_mgmt_ie(MLAN_BSS_TYPE_STA, MGMT_MBO_IE, pmpriv->mbo_mgmt_bitmap_index);
+        if (pmpriv->mbo_index != MLAN_MGMT_IE_INVALID_IDX)
+        {
+            ret = wifi_mgmt_ie_clear(pmpriv, &pmpriv->mbo_index);
+        }
     }
-    pmpriv->enable_mbo = (t_u8)enable_mbo;
+
+    if (ret == MLAN_STATUS_SUCCESS)
+    {
+        pmpriv->enable_mbo = (t_u8)enable_mbo;
+    }
 
     return ret;
 }
@@ -5162,7 +4712,6 @@ int wifi_mbo_preferch_cfg(t_u8 ch0, t_u8 pefer0, t_u8 ch1, t_u8 pefer1)
     if (pmpriv->enable_mbo != 0U)
     {
         /* remove MBO OCE IE in case there is already a MBO OCE IE. */
-        ret                       = wifi_clear_mgmt_ie(MLAN_BSS_TYPE_STA, MGMT_MBO_IE, pmpriv->mbo_mgmt_bitmap_index);
         mboie.vend_hdr.element_id = (IEEEtypes_ElementId_e)MGMT_MBO_IE;
         pos                       = mboie.vend_hdr.oui;
         pos                       = wlan_add_mbo_oui(pos);
@@ -5171,8 +4720,8 @@ int wifi_mbo_preferch_cfg(t_u8 ch0, t_u8 pefer0, t_u8 ch1, t_u8 pefer1)
         pos                       = wlan_add_mbo_prefer_ch(pos, ch0, pefer0, ch1, pefer1);
         meas_vend_hdr_len         = pos - mboie.vend_hdr.oui;
         mboie.vend_hdr.len        = (t_u8)meas_vend_hdr_len;
-        pmpriv->mbo_mgmt_bitmap_index =
-            wifi_set_mgmt_ie(MLAN_BSS_TYPE_STA, MGMT_MBO_IE, (void *)&(mboie.vend_hdr.oui), mboie.vend_hdr.len);
+        ret = wifi_mgmt_ie_set(pmpriv, MGMT_MASK_PROBE_REQ | MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ,
+                               (t_u8 *)&mboie, meas_vend_hdr_len + sizeof(IEEEtypes_Header_t), &pmpriv->mbo_index);
     }
 
     return ret;
@@ -5932,7 +5481,6 @@ int wifi_set_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_
 {
     IEEEtypes_ExtChanSwitchAnn_t *ext_chan_switch = NULL;
     IEEEtypes_ChanSwitchAnn_t *chan_switch        = NULL;
-    custom_ie *pcust_chansw_ie                    = NULL;
     t_u32 usr_dot_11n_dev_cap                     = 0;
     mlan_private *pmpriv                          = (mlan_private *)mlan_adap->priv[1];
     BSSDescriptor_t *pbss_desc;
@@ -5946,54 +5494,40 @@ int wifi_set_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_
     IEEEtypes_WideBWChanSwitch_t *pbwchansw_ie = NULL;
     IEEEtypes_VhtTpcEnvelope_t *pvhttpcEnv_ie  = NULL;
 #endif
-    uint8_t *buf               = NULL;
-    tlvbuf_custom_ie *tlv      = NULL;
-    unsigned int mgmt_ie_index = -1;
-    int total_len = sizeof(tlvbuf_custom_ie) + (sizeof(custom_ie) - MAX_IE_SIZE) + sizeof(IEEEtypes_ChanSwitchAnn_t) +
-                    sizeof(IEEEtypes_ExtChanSwitchAnn_t);
+    t_u16 ecsa_mgmt_ie_index = MLAN_MGMT_IE_INVALID_IDX;
+    t_u8 *ie_buf = NULL;
+    t_u8 *pos    = NULL;
+    int total_len = sizeof(IEEEtypes_ChanSwitchAnn_t) + sizeof(IEEEtypes_ExtChanSwitchAnn_t);
 #if (CONFIG_11AC)
     total_len += sizeof(IEEEtypes_WideBWChanSwitch_t) + sizeof(IEEEtypes_VhtTpcEnvelope_t) + sizeof(IEEEtypes_Header_t);
 #endif
-    uint16_t buf_len = 0;
+    t_u16 ie_len = 0;
 
 #if !CONFIG_MEM_POOLS
-    buf = (uint8_t *)OSA_MemoryAllocate(total_len);
+    ie_buf = (uint8_t *)OSA_MemoryAllocate(total_len);
 #else
-    buf = OSA_MemoryPoolAllocate(buf_1024_MemoryPool);
+    ie_buf = OSA_MemoryPoolAllocate(buf_1024_MemoryPool);
 #endif
-    if (!buf)
+    if (!ie_buf)
     {
         wifi_e("ECSA allocate memory failed \r\n");
         return -WM_FAIL;
     }
 
-    (void)memset(buf, 0, total_len);
-    tlv       = (tlvbuf_custom_ie *)buf;
-    tlv->type = MRVL_MGMT_IE_LIST_TLV_ID;
+    (void)memset(ie_buf, 0, total_len);
 
-    ret = get_free_mgmt_ie_index(&mgmt_ie_index);
-    if (WM_SUCCESS != ret)
-    {
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_1024_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
-    }
+    pos = ie_buf;
 
-    pcust_chansw_ie                    = (custom_ie *)(tlv->ie_data);
-    pcust_chansw_ie->ie_index          = mgmt_ie_index;
-    pcust_chansw_ie->ie_length         = sizeof(IEEEtypes_ChanSwitchAnn_t);
-    pcust_chansw_ie->mgmt_subtype_mask = MGMT_MASK_BEACON | MGMT_MASK_PROBE_RESP; /*Add IE for
-                                                                 BEACON/probe resp*/
-    chan_switch                    = (IEEEtypes_ChanSwitchAnn_t *)pcust_chansw_ie->ie_buffer;
+    chan_switch                    = (IEEEtypes_ChanSwitchAnn_t *)pos;
     chan_switch->element_id        = CHANNEL_SWITCH_ANN;
     chan_switch->len               = 3;
     chan_switch->chan_switch_mode  = block_tx;
     chan_switch->new_channel_num   = channel;
     chan_switch->chan_switch_count = switch_count;
-    DBG_HEXDUMP(MCMD_D, "CSA IE", (t_u8 *)pcust_chansw_ie->ie_buffer, pcust_chansw_ie->ie_length);
+
+    pos += sizeof(IEEEtypes_ChanSwitchAnn_t);
+
+    DBG_HEXDUMP(MCMD_D, "CSA IE", (t_u8 *)chan_switch, sizeof(IEEEtypes_ChanSwitchAnn_t));
 
 #if CONFIG_5GHz_SUPPORT
     if (pbss_desc->bss_band & BAND_A)
@@ -6031,17 +5565,16 @@ int wifi_set_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_
 
     if (new_oper_class)
     {
-        pcust_chansw_ie->ie_length += sizeof(IEEEtypes_ExtChanSwitchAnn_t);
-        ext_chan_switch =
-            (IEEEtypes_ExtChanSwitchAnn_t *)(pcust_chansw_ie->ie_buffer + sizeof(IEEEtypes_ChanSwitchAnn_t));
+        ext_chan_switch                    = (IEEEtypes_ExtChanSwitchAnn_t *)pos;
         ext_chan_switch->element_id        = EXTEND_CHANNEL_SWITCH_ANN;
         ext_chan_switch->len               = 4;
         ext_chan_switch->chan_switch_mode  = block_tx;
         ext_chan_switch->new_oper_class    = new_oper_class;
         ext_chan_switch->new_channel_num   = channel;
         ext_chan_switch->chan_switch_count = switch_count;
-        DBG_HEXDUMP(MCMD_D, "ECSA IE", (t_u8 *)(pcust_chansw_ie->ie_buffer + sizeof(IEEEtypes_ChanSwitchAnn_t)),
-                    pcust_chansw_ie->ie_length - sizeof(IEEEtypes_ChanSwitchAnn_t));
+        pos += sizeof(IEEEtypes_ExtChanSwitchAnn_t);
+
+        DBG_HEXDUMP(MCMD_D, "ECSA IE", (t_u8 *)ext_chan_switch, sizeof(IEEEtypes_ExtChanSwitchAnn_t));
     }
 
 #if (CONFIG_11AC)
@@ -6049,7 +5582,7 @@ int wifi_set_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_
      * channel*/
     if (band_width && channel > 14)
     {
-        pChanSwWrap_ie             = (IEEEtypes_Header_t *)(pcust_chansw_ie->ie_buffer + pcust_chansw_ie->ie_length);
+        pChanSwWrap_ie             = (IEEEtypes_Header_t *)pos;
         pChanSwWrap_ie->element_id = EXT_POWER_CONSTR;
         pChanSwWrap_ie->len        = sizeof(IEEEtypes_WideBWChanSwitch_t);
 
@@ -6090,72 +5623,50 @@ int wifi_set_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_
         pvhttpcEnv_ie->local_max_tp_80mhz           = 0xff;
         pvhttpcEnv_ie->local_max_tp_160mhz_80_80mhz = 0xff;
         pChanSwWrap_ie->len += sizeof(IEEEtypes_VhtTpcEnvelope_t);
-        pcust_chansw_ie->ie_length += pChanSwWrap_ie->len + sizeof(IEEEtypes_Header_t);
+
+        pos += sizeof(IEEEtypes_Header_t) + pChanSwWrap_ie->len;
+
         DBG_HEXDUMP(MCMD_D, "Channel switch wrapper IE", (t_u8 *)pChanSwWrap_ie,
                     pChanSwWrap_ie->len + sizeof(IEEEtypes_Header_t));
     }
 #endif
-    tlv->length = sizeof(custom_ie) + pcust_chansw_ie->ie_length - MAX_IE_SIZE;
+    ie_len = pos - ie_buf;
 
-    buf_len = pcust_chansw_ie->ie_length + sizeof(tlvbuf_custom_ie) + sizeof(custom_ie) - MAX_IE_SIZE;
-
-    ret = wrapper_wlan_cmd_mgmt_ie(MLAN_BSS_TYPE_UAP, buf, buf_len, HostCmd_ACT_GEN_SET);
+    ret = wifi_mgmt_ie_set(mlan_adap->priv[1], MGMT_MASK_BEACON | MGMT_MASK_PROBE_RESP, ie_buf, ie_len, &ecsa_mgmt_ie_index);
     if (ret != MLAN_STATUS_SUCCESS && ret != MLAN_STATUS_PENDING)
     {
         wifi_e("Failed to set ECSA IE");
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_1024_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
+        ret = -WM_FAIL;
+        goto done;
     }
-    set_ie_index(mgmt_ie_index);
 
     OSA_TimeDelay((switch_count + 2) * wm_wifi.beacon_period);
     set_ecsa_block_tx_flag(false);
 
-    if (!ie_index_is_set(mgmt_ie_index))
-    {
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_1024_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
-    }
-
     /*Clear ECSA ie*/
-    (void)memset(buf, 0, total_len);
-    tlv         = (tlvbuf_custom_ie *)buf;
-    tlv->type   = MRVL_MGMT_IE_LIST_TLV_ID;
-    tlv->length = sizeof(custom_ie) - MAX_IE_SIZE;
-
-    pcust_chansw_ie->mgmt_subtype_mask = MGMT_MASK_CLEAR;
-    pcust_chansw_ie->ie_length         = 0;
-    pcust_chansw_ie->ie_index          = mgmt_ie_index;
-    buf_len                            = sizeof(tlvbuf_custom_ie) + tlv->length;
-
-    ret = wrapper_wlan_cmd_mgmt_ie(MLAN_BSS_TYPE_UAP, buf, buf_len, HostCmd_ACT_GEN_SET);
-    if (ret != MLAN_STATUS_SUCCESS && ret != MLAN_STATUS_PENDING)
+    if (ecsa_mgmt_ie_index != MLAN_MGMT_IE_INVALID_IDX)
     {
-        wifi_e("Failed to clear ECSA IE");
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_1024_MemoryPool, buf);
-#endif
-        return -WM_FAIL;
+        (void)memset(ie_buf, 0, total_len);
+        ret = wifi_mgmt_ie_clear(mlan_adap->priv[1], &ecsa_mgmt_ie_index);
+        if (ret != MLAN_STATUS_SUCCESS && ret != MLAN_STATUS_PENDING)
+        {
+            wifi_e("Failed to clear ECSA IE");
+            ret = -WM_FAIL;
+            goto done;
+        }
     }
-    clear_ie_index(mgmt_ie_index);
 
+done:
+    if (ie_buf != NULL)
+    {
 #if !CONFIG_MEM_POOLS
-    OSA_MemoryFree(buf);
+        OSA_MemoryFree(ie_buf);
 #else
-    OSA_MemoryPoolFree(buf_1024_MemoryPool, buf);
+        OSA_MemoryPoolFree(buf_1024_MemoryPool, ie_buf);
 #endif
+    }
 
-    return WM_SUCCESS;
+    return ret;
 }
 
 int wifi_set_action_ecsa_cfg(t_u8 block_tx, t_u8 oper_class, t_u8 channel, t_u8 switch_count)

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_cmdevt.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_cmdevt.c
@@ -984,6 +984,7 @@ mlan_status wlan_cmd_txrx_histogram(pmlan_private pmpriv, IN HostCmd_DS_COMMAND 
     cmd->command      = wlan_cpu_to_le16(HostCmd_CMD_TX_RX_PKT_STATS);
     histogram->action = cfg->action;
     histogram->enable = cfg->enable;
+    cmd->seq_num      = HostCmd_SET_SEQ_NO_BSS_INFO(0U /* seq_num */, 0U /* bss_num */, pmpriv->bss_type);
     cmd->size         = wlan_cpu_to_le16(S_DS_GEN + sizeof(HostCmd_DS_TX_RX_HISTOGRAM));
 
     LEAVE();
@@ -1194,6 +1195,29 @@ mlan_status wlan_ret_get_hw_spec(IN pmlan_private pmpriv, IN HostCmd_DS_COMMAND 
     for (i = 1; i <= (unsigned)(MAX_PORT - pmadapter->mp_end_port); i++)
     {
         pmadapter->mp_data_port_mask &= ~(1U << (MAX_PORT - i));
+    }
+#endif
+
+    pmadapter->max_mgmt_buf_count = wlan_le16_to_cpu(hw_spec->mgmt_buf_count);
+    PRINTM(MCMND, "GET_HW_SPEC: mgmt IE count=%d\n", pmadapter->max_mgmt_buf_count);
+    if (!pmadapter->max_mgmt_buf_count || pmadapter->max_mgmt_buf_count > MAX_MGMT_IE_FW_INDEX)
+    {
+        pmadapter->max_mgmt_buf_count = MAX_MGMT_IE_FW_INDEX;
+    }
+#if 0
+    pmadapter->mgmt_ie_cnt_sm = wlan_le16_to_cpu(hw_spec->mgmt_buf_cnt_sm);
+    pmadapter->mgmt_ie_cnt_md = wlan_le16_to_cpu(hw_spec->mgmt_buf_cnt_md);
+    pmadapter->mgmt_ie_cnt_lg = wlan_le16_to_cpu(hw_spec->mgmt_buf_cnt_lg);
+    if (pmadapter->mgmt_ie_cnt_sm +
+        pmadapter->mgmt_ie_cnt_md +
+        pmadapter->mgmt_ie_cnt_lg != pmadapter->max_mgmt_buf_count)
+    {
+        PRINTM(MWARN, "GET_HW_SPEC: mgmt IE count mismatch (sm %d + md %d + lg %d != total %d)\n",
+               pmadapter->mgmt_ie_cnt_sm, pmadapter->mgmt_ie_cnt_md, pmadapter->mgmt_ie_cnt_lg,
+               pmadapter->max_mgmt_buf_count);
+        pmadapter->mgmt_ie_cnt_sm = MLAN_MGMT_BUF_SM_CNT;
+        pmadapter->mgmt_ie_cnt_md = MLAN_MGMT_BUF_MD_CNT;
+        pmadapter->mgmt_ie_cnt_lg = MLAN_MGMT_BUF_LG_CNT;
     }
 #endif
 
@@ -2257,7 +2281,7 @@ mlan_status wlan_process_vdll_event(pmlan_private pmpriv, t_u8 *pevent)
 }
 #endif /* CONFIG_FW_VDLL */
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /**
  *  @brief This function prepares command of independent reset.
  *

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
@@ -172,8 +172,6 @@ int wrapper_wlan_set_regiontable(t_u8 region, t_u16 band);
 int wrapper_wlan_handle_rx_packet(t_u16 datalen, RxPD *rxpd, void *p, void *payload);
 int wrapper_get_wpa_ie_in_assoc(uint8_t *wpa_ie);
 
-int wlan_process_hang(uint8_t fw_reload);
-
 #if CONFIG_11N
 /*
  * The command event received from the firmware (e.g. EVENT_ADDBA) cannot
@@ -1915,7 +1913,7 @@ int wlan_set_uap_coutry_regd_by_conn_bss(pmlan_private priv, BSSDescriptor_t *d)
     t_u32 country_ie_len = 0;
     int ret = WM_SUCCESS;
 
-	wifi_d("%s: Enter", __FUNCTION__);
+    wifi_d("%s: Enter", __FUNCTION__);
 
     if (mlan_adap->priv[1]->uap_bss_started != MTRUE)
     {
@@ -1937,157 +1935,16 @@ int wlan_set_uap_coutry_regd_by_conn_bss(pmlan_private priv, BSSDescriptor_t *d)
         wifi_io_dump_hex(&(d->country_info), country_ie_len + 2U);
     }
 
-    if (country_ie_len > 0)
+    if (country_ie_len == 0)
     {
-        uint8_t *buf = NULL;
-        uint8_t *buf_ptr = NULL;
-        unsigned int buf_len = MAX_CUSTOM_IE_LEN;
-        int buf_len_left = 0;
-        uint8_t *buf_new = NULL;
-        uint8_t *buf_new_ptr = NULL;
-        unsigned int buf_new_len = MAX_CUSTOM_IE_LEN;
-        unsigned short mask = MGMT_MASK_BEACON | MGMT_MASK_PROBE_RESP | MGMT_MASK_ASSOC_RESP;
-        unsigned int ie_index_bitmap = 0;
-        t_u32 bit = 0;
-        t_u8 updated_cur_rnd = 0;
-        t_u8 updated_all = 0;
+        wifi_d("%s: no country ie in bss or country ie ignored.", __FUNCTION__);
+        return WM_SUCCESS;
+    }
 
-#if !CONFIG_MEM_POOLS
-        buf = (uint8_t *)OSA_MemoryAllocate(buf_len);
-#else
-        buf = OSA_MemoryPoolAllocate(buf_512_MemoryPool);
-#endif
-        if (buf == NULL)
-        {
-            wifi_e("%s: alloc %u size buf fail.", __FUNCTION__, buf_len);
-            return -WM_FAIL;
-        }
-#if !CONFIG_MEM_POOLS
-        buf_new = (uint8_t *)OSA_MemoryAllocate(buf_new_len);
-#else
-        buf_new = OSA_MemoryPoolAllocate(buf_512_MemoryPool);
-#endif
-        if (buf_new == NULL)
-        {
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree(buf);
-#else
-            OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-            wifi_e("%s: alloc %u size buf_new fail.", __FUNCTION__, buf_new_len);
-            return -WM_FAIL;
-        }
-
-        ie_index_bitmap = get_ie_index();
-        while (ie_index_bitmap != 0)
-        {
-            wifi_d("%s: ie_index_bitmap=0x%x bit=%u", __FUNCTION__, ie_index_bitmap, bit);
-            if ((ie_index_bitmap & MBIT(bit)) != 0)
-            {
-                __memset(priv->adapter, buf, 0x00, MAX_CUSTOM_IE_LEN);
-                buf_len = MAX_CUSTOM_IE_LEN;
-                ret = wifi_get_mgmt_ie_by_index(MLAN_BSS_TYPE_UAP, buf, &buf_len, bit);
-                if (ret == WM_SUCCESS)
-                {
-                    wifi_d("%s: get_mgmt_ie index=%u len=%u", __FUNCTION__, bit, buf_len);
-                    if (buf_len < (sizeof(tlvbuf_custom_ie) + sizeof(custom_ie) - MAX_IE_SIZE))
-                    {
-                        wifi_d("%s: get_mgmt_ie index=%u invalid len=%u", __FUNCTION__, bit, buf_len);
-                    }
-                    else if (buf_len > MAX_CUSTOM_IE_LEN)
-                    {
-                        wifi_e("%s: get_mgmt_ie index=%u invalid len=%u>%u", __FUNCTION__, bit, buf_len, MAX_CUSTOM_IE_LEN);
-                    }
-                    else
-                    {
-                        custom_ie *cu_ie = (custom_ie *)(buf + sizeof(tlvbuf_custom_ie));
-                        IEEEtypes_ElementId_e element_id = 0;
-                        t_u8 element_len = 0;
-
-						wifi_d("%s: get_mgmt_ie index=%u SUCCESS: len=%u", __FUNCTION__, bit, buf_len);
-                        wifi_io_dump_hex(buf, buf_len);
-                        buf_ptr = (t_u8 *)cu_ie + (sizeof(custom_ie) - MAX_IE_SIZE);
-                        buf_len_left = cu_ie->ie_length;
-
-                        __memset(priv->adapter, buf_new, 0x00, MAX_CUSTOM_IE_LEN);
-                        buf_new_ptr = buf_new;
-                        buf_new_len = 0;
-
-                        updated_cur_rnd = 0;
-                        while (buf_len_left >= 2U)
-                        {
-                            element_id	= (IEEEtypes_ElementId_e)(*((t_u8 *)buf_ptr));
-                            element_len = *((t_u8 *)buf_ptr + 1);
-                            if (buf_len_left < (element_len + 2U))
-                            {
-                                wifi_e("%s: Error in processing IE bytes_left 0x%x < cur_ie_len 0x%x",
-                                    __FUNCTION__, buf_len_left, (element_len + 2U));
-                                break;
-                            }
-                            if ((element_id == COUNTRY_INFO) && (country_ie_len > 0))
-                            {
-                                wifi_d("%s: Find COUNTRY IE: id=%u\n", __FUNCTION__, element_id);
-                                __memcpy(priv->adapter, buf_new_ptr, &(d->country_info), country_ie_len + 2U);
-                                buf_new_ptr += (country_ie_len + 2U);
-                                buf_new_len += (country_ie_len + 2U);
-                                updated_cur_rnd = 1;
-                            }
-                            else
-                            {
-                                __memcpy(priv->adapter, buf_new_ptr, buf_ptr, (element_len + 2U));
-                                buf_new_ptr += (element_len + 2U);
-                                buf_new_len += (element_len + 2U);
-                            }
-                            buf_ptr += (element_len + 2U);
-                            buf_len_left -= (element_len + 2U);
-                        }
-
-                        if (updated_cur_rnd != 0)
-                        {
-                            wifi_d("%s: updated_cur_rnd=%u: dump buf_new %u", __FUNCTION__, updated_cur_rnd, buf_new_len);
-                            wifi_io_dump_hex(buf_new, buf_new_len);
-                            wifi_clear_mgmt_ie2(MLAN_BSS_TYPE_UAP, bit);
-                            ret = wifi_set_mgmt_ie2(MLAN_BSS_TYPE_UAP, cu_ie->mgmt_subtype_mask, buf_new, buf_new_len);
-                            if (ret < 0)
-                            {
-                                wifi_e("%s: updated_cur_rnd=%u: wifi_set_mgmt_ie2 fail ret=%d.", __FUNCTION__, updated_cur_rnd, ret);
-                            }
-                            updated_all = 1;
-                        }
-                    }
-                }
-            }
-            ie_index_bitmap &= ~(MBIT(bit));
-            bit++;
-        }
-        if (updated_all == 0)
-        {
-            __memset(priv->adapter, buf_new, 0x00, MAX_CUSTOM_IE_LEN);
-            buf_new_ptr = buf_new;
-            buf_new_len = 0;
-            if (country_ie_len > 0)
-            {
-                __memcpy(priv->adapter, (void *)buf_new_ptr, (const void *)&(d->country_info), (country_ie_len + 2U));
-                buf_new_ptr += (country_ie_len + 2U);
-                buf_new_len += (country_ie_len + 2U);
-            }
-            wifi_d("%s: updated_all=%u: dump buf_new %u", __FUNCTION__, updated_all, buf_new_len);
-            ret = wifi_set_mgmt_ie2(MLAN_BSS_TYPE_UAP, mask, buf_new, buf_new_len);
-            if (ret < 0)
-            {
-                wifi_e("%s: updated_all=%u: wifi_set_mgmt_ie2 fail ret=%d.", __FUNCTION__, updated_all, ret);
-            }
-        }
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf);
-#else
-        OSA_MemoryPoolFree(buf_512_MemoryPool, buf);
-#endif
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(buf_new);
-#else
-        OSA_MemoryPoolFree(buf_512_MemoryPool, buf_new);
-#endif
+    ret = wifi_mgmt_ie_replace_elem(mlan_adap->priv[1], (t_u8 *)&(d->country_info), country_ie_len + 2U, COUNTRY_INFO, NULL);
+    if (ret != WM_SUCCESS)
+    {
+        wifi_e("%s: failed to update country ie.", __FUNCTION__);
     }
 
     return ret;
@@ -2914,18 +2771,13 @@ static int wifi_assocreq_wps_ie_cfg(mlan_private *priv)
 {
     int ret       = WM_SUCCESS;
     int wpsie_len = 0;
-    u8 *wps_buf   = NULL;
-    wpsie_len     = sizeof(IEEEtypes_Header_t) + priv->wps.wps_ie.vend_hdr.len;
-    wps_buf       = (t_u8 *)OSA_MemoryAllocate(wpsie_len);
-    (void)memset(wps_buf, 0, wpsie_len);
-    (void)__memcpy(priv->adapter, wps_buf, (t_u8 *)&priv->wps.wps_ie, wpsie_len);
-    priv->wps.wps_mgmt_bitmap_index =
-        wifi_set_mgmt_ie2(priv->bss_type, MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ, (void *)wps_buf, wpsie_len);
-    if (-WM_FAIL != priv->wps.wps_mgmt_bitmap_index)
-        ret = WM_SUCCESS;
-    else
+    wpsie_len = sizeof(IEEEtypes_Header_t) + priv->wps.wps_ie.vend_hdr.len;
+    ret = wifi_mgmt_ie_set(priv, MGMT_MASK_ASSOC_REQ | MGMT_MASK_REASSOC_REQ, (t_u8 *)&priv->wps.wps_ie, wpsie_len, &priv->wps.wps_mgmt_bitmap_index);
+    if (ret != WM_SUCCESS)
+    {
         ret = -WM_FAIL;
-    OSA_MemoryFree(wps_buf);
+    }
+
     return ret;
 }
 #endif
@@ -3005,22 +2857,21 @@ int wifi_nxp_send_assoc(nxp_wifi_assoc_info_t *assoc_info)
     }
 #if CONFIG_WPA_SUPP
 #if CONFIG_WPA_SUPP_WPS
-    if (priv->wps.wps_mgmt_bitmap_index != -1)
+    if (priv->wps.wps_mgmt_bitmap_index != MLAN_MGMT_IE_INVALID_IDX)
     {
-        ret = wifi_clear_mgmt_ie2(priv->bss_type, priv->wps.wps_mgmt_bitmap_index);
+        ret = wifi_mgmt_ie_clear(priv, &priv->wps.wps_mgmt_bitmap_index);
         if (ret != WM_SUCCESS)
         {
-            wifi_e("Clear Assoc req IE failed");
+            wifi_e("Clear assocreq WPS IE failed");
             return -WM_FAIL;
         }
-        priv->wps.wps_mgmt_bitmap_index = -1;
     }
-    else if (priv->wps.session_enable == MTRUE)
+    else if (priv->wps.session_enable)
     {
         ret = wifi_assocreq_wps_ie_cfg(priv);
         if (ret != WM_SUCCESS)
         {
-            wifi_w("add WPS_IE to assocreq fail");
+            wifi_w("add WPS IE to assocreq fail");
             return -WM_FAIL;
         }
     }
@@ -4125,6 +3976,48 @@ int wifi_process_cmd_response(HostCmd_DS_COMMAND *resp)
                 wm_wifi.cmd_resp_status = WM_SUCCESS;
             }
             break;
+            case HostCmd_CMD_TARGET_ACCESS:
+            {
+                HostCmd_DS_TARGET_ACCESS *target;
+                target = (HostCmd_DS_TARGET_ACCESS *)&resp->params.target;
+                if (target->action == HostCmd_ACT_GEN_GET)
+                {
+                    if (wm_wifi.cmd_resp_priv != NULL)
+                    {
+                        uint32_t *target_value = (uint32_t *)wm_wifi.cmd_resp_priv;
+                        *target_value          = target->data;
+                    }
+                }
+            }
+            break;
+            case HostCmd_CMD_BCA_REG_ACCESS:
+            {
+                HostCmd_DS_BCA_REG_ACCESS *bca_reg;
+                bca_reg = (HostCmd_DS_BCA_REG_ACCESS *)&resp->params.bca_reg;
+                if (bca_reg->action == HostCmd_ACT_GEN_GET)
+                {
+                    if (wm_wifi.cmd_resp_priv != NULL)
+                    {
+                        uint32_t *bca_value = (uint32_t *)wm_wifi.cmd_resp_priv;
+                        *bca_value          = bca_reg->value;
+                    }
+                }
+            }
+            break;
+            case HostCmd_CMD_REG_ACCESS:
+            {
+                HostCmd_DS_REG_ACCESS *reg;
+                reg = (HostCmd_DS_REG_ACCESS *)&resp->params.reg;
+                if (reg->action == HostCmd_ACT_GEN_GET)
+                {
+                    if (wm_wifi.cmd_resp_priv != NULL)
+                    {
+                        uint32_t *reg_value = (uint32_t *)wm_wifi.cmd_resp_priv;
+                        *reg_value          = reg->value;
+                    }
+                }
+            }
+            break;
             case HostCmd_CMD_MGMT_IE_LIST:
             {
                 HostCmd_DS_MGMT_IE_LIST_CFG *ie_list_cfg;
@@ -5207,7 +5100,7 @@ int wifi_process_cmd_response(HostCmd_DS_COMMAND *resp)
                     wm_wifi.cmd_resp_status = -WM_FAIL;
                 break;
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
             case HostCmd_CMD_INDEPENDENT_RESET_CFG:
             {
                 if (resp->result == HostCmd_RESULT_OK)
@@ -6040,31 +5933,6 @@ int wifi_request_bgscan(mlan_private *pmpriv)
 }
 #endif
 
-int wifi_set_rssi_low_threshold(uint8_t *low_rssi)
-{
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-    mlan_private *pmpriv = mlan_adap->priv[0];
-    mlan_ds_subscribe_evt subscribe_evt;
-
-    wifi_get_command_lock();
-    HostCmd_DS_COMMAND *cmd = wifi_get_command_buffer();
-    (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
-    cmd->seq_num                = 0;
-    cmd->result                 = 0x0;
-    subscribe_evt.evt_action    = SUBSCRIBE_EVT_ACT_BITWISE_SET;
-    subscribe_evt.evt_bitmap    = SUBSCRIBE_EVT_RSSI_LOW;
-    subscribe_evt.low_rssi      = *low_rssi;
-    subscribe_evt.low_rssi_freq = 0;
-    wlan_ops_sta_prepare_cmd(pmpriv, HostCmd_CMD_802_11_SUBSCRIBE_EVENT, HostCmd_ACT_GEN_SET, 0, NULL, &subscribe_evt,
-                             cmd);
-    wifi_wait_for_cmdresp(NULL);
-
-    return wm_wifi.cmd_resp_status;
-#else
-    return 0;
-#endif
-}
-
 #if CONFIG_BG_SCAN
 int wifi_request_bgscan_query(mlan_private *pmpriv)
 {
@@ -6186,9 +6054,7 @@ int wifi_handle_fw_event(struct bus_message *msg)
 #if CONFIG_EXT_SCAN_SUPPORT
     mlan_event_scan_result *pext_scan_result;
 #endif
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
-    int16_t *curr_rssi;
-#endif
+    int16_t *rssi_snr;
 
     if (evt == NULL)
     {
@@ -6282,7 +6148,7 @@ int wifi_handle_fw_event(struct bus_message *msg)
 #if CONFIG_HOST_SLEEP
                 wakelock_get();
 #endif
-                if (split_scan_in_progress == false)
+                if (is_split_scan_complete())
                 {
                     wifi_event_completion(WIFI_EVENT_SLEEP, WIFI_EVENT_REASON_SUCCESS, NULL);
                 }
@@ -6441,38 +6307,58 @@ int wifi_handle_fw_event(struct bus_message *msg)
             break;
 #endif
         case EVENT_RSSI_LOW:
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
+        {
 #if !CONFIG_MEM_POOLS
-            curr_rssi = (t_s16 *)OSA_MemoryAllocate(sizeof(t_s16));
+            rssi_snr = (t_s16 *)OSA_MemoryAllocate(sizeof(t_s16));
 #else
-            curr_rssi = (t_s16 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
+            rssi_snr = (t_s16 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
 #endif
-            if (curr_rssi == MNULL)
+            if (rssi_snr == MNULL)
             {
-                wifi_w("No mem. Failed to alloc memory for EVENT_RSSI_LOW");
+                wifi_w("No mem. Failed to alloc for EVENT_RSSI_LOW");
                 break;
             }
-            *curr_rssi = (t_s16)evt->reason_code;
-            if(wifi_event_completion(WIFI_EVENT_RSSI_LOW,
+            *rssi_snr = (t_s16)evt->reason_code;
+            if (wifi_event_completion(WIFI_EVENT_RSSI_LOW,
                                      WIFI_EVENT_REASON_SUCCESS,
-                                     (void *)curr_rssi) != WM_SUCCESS)
+                                     (void *)rssi_snr) != WM_SUCCESS)
             {
 #if !CONFIG_MEM_POOLS
-                OSA_MemoryFree((void *)curr_rssi);
+                OSA_MemoryFree((void *)rssi_snr);
 #else
-                OSA_MemoryPoolFree(buf_32_MemoryPool, curr_rssi);
+                OSA_MemoryPoolFree(buf_32_MemoryPool, rssi_snr);
 #endif
             }
-#else
-            (void)wifi_event_completion(WIFI_EVENT_RSSI_LOW, WIFI_EVENT_REASON_SUCCESS, NULL);
-#endif
             break;
+        }
+        case EVENT_SNR_LOW:
+        {
+#if !CONFIG_MEM_POOLS
+            rssi_snr = (t_s16 *)OSA_MemoryAllocate(sizeof(t_s16));
+#else
+            rssi_snr = (t_s16 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
+#endif
+            if (rssi_snr == MNULL)
+            {
+                wifi_w("No mem. Failed to alloc for EVENT_SNR_LOW");
+                break;
+            }
+            *rssi_snr = (t_s16)evt->reason_code;
+            if (wifi_event_completion(WIFI_EVENT_SNR_LOW,
+                                     WIFI_EVENT_REASON_SUCCESS,
+                                     (void *)rssi_snr) != WM_SUCCESS)
+            {
+#if !CONFIG_MEM_POOLS
+                OSA_MemoryFree((void *)rssi_snr);
+#else
+                OSA_MemoryPoolFree(buf_32_MemoryPool, rssi_snr);
+#endif
+            }
+            break;
+        }
 #if CONFIG_SUBSCRIBE_EVENT_SUPPORT
         case EVENT_RSSI_HIGH:
             (void)wifi_event_completion(WIFI_EVENT_RSSI_HIGH, WIFI_EVENT_REASON_SUCCESS, NULL);
-            break;
-        case EVENT_SNR_LOW:
-            (void)wifi_event_completion(WIFI_EVENT_SNR_LOW, WIFI_EVENT_REASON_SUCCESS, NULL);
             break;
         case EVENT_SNR_HIGH:
             (void)wifi_event_completion(WIFI_EVENT_SNR_HIGH, WIFI_EVENT_REASON_SUCCESS, NULL);
@@ -8284,7 +8170,7 @@ int wifi_set_tx_pert(void *cfg, mlan_bss_type bss_type)
 #endif
 
 #if CONFIG_TX_RX_HISTOGRAM
-int wifi_set_txrx_histogram(void *cfg, t_u8 *data)
+int wifi_set_txrx_histogram(int bss_type, void *cfg, t_u8 *data)
 {
     txrx_histogram_info *txrx_histogram    = (txrx_histogram_info *)cfg;
     txrx_histogram_info txrx_histogram_cmd = {0};
@@ -8305,7 +8191,7 @@ int wifi_set_txrx_histogram(void *cfg, t_u8 *data)
     HostCmd_DS_COMMAND *cmd = wifi_get_command_buffer();
     (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
 
-    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0], HostCmd_CMD_TX_RX_PKT_STATS, HostCmd_ACT_GEN_GET, 0,
+    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[bss_type], HostCmd_CMD_TX_RX_PKT_STATS, HostCmd_ACT_GEN_GET, 0,
                              NULL, &txrx_histogram_cmd, cmd);
     wifi_wait_for_cmdresp(data);
     return wm_wifi.cmd_resp_status;
@@ -8362,21 +8248,14 @@ void wifi_enable_low_pwr_mode()
 #endif
 
 #if CONFIG_ROAMING
-int wifi_config_roaming(const int enable, uint8_t *rssi_low)
+int wifi_config_roaming(const int enable, uint8_t rssi_low)
 {
     mlan_private *pmpriv = mlan_adap->priv[0];
-    int ret              = WM_SUCCESS;
 
     if (enable)
     {
         pmpriv->roaming_enabled = MTRUE;
-        pmpriv->rssi_low        = *rssi_low;
-        ret                     = wifi_set_rssi_low_threshold(rssi_low);
-        if (ret != WM_SUCCESS)
-        {
-            wifi_e("Failed to config rssi threshold for roaming");
-            return -WM_FAIL;
-        }
+        pmpriv->rssi_low        = rssi_low;
     }
     else
     {
@@ -8387,7 +8266,7 @@ int wifi_config_roaming(const int enable, uint8_t *rssi_low)
             wifi_stop_bgscan();
         }
     }
-    return ret;
+    return WM_SUCCESS;
 }
 #endif
 
@@ -8414,6 +8293,55 @@ int wifi_set_11ax_tx_omi(const mlan_bss_type bss_type,
     cfg.param.txomi_cfg.omi           = tx_omi;
     cfg.param.txomi_cfg.tx_option     = tx_option;
     cfg.param.txomi_cfg.num_data_pkts = num_data_pkts;
+
+    mlan_status rv;
+
+    if (bss_type == MLAN_BSS_TYPE_UAP)
+    {
+        req.bss_index = (t_u32)MLAN_BSS_TYPE_UAP;
+        rv            = wlan_ops_uap_ioctl(mlan_adap, &req);
+    }
+    else
+    {
+        req.bss_index = (t_u32)MLAN_BSS_TYPE_STA;
+        rv            = wlan_ops_sta_ioctl(mlan_adap, &req);
+    }
+
+    wm_wifi.cmd_resp_ioctl = NULL;
+
+    if (rv != MLAN_STATUS_SUCCESS && rv != MLAN_STATUS_PENDING)
+    {
+        return -WM_FAIL;
+    }
+
+    return WM_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable HTC in TX packets via HostCmd_CMD_11AX_CMD (0x026D)
+ *        with sub_id MLAN_11AXCMD_HTC_SUBID (0x0104).
+ *
+ * @param[in] bss_type  BSS type (MLAN_BSS_TYPE_STA or MLAN_BSS_TYPE_UAP)
+ * @param[in] enable    1 = enable HTC in TX packets, 0 = disable
+ *
+ * @return WM_SUCCESS or -WM_FAIL
+ */
+int wifi_set_11ax_htc(const mlan_bss_type bss_type, const t_u8 enable)
+{
+    mlan_ioctl_req req;
+    mlan_ds_11ax_cmd_cfg cfg;
+
+    (void)memset(&req, 0x00, sizeof(mlan_ioctl_req));
+    (void)memset(&cfg, 0x00, sizeof(mlan_ds_11ax_cmd_cfg));
+
+    req.req_id  = MLAN_IOCTL_11AX_CFG;
+    req.action  = MLAN_ACT_SET;
+    req.pbuf    = (t_u8 *)&cfg;
+    req.buf_len = sizeof(mlan_ds_11ax_cmd_cfg);
+
+    cfg.sub_command         = MLAN_OID_11AX_CMD_CFG;
+    cfg.sub_id              = MLAN_11AXCMD_HTC_SUBID;
+    cfg.param.htc_cfg.value = enable;
 
     mlan_status rv;
 
@@ -9426,6 +9354,64 @@ int wifi_set_threshold_pre_beacon_lost(mlan_private *pmpriv, unsigned int pre_be
     sub_evt.evt_bitmap      = SUBSCRIBE_EVT_PRE_BEACON_LOST;
     sub_evt.pre_beacon_miss = pre_beacon_lost;
     return wifi_subscribe_event_submit(pmpriv, &sub_evt);
+}
+#endif
+
+#if CONFIG_ROAMING
+int wifi_roaming_subscribe_event(uint8_t bitmap, uint8_t rssi_low, uint8_t snr_low)
+{
+    mlan_private *pmpriv = mlan_adap->priv[0];
+    mlan_ds_subscribe_evt subscribe_evt;
+
+    (void)memset(&subscribe_evt, 0, sizeof(mlan_ds_subscribe_evt));
+    subscribe_evt.evt_action = SUBSCRIBE_EVT_ACT_BITWISE_SET;
+
+    if (bitmap & 0x01)
+    {
+        subscribe_evt.evt_bitmap |= SUBSCRIBE_EVT_RSSI_LOW;
+        subscribe_evt.low_rssi = rssi_low;
+        subscribe_evt.low_rssi_freq = 0;
+    }
+    if (bitmap & 0x02)
+    {
+        subscribe_evt.evt_bitmap |= SUBSCRIBE_EVT_SNR_LOW;
+        subscribe_evt.low_snr = snr_low;
+        subscribe_evt.low_snr_freq = 0;
+    }
+
+    wifi_get_command_lock();
+    HostCmd_DS_COMMAND *cmd = wifi_get_command_buffer();
+    (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
+    cmd->seq_num = 0;
+    cmd->result = 0x0;
+
+    wlan_ops_sta_prepare_cmd(pmpriv, HostCmd_CMD_802_11_SUBSCRIBE_EVENT,
+                             HostCmd_ACT_GEN_SET, 0, NULL, &subscribe_evt, cmd);
+    wifi_wait_for_cmdresp(NULL);
+
+    return wm_wifi.cmd_resp_status;
+}
+
+int wifi_roaming_clear_subscribe(void)
+{
+    mlan_private *pmpriv = mlan_adap->priv[0];
+    mlan_ds_subscribe_evt subscribe_evt;
+
+    (void)memset(&subscribe_evt, 0, sizeof(mlan_ds_subscribe_evt));
+    subscribe_evt.evt_action = SUBSCRIBE_EVT_ACT_BITWISE_CLR;
+    subscribe_evt.evt_bitmap = SUBSCRIBE_EVT_RSSI_LOW | SUBSCRIBE_EVT_SNR_LOW;
+
+    wifi_get_command_lock();
+    HostCmd_DS_COMMAND *cmd = wifi_get_command_buffer();
+    (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
+    cmd->seq_num = 0;
+    cmd->result = 0x0;
+
+    wlan_ops_sta_prepare_cmd(pmpriv, HostCmd_CMD_802_11_SUBSCRIBE_EVENT,
+                             HostCmd_ACT_GEN_SET, 0, NULL, &subscribe_evt, cmd);
+    wifi_wait_for_cmdresp(NULL);
+
+    return wm_wifi.cmd_resp_status;
 }
 #endif
 
@@ -10575,7 +10561,7 @@ uint32_t wifi_get_board_type()
 }
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 int wifi_set_indrst_cfg(const wifi_indrst_cfg_t *indrst_cfg, mlan_bss_type bss_type)
 {
     int ret;
@@ -10595,6 +10581,7 @@ int wifi_set_indrst_cfg(const wifi_indrst_cfg_t *indrst_cfg, mlan_bss_type bss_t
 
     misc->param.ind_rst_cfg.ir_mode  = indrst_cfg->ir_mode;
     misc->param.ind_rst_cfg.gpio_pin = indrst_cfg->gpio_pin;
+    wifi_reset_mode_set(indrst_cfg->ir_mode);
 
     misc->sub_command       = (t_u32)MLAN_OID_MISC_IND_RST_CFG;
     wm_wifi.cmd_resp_ioctl = &req;
@@ -10673,17 +10660,4 @@ int wifi_get_indrst_cfg(wifi_indrst_cfg_t *indrst_cfg, mlan_bss_type bss_type)
 
     return ret;
 }
-
-int wifi_trigger_inband_indrst()
-{
-    wlan_process_hang(FW_RELOAD_SDIO_INBAND_RESET);
-
-    return WM_SUCCESS;
-}
-
-int wifi_trigger_oob_indrst()
-{
-    return wlan_process_hang(FW_RELOAD_NO_EMULATION);
-}
-
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
@@ -183,7 +183,7 @@ mlan_status wlan_init_priv(pmlan_private priv)
 #endif
 #if CONFIG_11K
     priv->neighbor_rep_token    = (t_u8)1U;
-    priv->rrm_mgmt_bitmap_index = -1;
+    priv->rrm_mgmt_bitmap_index = MLAN_MGMT_IE_INVALID_IDX;
 #endif
 #if CONFIG_11V
     priv->bss_trans_query_token = (t_u8)1U;
@@ -213,19 +213,22 @@ mlan_status wlan_init_priv(pmlan_private priv)
     priv->uap_host_based  = MFALSE;
 #endif
 
-    reset_ie_index();
+#if CONFIG_DRIVER_MBO
+    priv->mbo_index = MLAN_MGMT_IE_INVALID_IDX;
+#endif
+
 #if CONFIG_WPA_SUPP
     priv->default_scan_ies_len = 0;
-    priv->probe_req_index      = -1;
+    priv->probe_req_index      = MLAN_MGMT_IE_INVALID_IDX;
 #if CONFIG_WPA_SUPP_WPS
-    priv->wps.wps_mgmt_bitmap_index = -1;
+    priv->wps.wps_mgmt_bitmap_index = MLAN_MGMT_IE_INVALID_IDX;
 #endif
 #if CONFIG_WPA_SUPP_AP
-    priv->beacon_vendor_index = -1;
-    priv->beacon_index        = 0;
-    priv->proberesp_index     = 1;
-    priv->assocresp_index     = 2;
-    priv->beacon_wps_index    = 3;
+    priv->beacon_index        = MLAN_MGMT_IE_INVALID_IDX;
+    priv->proberesp_index     = MLAN_MGMT_IE_INVALID_IDX;
+    priv->assocresp_index     = MLAN_MGMT_IE_INVALID_IDX;
+    priv->beacon_wps_index    = MLAN_MGMT_IE_INVALID_IDX;
+    priv->beacon_vendor_index = MLAN_MGMT_IE_INVALID_IDX;
 #endif
 #endif
 #if CONFIG_TCP_ACK_ENH
@@ -351,6 +354,9 @@ t_void wlan_init_adapter(pmlan_adapter pmadapter)
 
     wlan_wmm_init(pmadapter);
     wlan_init_wmm_param(pmadapter);
+
+    wlan_init_mgmt_ie_param(pmadapter);
+
 #if CONFIG_WMM_UAPSD
     (void)__memset(pmadapter, &pmadapter->sleep_params, 0, sizeof(pmadapter->sleep_params));
     (void)__memset(pmadapter, &pmadapter->sleep_period, 0, sizeof(pmadapter->sleep_period));

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_mgmt_ie.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_mgmt_ie.c
@@ -1,0 +1,2279 @@
+/** @file mlan_mgmt_ie.c
+ *
+ *  @brief  This file provides functions for MGMT IE management
+ *
+ *  Copyright 2026 NXP
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include <mlan_api.h>
+#include <osa.h>
+#if defined(RW610)
+#include "wifi-imu.h"
+#else
+#include "wifi-sdio.h"
+#endif
+#include "mlan_mgmt_ie.h"
+
+/********************************************************
+    Local Variables
+********************************************************/
+
+/** Custom IE header size */
+#define MLAN_CUSTOM_IE_HDR_SIZE (sizeof(custom_ie) - MAX_IE_SIZE)
+
+static mlan_buf_cfg s_mgmt_buf_cfgs[] = {
+    {MLAN_MGMT_BUF_SM_SIZE, 0},
+    {MLAN_MGMT_BUF_MD_SIZE, 0},
+    {MLAN_MGMT_BUF_LG_SIZE, 0}
+};
+
+#define MGMT_BUFPOOL_NUM (sizeof(s_mgmt_buf_cfgs)/sizeof(s_mgmt_buf_cfgs[0]))
+
+#define IE_MASK_WPS    0x0001
+#define IE_MASK_P2P    0x0002
+#define IE_MASK_WFD    0x0004
+#define IE_MASK_VENDOR 0x0008
+#define IE_MASK_EXTCAP 0x0010
+
+static OSA_MUTEX_HANDLE_DEFINE(s_ie_mutex);
+
+static mlan_buf_handle s_mgmt_buf_handle = {0};
+static mlan_buf_class s_mlan_buf_class[MGMT_BUFPOOL_NUM] = {0};
+static bool s_mgmt_ie_initialized = false;
+
+/********************************************************
+                Local Functions
+********************************************************/
+
+static void *wrapper_buffer_malloc(t_u32 size)
+{
+#if !CONFIG_MEM_POOLS
+    return OSA_MemoryAllocate((uint32_t)size);
+#else
+    if (size <= 256U)
+    {
+        return OSA_MemoryPoolAllocate(buf_256_MemoryPool);
+    }
+    else if (size <= 512U)
+    {
+        return OSA_MemoryPoolAllocate(buf_512_MemoryPool);
+    }
+    else
+    {
+        return OSA_MemoryPoolAllocate(buf_2048_MemoryPool);
+    }
+#endif
+}
+
+static void wrapper_buffer_free(void *ptr)
+{
+    if (ptr == MNULL)
+    {
+        return;
+    }
+
+#if !CONFIG_MEM_POOLS
+    OSA_MemoryFree(ptr);
+#else
+#define POOL_256_SZ     (256 * 8 + 8 * sizeof(uint32_t))
+#define POOL_512_SZ     (512 * 4 + 4 * sizeof(uint32_t))
+#define POOL_2048_SZ    (2048 * 4 + 4 * sizeof(uint32_t))
+    if (ptr >= buf_256_MemoryPool && ptr < ((t_u8 *)buf_256_MemoryPool + POOL_256_SZ))
+    {
+        OSA_MemoryPoolFree(buf_256_MemoryPool, ptr);
+    }
+    else if (ptr >= buf_512_MemoryPool && ptr < ((t_u8 *)buf_512_MemoryPool + POOL_512_SZ))
+    {
+        OSA_MemoryPoolFree(buf_512_MemoryPool, ptr);
+    }
+    else if (ptr >= buf_2048_MemoryPool && ptr < ((t_u8 *)buf_2048_MemoryPool + POOL_2048_SZ))
+    {
+        OSA_MemoryPoolFree(buf_2048_MemoryPool, ptr);
+    }
+    else
+    {
+        wifi_e("Invalid pointer to free %p", ptr);
+    }
+#endif
+}
+
+static inline void wrapper_mgmt_ie_lock(void)
+{
+    (void)OSA_MutexLock((osa_mutex_handle_t)s_ie_mutex, osaWaitForever_c);
+}
+
+static inline void wrapper_mgmt_ie_unlock(void)
+{
+    (void)OSA_MutexUnlock((osa_mutex_handle_t)s_ie_mutex);
+}
+
+/**
+ * @brief Initialize a tiered buffer pool.
+ *
+ * Allocates a single contiguous memory region and partitions it into
+ * @p num buffer classes, each with a fixed block size and count as
+ * described by @p cfgs[].  All free blocks within each class are linked
+ * into a singly-linked free list.
+ *
+ * Memory layout (contiguous):
+ *   [ class-0 blocks ... ][ class-1 blocks ... ] ... [ class-(num-1) blocks ]
+ *
+ * Each block = mlan_buf_block header + data area, 4-byte aligned.
+ *
+ * @param handle     Output handle that tracks the pool state
+ * @param classes    Array of @p num mlan_buf_class descriptors to populate
+ * @param cfgs       Array of @p num configuration entries (buf_size, buf_cnt)
+ * @param num        Number of buffer classes
+ * @param malloc_fn  Allocator used for the memory region
+ * @param free_fn    Deallocator paired with @p malloc_fn
+ *
+ * @return  0 on success, -1 on invalid arguments or allocation failure
+ */
+static t_s8 util_buf_pool_init(pmlan_buf_handle handle,
+                                pmlan_buf_class classes,
+                                pmlan_buf_cfg cfgs,
+                                t_u32 num,
+                                void *(*malloc_fn)(t_u32),
+                                void (*free_fn)(void *))
+{
+    t_u8 i;
+    t_u16 j;
+    t_u32 total_size = 0;
+    t_u32 block_size = 0;
+    t_u8 *pos           = MNULL;
+    pmlan_buf_block blk = MNULL;
+
+    if (!handle || !classes || !cfgs || num == 0 || !malloc_fn || !free_fn)
+    {
+        return -1;
+    }
+
+    (void)memset(handle, 0, sizeof(*handle));
+
+    handle->classes   = classes;
+    handle->class_num = num;
+    handle->malloc_fn = malloc_fn;
+    handle->free_fn   = free_fn;
+
+    /* Pass 1: calculate the total memory required across all classes. */
+    for (i = 0; i < num; i++)
+    {
+        if (cfgs[i].buf_size == 0)
+        {
+            return -1;
+        }
+
+        block_size = ALIGN_SZ((sizeof(mlan_buf_block) + cfgs[i].buf_size), 4);
+        total_size += block_size * cfgs[i].buf_cnt;
+    }
+
+    if (total_size == 0)
+    {
+        return -1;
+    }
+
+    /* Allocate one contiguous region for all classes */
+    handle->mem_base = (t_u8 *)malloc_fn(total_size);
+    if (!handle->mem_base)
+    {
+        return -1;
+    }
+    handle->mem_size = total_size;
+
+    pos = handle->mem_base;
+
+    /* Pass 2: partition the region into classes and build each free list. */
+    for (i = 0; i < num; i++)
+    {
+        classes[i].free_list = MNULL;
+        classes[i].buf_size  = cfgs[i].buf_size;
+        classes[i].total     = cfgs[i].buf_cnt;
+        classes[i].class_id  = i;
+        classes[i].base      = pos;
+
+        block_size = ALIGN_SZ((sizeof(mlan_buf_block) + classes[i].buf_size), 4);
+
+        for (j = 0; j < classes[i].total; j++)
+        {
+            blk = (pmlan_buf_block)(pos + j * block_size);
+            blk->next     = classes[i].free_list;
+            blk->class_id = i;
+            blk->magic    = 0;
+            classes[i].free_list = blk;
+        }
+
+        pos += block_size * classes[i].total;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Deinitialize a buffer pool
+ *
+ * @param handle  Pool handle.
+ */
+static void util_buf_pool_deinit(pmlan_buf_handle handle)
+{
+    t_u8 i;
+
+    if (!handle)
+    {
+        return;
+    }
+
+    if (handle->classes)
+    {
+        for (i = 0; i < handle->class_num; i++)
+        {
+            handle->classes[i].free_list = MNULL;
+            handle->classes[i].buf_size  = 0;
+            handle->classes[i].total     = 0;
+            handle->classes[i].class_id  = 0;
+            handle->classes[i].base      = MNULL;
+        }
+    }
+
+    if (handle->mem_base)
+    {
+        handle->free_fn(handle->mem_base);
+        handle->mem_base = MNULL;
+    }
+
+    handle->mem_size  = 0;
+    handle->classes   = MNULL;
+    handle->class_num = 0;
+    handle->malloc_fn = MNULL;
+    handle->free_fn   = MNULL;
+}
+
+/**
+ * @brief Allocate a data buffer from the pool.
+ *
+ * Iterates the buffer classes in ascending size order and returns the data
+ * area of the first free block whose buf_size >= @p size.  The block's magic
+ * field is set to MLAN_BUF_MAGIC to mark it as allocated.
+ *
+ * @param handle  Pool handle
+ * @param size    Minimum number of usable data bytes required
+ *
+ * @return  Pointer to the data area on success, NULL if no suitable free
+ *          block is available or arguments are invalid
+ */
+static t_u8 *util_buf_pool_alloc(pmlan_buf_handle handle, t_u16 size)
+{
+    t_u8 i;
+    pmlan_buf_class cls = MNULL;
+    pmlan_buf_block blk = MNULL;
+
+    if (!handle || size == 0)
+    {
+        return MNULL;
+    }
+
+    for (i = 0; i < handle->class_num; i++)
+    {
+        cls = &handle->classes[i];
+
+        if (size <= cls->buf_size && cls->free_list != MNULL)
+        {
+            blk = cls->free_list;
+            cls->free_list = blk->next;
+            blk->magic = MLAN_BUF_MAGIC;
+            return blk->data;
+        }
+    }
+
+    return MNULL;
+}
+
+/**
+ * @brief Free a data buffer back to the pool.
+ *
+ * @param handle  Pool handle.
+ * @param ptr     Pointer to the data area of the buffer to free.
+ */
+static void util_buf_pool_free(pmlan_buf_handle handle, void *ptr)
+{
+    pmlan_buf_block blk = MNULL;
+    pmlan_buf_class cls = MNULL;
+    t_u32 block_size = 0;
+
+    if (!handle || !ptr)
+    {
+        return;
+    }
+
+    blk = util_container_of(ptr, mlan_buf_block, data);
+    if (blk->magic != MLAN_BUF_MAGIC)
+    {
+        return;
+    }
+
+    if (blk->class_id >= handle->class_num)
+    {
+        return;
+    }
+
+    cls = &handle->classes[blk->class_id];
+    /* Bounds-check: ensure the block actually belongs to this class's region */
+    block_size = ALIGN_SZ(sizeof(mlan_buf_block) + cls->buf_size, 4);
+    if ((t_u8 *)blk < cls->base || (t_u8 *)blk >= (cls->base + block_size * cls->total))
+    {
+        return;
+    }
+
+    blk->next      = cls->free_list;
+    blk->magic     = 0;
+    cls->free_list = blk;
+}
+
+/**
+ * @brief Resize a pool buffer migration to a different class.
+ *
+ * Three outcomes are possible:
+ *  1. @p new_size > current class buf_size, allocate a larger block, copy
+ *     MIN(@p data_len, old_buf_size) bytes, free the old block, return new ptr.
+ *  2. @p new_size fits in a smaller class and a free block is available,
+ *     migrate down, copy data, free old block, return new ptr.
+ *  3. Neither upgrade nor downgrade is needed/possible, return @p ptr
+ *     unchanged (no copy, no free).
+ *
+ * On allocation failure during upgrade, returns NULL.
+ *
+ * @param handle    Pool handle
+ * @param ptr       Existing data pointer to resize
+ * @param data_len  Number of valid bytes currently in @p ptr to preserve
+ * @param new_size  New size
+ *
+ * @return  Pointer to the (possibly new) data area, or NULL on failure
+ */
+static void *util_buf_pool_renew(pmlan_buf_handle handle,
+                            void *ptr,
+                            t_u16 data_len,
+                            t_u16 new_size)
+{
+    pmlan_buf_block blk      = MNULL;
+    pmlan_buf_class cls      = MNULL;
+    pmlan_buf_block new_blk  = MNULL;
+    pmlan_buf_class best_cls = MNULL;
+    void *new_ptr            = MNULL;
+    t_u8 i;
+
+    if (!handle || !ptr)
+    {
+        return MNULL;
+    }
+
+    blk = util_container_of(ptr, mlan_buf_block, data);
+
+    if (blk->magic != MLAN_BUF_MAGIC)
+    {
+        return MNULL;
+    }
+
+    if (blk->class_id >= handle->class_num)
+    {
+        return MNULL;
+    }
+
+    cls = &handle->classes[blk->class_id];
+
+    /* If current buffer is too small, allocate a larger one */
+    if (new_size > cls->buf_size)
+    {
+        new_ptr = util_buf_pool_alloc(handle, new_size);
+        if (!new_ptr)
+        {
+            return MNULL;
+        }
+
+        (void)memcpy(new_ptr, ptr, MIN(data_len, cls->buf_size));
+        util_buf_pool_free(handle, ptr);
+        return new_ptr;
+    }
+
+    /* Try to find a smaller class that can hold the data */
+    for (i = 0; i < blk->class_id; i++)
+    {
+        best_cls = &handle->classes[i];
+
+        if (best_cls->buf_size >= new_size && best_cls->free_list != MNULL)
+        {
+            new_blk             = best_cls->free_list;
+            best_cls->free_list = new_blk->next;
+            new_blk->magic      = MLAN_BUF_MAGIC;
+            new_ptr             = new_blk->data;
+
+            (void)memcpy(new_ptr, ptr, MIN(data_len, best_cls->buf_size));
+            util_buf_pool_free(handle, ptr);
+            return new_ptr;
+        }
+    }
+
+    /* no class change required or possible — return as-is */
+    return ptr;
+}
+
+/**
+ * @brief Allocate an IE data buffer from the MGMT IE pool.
+ *
+ * @param size  Required buffer size
+ * @return      Pointer to the data area, or NULL if the pool is exhausted
+ */
+static inline t_u8 *ie_buf_get(t_u16 size)
+{
+    return util_buf_pool_alloc(&s_mgmt_buf_handle, size);
+}
+
+/**
+ * @brief Return an IE data buffer to the MGMT IE pool.
+ *
+ * @param buf   IE data buffer pointer to free
+ */
+static inline void ie_buf_put(t_u8 *buf)
+{
+    util_buf_pool_free(&s_mgmt_buf_handle, buf);
+}
+
+/**
+ * @brief Resize an IE data buffer within the MGMT IE pool.
+ *
+ * @param buf       Existing IE buffer pointer
+ * @param data_len  Number of valid bytes currently in @p buf to preserve
+ * @param new_size  New size
+ *
+ * @return  Pointer to the (possibly reallocated) buffer, or NULL on failure
+ */
+static inline t_u8 *ie_buf_renew(t_u8 *buf, t_u16 data_len, t_u16 new_size)
+{
+    return util_buf_pool_renew(&s_mgmt_buf_handle, buf, data_len, new_size);
+}
+
+static inline void mgmt_ie_entry_clear(pmlan_adapter pmadapter, t_u16 idx)
+{
+    if (idx >= MAX_MGMT_IE_DRV_INDEX)
+    {
+        return;
+    }
+
+    pmadapter->mgmt_ie[idx].bss_type   = MLAN_BSS_TYPE_ANY;
+    pmadapter->mgmt_ie[idx].cust_ie    = MNULL;
+    pmadapter->mgmt_ie[idx].ie_offset  = 0;
+    pmadapter->mgmt_ie[idx].cur_ie_len = 0;
+}
+
+static inline void mgmt_buffer_entry_clear(pmlan_adapter pmadapter, t_u16 idx)
+{
+    if (idx >= MAX_MGMT_IE_FW_INDEX)
+    {
+        return;
+    }
+
+    pmadapter->mgmt_buffer[idx].ie_index          = MLAN_MGMT_IE_INVALID_IDX;
+    pmadapter->mgmt_buffer[idx].mgmt_subtype_mask = MLAN_MGMT_IE_INVALID_MASK;
+    pmadapter->mgmt_buffer[idx].ie_length         = 0;
+    pmadapter->mgmt_buffer[idx].dirty             = 0;
+    if (pmadapter->mgmt_buffer[idx].ie_buf != MNULL)
+    {
+        ie_buf_put(pmadapter->mgmt_buffer[idx].ie_buf);
+        pmadapter->mgmt_buffer[idx].ie_buf = MNULL;
+    }
+}
+
+/**
+ * @brief Append a custom IE to the TLV payload.
+ *
+ * @param pos           IN/OUT: current position in the custom IE buffer to append to
+ * @param remain_len    IN/OUT: number of bytes remaining in the buffer after @p pos
+ * @param total_len     IN/OUT: total length of valid data in the buffer after appending
+ * @param src           Source IE header containing the IE to append
+ *
+ * @return              MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status append_custom_ie(custom_ie **pos, t_u32 *remain_len, t_u16 *total_len, custom_ie_hdr *src)
+{
+    t_u16 len;
+
+    if (!src)
+    {
+        return MLAN_STATUS_SUCCESS;
+    }
+
+    len = MLAN_CUSTOM_IE_HDR_SIZE + src->ie_length;
+    if (len > *remain_len)
+    {
+        return MLAN_STATUS_FAILURE;
+    }
+
+    (*pos)->ie_index = src->ie_index;
+    (*pos)->mgmt_subtype_mask = src->mgmt_subtype_mask;
+    (*pos)->ie_length = src->ie_length;
+
+    memcpy((*pos)->ie_buffer, src->ie_buf, src->ie_length);
+
+    *pos = (custom_ie *)((t_u8 *)(*pos) + len);
+    *remain_len -= len;
+    *total_len += len;
+
+    return MLAN_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Download a list of mgmt buffer entries to FW.
+ *
+ * Serializes @p ies_list into one or more mlan_ds_misc_custom_ie TLV payloads
+ * (batched at most MAX_MGMT_IE_INDEX_TO_FW entries per command).
+ *
+ * @param priv      Pointer to the mlan_private driver data struct
+ * @param ies_list  Array of mgmt buffer entries to commit
+ * @param ies_cnt   Number of entries in @p ies_list.
+ *
+ * @return          MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_commit(mlan_private *priv, custom_ie_hdr *ies_list, t_u8 ies_cnt)
+{
+    mlan_status status                 = MLAN_STATUS_SUCCESS;
+    mlan_ds_misc_custom_ie *pcustom_ie = MNULL;
+    custom_ie *pos                     = MNULL;
+    t_u16 len                          = 0;
+    t_u32 remain_len                   = 0;
+    HostCmd_DS_COMMAND *cmd            = MNULL;
+    t_u8 batch_start = 0;
+    t_u8 batch_size  = 0;
+    t_u8 i;
+
+    ENTER();
+
+    if (!priv || !ies_list || ies_cnt == 0)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    pcustom_ie = wrapper_buffer_malloc(sizeof(mlan_ds_misc_custom_ie));
+    if (!pcustom_ie)
+    {
+        wifi_e("Fail to allocate custome_ie\n");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    wifi_d("Total IEs to commit: %d, will download in batches of max %d",
+            ies_cnt, MAX_MGMT_IE_INDEX_TO_FW);
+
+    batch_start = 0;
+    batch_size  = 0;
+
+    /* Iterate over all IEs in chunks of at most MAX_MGMT_IE_INDEX_TO_FW
+     * to stay within the firmware command buffer size limit. */
+    while (batch_start < ies_cnt)
+    {
+        batch_size = MIN((ies_cnt - batch_start), MAX_MGMT_IE_INDEX_TO_FW);
+
+        wifi_d("Batch: start_idx=%d, size=%d", batch_start, batch_size);
+
+        /* Re-use the same buffer; reset all fields before building the payload */
+        (void)memset(pcustom_ie, 0, sizeof(mlan_ds_misc_custom_ie));
+        pcustom_ie->type = TLV_TYPE_MGMT_IE;
+        pos        = pcustom_ie->ie_data_list;
+        remain_len = sizeof(pcustom_ie->ie_data_list);
+        len        = 0;
+
+        for (i = 0; i < batch_size; i++)
+        {
+            /* Skip entries that carry no valid mask */
+            if (ies_list[batch_start + i].mgmt_subtype_mask == MLAN_MGMT_IE_INVALID_MASK)
+            {
+                continue;
+            }
+
+            status = append_custom_ie(&pos, &remain_len, &len, &ies_list[batch_start + i]);
+            if (status != MLAN_STATUS_SUCCESS)
+            {
+                wifi_e("Failed to append custom IE at num %d", batch_start + i);
+                goto out;
+            }
+        }
+
+        pcustom_ie->len = len;
+
+        if (len == 0)
+        {
+            wifi_d("Batch has no valid IEs, skipping");
+            batch_start += batch_size;
+            continue;
+        }
+
+        wifi_d("Dumping custom IE batch to be committed to FW:");
+        // dump_hex(pcustom_ie, pcustom_ie->len + 4);
+
+        (void)wifi_get_command_lock();
+
+        cmd = wifi_get_command_buffer();
+        (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
+
+        cmd->seq_num = HostCmd_SET_SEQ_NO_BSS_INFO(0U /* seq_num */, 0U /* bss_num */, priv->bss_type);
+        cmd->result  = 0x0;
+
+    #if UAP_SUPPORT
+        if (priv->bss_type == MLAN_BSS_TYPE_UAP
+    #if CONFIG_WPA_SUPP_P2P
+            || ((priv->bss_type == MLAN_BSS_TYPE_WIFIDIRECT) && (priv->bss_role == MLAN_BSS_ROLE_UAP))
+    #endif
+            )
+        {
+            wifi_d("[SET] Custom IE for UAP");
+            status = wlan_ops_uap_prepare_cmd(priv, HOST_CMD_APCMD_SYS_CONFIGURE, HostCmd_ACT_GEN_SET, 0,
+                                            MNULL, (void *)pcustom_ie, cmd);
+        }
+        else
+    #endif
+        {
+            wifi_d("[SET] Custom IE for STA");
+            status = wlan_ops_sta_prepare_cmd(priv, HostCmd_CMD_MGMT_IE_LIST, HostCmd_ACT_GEN_SET, 0,
+                                            MNULL, (void *)pcustom_ie, cmd);
+        }
+
+        if (status != MLAN_STATUS_SUCCESS)
+        {
+            wifi_e("Failed to prepare cmd.");
+            wm_wifi.cmd_resp_priv = NULL;
+            (void)wifi_put_command_lock();
+            goto out;
+        }
+
+        (void)wifi_wait_for_cmdresp(MNULL);
+        if (wm_wifi.cmd_resp_status)
+        {
+            wifi_e("Failed to download custom ie to FW");
+            status = MLAN_STATUS_FAILURE;
+            goto out;
+        }
+
+        batch_start += batch_size;
+    }
+
+    wifi_d("All %d IEs downloaded successfully", ies_cnt);
+    status = MLAN_STATUS_SUCCESS;
+
+out:
+    if (pcustom_ie != MNULL)
+    {
+        wrapper_buffer_free(pcustom_ie);
+    }
+
+    LEAVE();
+
+    return status;
+}
+
+/**
+ * @brief Collect all dirty mgmt buffers for @p priv and commit them to firmware.
+ *
+ * Scans the adapter's DRV IE table for entries belonging to @p priv whose
+ * mgmt buffer is marked dirty.  Each unique dirty mgmt buffer is added
+ * to a local list and passed to mgmt_ie_commit().
+ *
+ * @param priv  Pointer to the mlan_private driver data struct
+ *
+ * @return      MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_commit_dirty(mlan_private *priv)
+{
+    mlan_status status        = MLAN_STATUS_SUCCESS;
+    mlan_adapter *pmadapter   = priv->adapter;
+    custom_ie_entry *pmgmt_ie = pmadapter->mgmt_ie;
+    custom_ie_hdr *pmgmt_buf  = MNULL;
+    custom_ie_hdr ies_list[MAX_MGMT_IE_FW_INDEX] = {0};
+    t_u16 fw_idx = MLAN_MGMT_IE_INVALID_IDX;
+    t_u8 ies_cnt = 0;
+    t_u8 i;
+    /* bitmap to track which mgmt buffers are dirty */
+    t_u32 mgmt_buf_dirty_bitmap = 0;
+    /* bitmap to track which mgmt ies are marked for clearing */
+    t_u32 mgmt_ie_clear_bitmap = 0;
+
+    /* Pass 1: collect unique dirty FW buffers owned by this priv */
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        /* Skip entries that don't belong to this interface or are empty */
+        if (pmgmt_ie[i].bss_type != priv->bss_type ||
+            pmgmt_ie[i].cust_ie == MNULL)
+        {
+            continue;
+        }
+
+        pmgmt_buf = pmgmt_ie[i].cust_ie;
+        fw_idx = pmgmt_buf->ie_index;
+
+        /* Skip clean buffers and buffers already captured in this pass */
+        if (!pmgmt_buf->dirty || (mgmt_buf_dirty_bitmap & MBIT(fw_idx)))
+        {
+            continue;
+        }
+
+        ies_list[ies_cnt++] = *pmgmt_buf;
+        mgmt_buf_dirty_bitmap |= MBIT(fw_idx);
+
+        if (pmgmt_ie[i].cust_ie->mgmt_subtype_mask == MGMT_MASK_CLEAR)
+        {
+            /* Track this IE for clearing after commit */
+            mgmt_ie_clear_bitmap |= MBIT(i);
+        }
+    }
+
+    if (ies_cnt == 0)
+    {
+        return MLAN_STATUS_SUCCESS;
+    }
+
+    status = mgmt_ie_commit(priv, ies_list, ies_cnt);
+    if (status != MLAN_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
+    /* Pass 2: post-commit cleanup — clear dirty flags and free CLEAR-marked mgmt buffers */
+    pmgmt_buf = pmadapter->mgmt_buffer;
+
+    for (i = 0; i < pmadapter->max_mgmt_buf_count; i++)
+    {
+        if (!(mgmt_buf_dirty_bitmap & MBIT(i)))
+        {
+            continue;
+        }
+
+        pmgmt_buf[i].dirty = 0;
+        /* If this buffer was a CLEAR command, release its IE data buffer and
+         * mark the FW slot as free. */
+        if (pmgmt_buf[i].mgmt_subtype_mask == MGMT_MASK_CLEAR)
+        {
+            mgmt_buffer_entry_clear(pmadapter, i);
+        }
+    }
+
+    /* Pass 3: clear DRV IE entries marked for removal */
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        if (!(mgmt_ie_clear_bitmap & MBIT(i)))
+        {
+            continue;
+        }
+
+        /* Clear the DRV IE entry */
+        mgmt_ie_entry_clear(pmadapter, i);
+    }
+
+    return MLAN_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Get a mgmt buffer slot from firmware.
+ *
+ * @param priv   Pointer to the mlan_private driver data struct
+ * @param buf    Buffer to receive the firmware response
+ *               (must be at least sizeof(tlvbuf_custom_ie) + sizeof(custom_ie))
+ * @param index  FW buffer index to query
+ *
+ * @return       MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_fetch(mlan_private *priv, void *buf, t_u16 index)
+{
+    mlan_status status                 = MLAN_STATUS_SUCCESS;
+    mlan_ds_misc_custom_ie *pcustom_ie = MNULL;
+    custom_ie *pos                     = MNULL;
+    HostCmd_DS_COMMAND *cmd            = MNULL;
+
+    ENTER();
+
+    pcustom_ie = wrapper_buffer_malloc(sizeof(mlan_ds_misc_custom_ie));
+    if (!pcustom_ie)
+    {
+        wifi_e("Fail to allocate custome_ie\n");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    pcustom_ie->type = TLV_TYPE_MGMT_IE;
+
+    pos = pcustom_ie->ie_data_list;
+    pos->ie_index = index;
+    pos->mgmt_subtype_mask = 0;
+    pos->ie_length = 0;
+    pcustom_ie->len = MLAN_CUSTOM_IE_HDR_SIZE;
+
+    (void)wifi_get_command_lock();
+
+    cmd = wifi_get_command_buffer();
+    (void)memset(cmd, 0x00, sizeof(HostCmd_DS_COMMAND));
+
+    cmd->seq_num = HostCmd_SET_SEQ_NO_BSS_INFO(0U /* seq_num */, 0U /* bss_num */, priv->bss_type);
+    cmd->result  = 0x0;
+
+#if UAP_SUPPORT
+    if (priv->bss_type == MLAN_BSS_TYPE_UAP
+#if CONFIG_WPA_SUPP_P2P
+        || ((priv->bss_type == MLAN_BSS_TYPE_WIFIDIRECT) && (priv->bss_role == MLAN_BSS_ROLE_UAP))
+#endif
+        )
+    {
+        wifi_d("[GET] Custom IE for UAP");
+        status = wlan_ops_uap_prepare_cmd(priv, HOST_CMD_APCMD_SYS_CONFIGURE, HostCmd_ACT_GEN_GET, 0,
+                                          MNULL, (void *)pcustom_ie, cmd);
+    }
+    else
+#endif
+    {
+        wifi_d("[GET] Custom IE for STA");
+        status = wlan_ops_sta_prepare_cmd(priv, HostCmd_CMD_MGMT_IE_LIST, HostCmd_ACT_GEN_GET, 0,
+                                          MNULL, (void *)pcustom_ie, cmd);
+    }
+    if (status != MLAN_STATUS_SUCCESS)
+    {
+        wifi_e("Failed to prepare cmd.");
+        wm_wifi.cmd_resp_priv = NULL;
+        (void)wifi_put_command_lock();
+        goto out;
+    }
+
+    (void)wifi_wait_for_cmdresp(buf);
+    if (wm_wifi.cmd_resp_status)
+    {
+        status = MLAN_STATUS_FAILURE;
+    }
+
+out:
+    if (pcustom_ie != MNULL)
+    {
+        wrapper_buffer_free(pcustom_ie);
+    }
+
+    LEAVE();
+
+    return status;
+}
+
+static inline t_u16 find_free_fw_idx(pmlan_adapter pmadapter)
+{
+    t_u16 i;
+
+    for (i = 0; i < pmadapter->max_mgmt_buf_count; i++)
+    {
+        if (pmadapter->mgmt_buffer[i].mgmt_subtype_mask == MLAN_MGMT_IE_INVALID_MASK)
+        {
+            return i;
+        }
+    }
+
+    wifi_e("No free FW index available");
+    return MLAN_MGMT_IE_INVALID_IDX;
+}
+
+/**
+ * @brief Allocate a DRV index and its associated mgmt buffer slot.
+ *
+ * @param priv    Pointer to the mlan_private driver data struct
+ * @param ie_mask Management frame type mask
+ * @param ie_len  Length of the IE data to be added
+ * @param index   MLAN_MGMT_IE_INVALID_IDX for a new allocation,
+ *                or an existing DRV index for an update
+ *
+ * @return        Allocated DRV index on success, MLAN_MGMT_IE_INVALID_IDX on failure
+ */
+static t_u16 mgmt_ie_get_index(mlan_private *priv, t_u16 ie_mask, t_u16 ie_len, t_u16 index)
+{
+    mlan_adapter *pmadapter     = MNULL;
+    custom_ie_entry *pmgmt_ie   = MNULL;
+    custom_ie_hdr *pmgmt_buffer = MNULL;
+    t_u8 *new_buf               = MNULL;
+    t_u8 i = 0;
+    t_u16 drv_idx = MLAN_MGMT_IE_INVALID_IDX, fw_idx = MLAN_MGMT_IE_INVALID_IDX;
+
+    ENTER();
+
+    if (!priv || ie_mask == 0 || ie_len == 0)
+    {
+        wifi_e("Invalid input parameters");
+        LEAVE();
+        return MLAN_MGMT_IE_INVALID_IDX;
+    }
+
+    pmadapter    = priv->adapter;
+    pmgmt_ie     = pmadapter->mgmt_ie;
+    pmgmt_buffer = pmadapter->mgmt_buffer;
+
+    /* Re-use existing DRV index if updating */
+    drv_idx = index;
+
+    /*
+     * Single pass over the DRV table:
+     *  - Records the first empty DRV slot (for new-allocation path).
+     *  - Looks for an existing mgmt buffer owned by the same bss_type with a
+     *    matching ie_mask so the new IE can be appended (IE-merging path).
+     */
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        if (!pmgmt_ie[i].cust_ie)
+        {
+            if (drv_idx == MLAN_MGMT_IE_INVALID_IDX)
+            {
+                drv_idx = i;
+                mgmt_ie_entry_clear(pmadapter, drv_idx);
+            }
+            continue;
+        }
+
+        if (fw_idx == MLAN_MGMT_IE_INVALID_IDX)
+        {
+            /* Try to find a shareable mgmt buffer (same interface + same IE mask) */
+            if (pmgmt_ie[i].bss_type == priv->bss_type &&
+                pmgmt_ie[i].cust_ie->mgmt_subtype_mask == ie_mask)
+            {
+                /* Grow the existing buffer to append the additional IE. */
+                new_buf = ie_buf_renew(pmgmt_ie[i].cust_ie->ie_buf,
+                                        pmgmt_ie[i].cust_ie->ie_length,
+                                        pmgmt_ie[i].cust_ie->ie_length + ie_len);
+                if (new_buf == MNULL)
+                {
+                    /* Buffer could not be grown; try the next candidate */
+                    continue;
+                }
+                pmgmt_ie[i].cust_ie->ie_buf = new_buf;
+                fw_idx = pmgmt_ie[i].cust_ie->ie_index;
+            }
+        }
+
+        if (fw_idx != MLAN_MGMT_IE_INVALID_IDX && drv_idx != MLAN_MGMT_IE_INVALID_IDX)
+        {
+            break;
+        }
+    }
+
+    if (drv_idx == MLAN_MGMT_IE_INVALID_IDX)
+    {
+        wifi_e("No free DRV index available");
+        LEAVE();
+        return MLAN_MGMT_IE_INVALID_IDX;
+    }
+
+    /* No shareable buffer was found — allocate a new mgmt buffer */
+    if (fw_idx == MLAN_MGMT_IE_INVALID_IDX)
+    {
+        fw_idx = find_free_fw_idx(pmadapter);
+        if (fw_idx == MLAN_MGMT_IE_INVALID_IDX)
+        {
+            wifi_e("No free FW index available");
+            LEAVE();
+            return MLAN_MGMT_IE_INVALID_IDX;
+        }
+        mgmt_buffer_entry_clear(pmadapter, fw_idx);
+    }
+
+    /* Link the DRV entry to its mgmt buffer */
+    pmgmt_buffer[fw_idx].ie_index = fw_idx;
+    pmgmt_ie[drv_idx].cust_ie = &pmgmt_buffer[fw_idx];
+
+    LEAVE();
+
+    return drv_idx;
+}
+
+/**
+ * @brief Add a new IE entry to the mgmt ie/mgmt buffer tables.
+ *
+ * @param priv     Pointer to the mlan_private driver data struct
+ * @param ie_mask  Management frame type mask
+ * @param ie_buf   IE data to append
+ * @param ie_len   Length of @p ie_buf in bytes
+ * @param index    IN/OUT: DRV index on success
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_add(mlan_private *priv, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index)
+{
+    mlan_status status          = MLAN_STATUS_SUCCESS;
+    mlan_adapter *pmadapter     = MNULL;
+    custom_ie_entry *pmgmt_ie   = MNULL;
+    custom_ie_hdr *pmgmt_buffer = MNULL;
+    t_u16 drv_idx = MLAN_MGMT_IE_INVALID_IDX;
+
+    ENTER();
+
+    if (!priv || ie_mask == MLAN_MGMT_IE_INVALID_MASK || !ie_buf || ie_len == 0 || !index)
+    {
+        wifi_e("Invalid input parameters");
+        status = MLAN_STATUS_FAILURE;
+        goto out;
+    }
+
+    drv_idx = mgmt_ie_get_index(priv, ie_mask, ie_len, *index);
+    if (drv_idx == MLAN_MGMT_IE_INVALID_IDX || drv_idx >= MAX_MGMT_IE_DRV_INDEX)
+    {
+        wifi_e("Invalid DRV index");
+        status = MLAN_STATUS_FAILURE;
+        goto out;
+    }
+
+    pmadapter    = priv->adapter;
+    pmgmt_ie     = pmadapter->mgmt_ie;
+    pmgmt_buffer = pmgmt_ie[drv_idx].cust_ie;
+
+    wifi_d("drv_idx=%d, fw_idx=%d", drv_idx, pmgmt_buffer->ie_index);
+
+    if (pmgmt_buffer->mgmt_subtype_mask == MLAN_MGMT_IE_INVALID_MASK)
+    {
+        pmgmt_buffer->ie_buf = ie_buf_get(ie_len);
+        if (pmgmt_buffer->ie_buf == MNULL)
+        {
+            wifi_e("Failed to allocate memory for IE buffer");
+            /* Roll back the DRV entry */
+            mgmt_ie_entry_clear(pmadapter, drv_idx);
+            status = MLAN_STATUS_FAILURE;
+            goto out;
+        }
+        pmgmt_buffer->mgmt_subtype_mask = ie_mask;
+    }
+
+    pmgmt_ie[drv_idx].ie_offset  = pmgmt_buffer->ie_length;
+    pmgmt_ie[drv_idx].bss_type   = priv->bss_type;
+    pmgmt_ie[drv_idx].cur_ie_len = ie_len;
+
+     /* Append the IE data */
+    (void)memcpy(pmgmt_buffer->ie_buf + pmgmt_buffer->ie_length, ie_buf, ie_len);
+    pmgmt_buffer->ie_length += ie_len;
+    /* Mark dirty for deferred FW download */
+    pmgmt_buffer->dirty = 1;
+
+    *index = drv_idx;
+
+out:
+    LEAVE();
+
+    return status;
+}
+
+/**
+ * @brief Remove one IE from a (possibly shared) mgmt buffer.
+ *
+ * @param priv     Pointer to the mlan_private driver data struct
+ * @param drv_idx  DRV index of the IE to remove
+ * @param fw_idx   mgmt buffer index that contains the IE
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_remove(mlan_private *priv, t_u16 drv_idx, t_u16 fw_idx)
+{
+    mlan_adapter *pmadapter     = MNULL;
+    custom_ie_entry *pmgmt_ie   = MNULL;
+    custom_ie_hdr *pmgmt_buffer = MNULL;
+    t_u8 *new_buf               = MNULL;
+    t_u8 i = 0;
+
+    ENTER();
+
+    if (!priv ||
+        drv_idx >= MAX_MGMT_IE_DRV_INDEX ||
+        fw_idx >= priv->adapter->max_mgmt_buf_count)
+    {
+        wifi_e("Invalid input parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    pmadapter    = priv->adapter;
+    pmgmt_ie     = pmadapter->mgmt_ie;
+    pmgmt_buffer = pmadapter->mgmt_buffer;
+
+    (void)memmove(pmgmt_buffer[fw_idx].ie_buf + pmgmt_ie[drv_idx].ie_offset,
+                    pmgmt_buffer[fw_idx].ie_buf + pmgmt_ie[drv_idx].ie_offset + pmgmt_ie[drv_idx].cur_ie_len,
+                    pmgmt_buffer[fw_idx].ie_length - (pmgmt_ie[drv_idx].ie_offset + pmgmt_ie[drv_idx].cur_ie_len));
+
+    pmgmt_buffer[fw_idx].ie_length -= pmgmt_ie[drv_idx].cur_ie_len;
+
+    /*
+     * Fixup ie_offset for all DRV entries that share fw_idx and
+     * whose data starts after the removed IE — they have all shifted left
+     * by cur_ie_len bytes.
+     */
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        if (pmgmt_ie[i].cust_ie && (i != drv_idx) &&
+            pmgmt_ie[i].cust_ie->ie_index == fw_idx &&
+            pmgmt_ie[i].ie_offset > pmgmt_ie[drv_idx].ie_offset)
+        {
+            pmgmt_ie[i].ie_offset -= pmgmt_ie[drv_idx].cur_ie_len;
+        }
+    }
+
+    /* Mark dirty for deferred FW download */
+    pmgmt_buffer[fw_idx].dirty = 1;
+
+    /*
+     * Opportunistically migrate the buffer to a smaller pool class now that
+     * its content is shorter.
+     */
+    new_buf = ie_buf_renew(pmgmt_buffer[fw_idx].ie_buf,
+                            pmgmt_buffer[fw_idx].ie_length,
+                            pmgmt_buffer[fw_idx].ie_length);
+    if (new_buf)
+    {
+        pmgmt_buffer[fw_idx].ie_buf = new_buf;
+    }
+
+    /* Release the DRV slot; the mgmt buffer still be shared by other entries */
+    mgmt_ie_entry_clear(pmadapter, drv_idx);
+
+    LEAVE();
+
+    return MLAN_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Update an existing IE entry in-place or via remove-then-add.
+ *
+ * Two paths depending on whether the DRV entry exclusively owns its mgmt buffer:
+ *
+ *  Exclusive path (mgmt buffer ie_length == DRV entry cur_ie_len):
+ *   - Calls ie_buf_renew() to resize the buffer if needed.
+ *   - Overwrites the buffer content with the new IE data.
+ *   - Updates ie_length and cur_ie_len, marks dirty.
+ *
+ *  Shared path (mgmt buffer holds IEs from multiple DRV entries):
+ *   - Calls mgmt_ie_remove() to excise the old IE from the shared buffer.
+ *   - Calls mgmt_ie_add() to insert the new IE (may land in the same or a
+ *     different mgmt buffer depending on available space).
+ *
+ * @param priv     Pointer to the mlan_private driver data struct
+ * @param ie_mask  Management frame type mask (used only in the shared path
+ *                 when re-adding the IE)
+ * @param ie_buf   New IE data
+ * @param ie_len   Length of @p ie_buf in bytes
+ * @param index    IN/OUT: DRV index of the IE to update
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_update(mlan_private *priv, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index)
+{
+    mlan_status status           = MLAN_STATUS_SUCCESS;
+    mlan_adapter *pmadapter      = MNULL;
+    custom_ie_entry *pmgmt_ie    = MNULL;
+    custom_ie_hdr *pmgmt_buffer  = MNULL;
+    t_u16 drv_idx = MLAN_MGMT_IE_INVALID_IDX;
+    t_u16 fw_idx  = MLAN_MGMT_IE_INVALID_IDX;
+    t_u8 *new_buf = MNULL;
+
+    ENTER();
+
+    if (!priv || !ie_buf || !index || *index == MLAN_MGMT_IE_INVALID_IDX || *index >= MAX_MGMT_IE_DRV_INDEX)
+    {
+        wifi_e("Invalid parameters");
+        status = MLAN_STATUS_FAILURE;
+        goto out;
+    }
+
+    pmadapter    = priv->adapter;
+    pmgmt_ie     = pmadapter->mgmt_ie;
+    drv_idx      = *index;
+    pmgmt_buffer = pmgmt_ie[drv_idx].cust_ie;
+    fw_idx       = pmgmt_buffer->ie_index;
+
+    /*
+     * If the mgmt buffer's total length equals the amount owned by this DRV
+     * entry, no other DRV entry is sharing the buffer — safe to overwrite.
+     */
+    if (pmgmt_buffer->ie_length == pmgmt_ie[drv_idx].cur_ie_len)
+    {
+        /* Resize the pool buffer if the new IE is larger or smaller */
+        new_buf = ie_buf_renew(pmgmt_buffer->ie_buf, pmgmt_buffer->ie_length, ie_len);
+        if (new_buf == MNULL)
+        {
+            wifi_e("Failed to renew memory for IE buffer");
+            status = MLAN_STATUS_FAILURE;
+            goto out;
+        }
+        pmgmt_buffer->ie_buf = new_buf;
+        (void)memcpy(pmgmt_buffer->ie_buf, ie_buf, ie_len);
+        pmgmt_buffer->ie_length      = ie_len;
+        pmgmt_ie[drv_idx].cur_ie_len = ie_len;
+        pmgmt_buffer->dirty = 1;
+    }
+    else
+    {
+        /*
+         * Shared-buffer path: excise the old bytes then re-insert the new
+         * IE.  mgmt_ie_add() will try to merge into the same FW buffer if
+         * capacity allows, or allocate a new one otherwise.
+         */
+        status = mgmt_ie_remove(priv, drv_idx, fw_idx);
+        if (status != MLAN_STATUS_SUCCESS)
+        {
+            wifi_e("Failed to remove management IE");
+            goto out;
+        }
+
+        /*
+         * Keep the DRV index the same to simplify the caller's tracking logic,
+         * but mgmt_ie_add() may link it to a different mgmt buffer if the IE size has changed.
+         */
+        status = mgmt_ie_add(priv, ie_mask, ie_buf, ie_len, &drv_idx);
+        if (status != MLAN_STATUS_SUCCESS)
+        {
+            wifi_e("Failed to add management IE");
+            goto out;
+        }
+    }
+
+out:
+    LEAVE();
+
+    return status;
+}
+
+/**
+ * @brief Mark an mgmt IE entry for removal
+ *
+ * Two paths depending on whether the DRV entry exclusively owns its mgmt buffer:
+ *
+ *  Exclusive path (mgmt buffer ie_length == DRV entry cur_ie_len):
+ *   - Sets mgmt_subtype_mask to MGMT_MASK_CLEAR and ie_length to 0.
+ *   - Marks the mgmt buffer dirty; mgmt_ie_commit_dirty() will send the CLEAR
+ *     command and then call mgmt_buffer_entry_clear() to free the IE buffer.
+ *
+ *  Shared path (mgmt buffer holds IEs from multiple DRV entries):
+ *   - Delegates to mgmt_ie_remove() which excises the IE bytes, adjusts
+ *     offsets of sibling DRV entries, and clears this DRV entry.
+ *
+ * @param priv   Pointer to the mlan_private driver data struct
+ * @param index  IN/OUT: DRV index to clear
+ *
+ * @return       MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+static mlan_status mgmt_ie_clear(mlan_private *priv, t_u16 *index)
+{
+    mlan_status status          = MLAN_STATUS_SUCCESS;
+    mlan_adapter *pmadapter     = MNULL;
+    custom_ie_entry *pmgmt_ie   = MNULL;
+    custom_ie_hdr *pmgmt_buffer = MNULL;
+    t_u16 drv_idx = MLAN_MGMT_IE_INVALID_IDX;
+    t_u16 fw_idx  = MLAN_MGMT_IE_INVALID_IDX;
+
+    ENTER();
+
+    if (!priv || !index || *index == MLAN_MGMT_IE_INVALID_IDX || *index >= MAX_MGMT_IE_DRV_INDEX)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    pmadapter    = priv->adapter;
+    pmgmt_ie     = pmadapter->mgmt_ie;
+    drv_idx      = *index;
+    pmgmt_buffer = pmgmt_ie[drv_idx].cust_ie;
+    fw_idx       = pmgmt_buffer->ie_index;
+
+    /*
+     * This DRV entry owns the entire FW buffer.
+     * Mark it for clearing and let mgmt_ie_commit_dirty() handle the FW update and buffer cleanup.
+     */
+    if (pmgmt_buffer->ie_length == pmgmt_ie[drv_idx].cur_ie_len)
+    {
+        pmgmt_buffer->mgmt_subtype_mask = MGMT_MASK_CLEAR;
+        pmgmt_buffer->ie_length         = 0;
+        pmgmt_buffer->dirty             = 1;
+    }
+    else
+    {
+        /*
+         * Shared-buffer path: excise the IE from the FW buffer and clear this DRV entry
+         */
+        status = mgmt_ie_remove(priv, drv_idx, fw_idx);
+        if (status != MLAN_STATUS_SUCCESS)
+        {
+            wifi_e("Failed to remove management IE");
+            LEAVE();
+            return status;
+        }
+    }
+
+    /* Invalidate the caller's index to prevent accidental reuse */
+    *index = MLAN_MGMT_IE_INVALID_IDX;
+
+    LEAVE();
+
+    return MLAN_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Filter a raw beacon IE buffer, retaining only driver-managed IEs.
+ *
+ * Parses the TLV-encoded IE stream at @p ie (length @p len) and copies
+ * selected IEs into @p ie_out.
+ *
+ * @param priv        Pointer to the mlan_private driver data struct
+ * @param ie          Input IE buffer
+ * @param len         Length of @p ie in bytes
+ * @param ie_out      Output buffer for filtered IEs
+ * @param ie_out_len  Size of @p ie_out in bytes
+ * @param wps_flag    Bitmask of IE_MASK_* flags controlling which vendor IEs
+ *                    are filtered out
+ *
+ * @return            Number of bytes written to @p ie_out.
+ */
+static t_u16 mgmt_ie_filter_beacon(mlan_private *priv,
+                                    const t_u8 *ie,
+                                    int len,
+                                    t_u8 *ie_out,
+                                    t_u32 ie_out_len,
+                                    t_u16 wps_flag)
+{
+    int left_len    = len;
+    const t_u8 *pos = ie;
+    int length;
+    t_u8 id                                = 0;
+    t_u16 out_len                          = 0;
+    IEEEtypes_VendorSpecific_t *pvendor_ie = NULL;
+    const t_u8 wps_oui[4]                  = {0x00, 0x50, 0xf2, 0x04};
+    const t_u8 p2p_oui[4]                  = {0x50, 0x6f, 0x9a, 0x09};
+    const t_u8 wfd_oui[4]                  = {0x50, 0x6f, 0x9a, 0x0a};
+    const t_u8 wmm_oui[4]                  = {0x00, 0x50, 0xf2, 0x02};
+    t_u8 find_p2p_ie                       = MFALSE;
+#define WLAN_EID_ERP_INFO 42
+
+    /* ERP_INFO/EXTENDED_SUPPORT_RATES/HT_CAPABILITY/HT_OPERATION/WMM
+     * and WPS/P2P/WFD IE will be fileter out
+     */
+    while (left_len >= 2)
+    {
+        length = *(pos + 1);
+        id     = *pos;
+        if ((length + 2) > left_len)
+            break;
+
+        switch (id)
+        {
+            case COUNTRY_INFO:
+                if ((out_len + length + 2) < (int)ie_out_len)
+                {
+                    (void)memcpy(ie_out + out_len, pos, length + 2);
+                    out_len += (t_u16)(length + 2);
+                }
+                else
+                {
+                    wifi_d("IE too big, fail copy COUNTRY INFO IE");
+                }
+                break;
+            case HT_CAPABILITY:
+            case HT_OPERATION:
+#if CONFIG_11AC
+            case VHT_CAPABILITY:
+            case VHT_OPERATION:
+#endif
+#if UAP_HOST_MLME
+                if ((out_len + length + 2) < (int)ie_out_len)
+                {
+                    (void)memcpy(ie_out + out_len, pos, length + 2);
+                    out_len += length + 2;
+                }
+                else
+                {
+                    wifi_d("IE too big, fail copy COUNTRY INFO IE");
+                }
+#endif
+                break;
+            case EXTENDED_SUPPORTED_RATES:
+            case WLAN_EID_ERP_INFO:
+                /* Fall Through */
+            case REGULATORY_CLASS:
+                /* Fall Through */
+            case OVERLAPBSSSCANPARAM:
+                break;
+#if CONFIG_11AX
+            case EXTENSION:
+#if UAP_SUPPORT
+#if CONFIG_11AX
+                if ((*(pos + 2) == HE_CAPABILITY || *(pos + 2) == HE_OPERATION) && !IS_FW_SUPPORT_11AX(mlan_adap))
+                {
+                    /* Ignore HE-cap and HE-op if FW doesn't support HE */
+                    break;
+                }
+
+                if (*(pos + 2) == HE_CAPABILITY)
+                {
+                    mlan_ds_11ax_he_cfg he_cfg;
+                    IEEEtypes_HECap_t *hecap_ie = NULL;
+                    (void)memset((void *)&he_cfg, 0, sizeof(mlan_ds_11ax_he_cfg));
+
+                    if (priv->uap_channel <= 14)
+                        he_cfg.band = MBIT(0);
+                    else
+                        he_cfg.band = MBIT(1);
+
+                    wifi_d("Retrieve 11ax cfg by channel=%d band=%d", priv->uap_channel, he_cfg.band);
+
+                    if (0 == wlan_cmd_11ax_cfg(priv, HostCmd_ACT_GEN_GET, &he_cfg))
+                    {
+                        t_u16 he_cap_len;
+                        hecap_ie                      = (IEEEtypes_HECap_t *)&he_cfg.he_cap.len;
+                        he_cap_len                    = he_cfg.he_cap.len;
+                        hecap_ie->ieee_hdr.len        = he_cap_len;
+                        hecap_ie->ieee_hdr.element_id = (IEEEtypes_ElementId_e)he_cfg.he_cap.id;
+
+                        (void)memcpy(ie_out + out_len, hecap_ie, hecap_ie->ieee_hdr.len + 2);
+
+                        out_len += hecap_ie->ieee_hdr.len + 2;
+                    }
+                    else
+                    {
+                        wifi_d("Fail to get 11ax he_cap parameters");
+                    }
+                }
+                else
+#endif
+#endif
+                {
+                    if ((out_len + length + 2) < (int)ie_out_len)
+                    {
+                        (void)memcpy(ie_out + out_len, pos, length + 2);
+                        out_len += length + 2;
+                    }
+                    else
+                    {
+                        wifi_d("IE too big, fail copy EXTENSION IE");
+                    }
+                }
+                break;
+#endif
+            case EXT_CAPABILITY:
+                /* filter out EXTCAP */
+                if (wps_flag & IE_MASK_EXTCAP)
+                {
+                    break;
+                }
+                if ((out_len + length + 2) < (int)ie_out_len)
+                {
+                    (void)memcpy(ie_out + out_len, pos, length + 2);
+                    out_len += length + 2;
+                }
+                else
+                {
+                    wifi_d("IE too big, fail copy EXTCAP IE");
+                }
+                break;
+            case VENDOR_SPECIFIC_221:
+                /* filter out wmm ie */
+                pvendor_ie = (IEEEtypes_VendorSpecific_t *)pos;
+                if (!memcmp(pvendor_ie->vend_hdr.oui, wmm_oui, sizeof(pvendor_ie->vend_hdr.oui)) &&
+                    pvendor_ie->vend_hdr.oui_type == wmm_oui[3])
+                {
+                    break;
+                }
+                /* filter out wps ie */
+                else if (!memcmp(pvendor_ie->vend_hdr.oui, wps_oui, sizeof(pvendor_ie->vend_hdr.oui)) &&
+                        pvendor_ie->vend_hdr.oui_type == wps_oui[3])
+                {
+                    if (wps_flag & IE_MASK_WPS)
+                        break;
+                }
+                /* filter out first p2p ie */
+                else if (!memcmp(pvendor_ie->vend_hdr.oui, p2p_oui, sizeof(pvendor_ie->vend_hdr.oui)) &&
+                        pvendor_ie->vend_hdr.oui_type == p2p_oui[3])
+                {
+                    if (!find_p2p_ie && (wps_flag & IE_MASK_P2P))
+                    {
+                        find_p2p_ie = MTRUE;
+                        break;
+                    }
+                }
+                /* filter out wfd ie */
+                else if (!memcmp(pvendor_ie->vend_hdr.oui, wfd_oui, sizeof(pvendor_ie->vend_hdr.oui)) &&
+                        pvendor_ie->vend_hdr.oui_type == wfd_oui[3])
+                {
+                    if (wps_flag & IE_MASK_WFD)
+                        break;
+                }
+                else if (wps_flag & IE_MASK_VENDOR)
+                {
+                    // filter out vendor IE
+                    break;
+                }
+                if ((out_len + length + 2) < (int)ie_out_len)
+                {
+                    (void)memcpy(ie_out + out_len, pos, length + 2);
+                    out_len += length + 2;
+                }
+                else
+                {
+                    wifi_d("IE too big, fail copy VENDOR_SPECIFIC_221 IE");
+                }
+                break;
+            default:
+                if ((out_len + length + 2) < (int)ie_out_len)
+                {
+                    (void)memcpy(ie_out + out_len, pos, length + 2);
+                    out_len += length + 2;
+                }
+                else
+                {
+                    wifi_d("IE too big, fail copy %d IE", id);
+                }
+                break;
+        }
+
+        pos += (length + 2);
+        left_len -= (length + 2);
+    }
+
+    return out_len;
+}
+
+/********************************************************
+                Global Functions
+********************************************************/
+
+void wlan_init_mgmt_ie_param(pmlan_adapter pmadapter)
+{
+    t_u8 i = 0;
+
+    ENTER();
+
+    pmadapter->max_mgmt_buf_count = 0;
+    pmadapter->mgmt_ie_cnt_sm = 0;
+    pmadapter->mgmt_ie_cnt_md = 0;
+    pmadapter->mgmt_ie_cnt_lg = 0;
+
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        mgmt_ie_entry_clear(pmadapter, i);
+    }
+
+    for (i = 0; i < MAX_MGMT_IE_FW_INDEX; i++)
+    {
+        mgmt_buffer_entry_clear(pmadapter, i);
+    }
+
+    LEAVE();
+}
+
+mlan_status wifi_mgmt_ie_init(void)
+{
+    ENTER();
+
+    if (s_mgmt_ie_initialized == MTRUE)
+    {
+        return MLAN_STATUS_SUCCESS;
+    }
+
+    s_mgmt_buf_cfgs[0].buf_cnt = MLAN_MGMT_BUF_SM_CNT; // mlan_adap->mgmt_ie_cnt_sm;
+    s_mgmt_buf_cfgs[1].buf_cnt = MLAN_MGMT_BUF_MD_CNT; // mlan_adap->mgmt_ie_cnt_md;
+    s_mgmt_buf_cfgs[2].buf_cnt = MLAN_MGMT_BUF_LG_CNT; // mlan_adap->mgmt_ie_cnt_lg;
+
+    if (util_buf_pool_init(&s_mgmt_buf_handle, s_mlan_buf_class, s_mgmt_buf_cfgs,
+                        MGMT_BUFPOOL_NUM, wrapper_buffer_malloc, wrapper_buffer_free) != 0)
+    {
+        wifi_e("Failed to init mgmt buffer pool");
+        return MLAN_STATUS_FAILURE;
+    }
+
+    if (OSA_MutexCreate((osa_mutex_handle_t)s_ie_mutex) != KOSA_StatusSuccess)
+    {
+        wifi_e("Failed to create IE mutex");
+        util_buf_pool_deinit(&s_mgmt_buf_handle);
+        return MLAN_STATUS_FAILURE;
+    }
+
+    s_mgmt_ie_initialized = MTRUE;
+
+    LEAVE();
+
+    return MLAN_STATUS_SUCCESS;
+}
+
+void wifi_mgmt_ie_deinit(void)
+{
+    ENTER();
+
+    if (s_mgmt_ie_initialized == MTRUE)
+    {
+        util_buf_pool_deinit(&s_mgmt_buf_handle);
+
+        if (OSA_MutexDestroy((osa_mutex_handle_t)s_ie_mutex) != KOSA_StatusSuccess)
+        {
+            wifi_e("Failed to destroy IE mutex");
+            return;
+        }
+
+        s_mgmt_ie_initialized = MFALSE;
+    }
+
+    LEAVE();
+}
+
+/**
+ * @brief Set (add or update) a mgmt IE
+ *
+ * Dispatch logic based on *@p index:
+ *  - MLAN_MGMT_IE_INVALID_IDX  →  mgmt_ie_add()    (new IE)
+ *  - valid DRV index           →  mgmt_ie_update() (replace existing IE)
+ *
+ * @param priv     Pointer to the mlan_private driver data struct
+ * @param ie_mask  Management frame type mask
+ * @param ie_buf   IE data buffer
+ * @param ie_len   Length of @p ie_buf in bytes
+ * @param index    IN/OUT: MLAN_MGMT_IE_INVALID_IDX for adding a new IE,
+ *                 or a valid DRV index for updating an existing IE
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+mlan_status wifi_mgmt_ie_set(mlan_private *priv, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index)
+{
+    mlan_status status = MLAN_STATUS_FAILURE;
+
+    ENTER();
+
+    if (!priv || ie_mask == MLAN_MGMT_IE_INVALID_MASK || !ie_buf || ie_len == 0 || !index)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    wrapper_mgmt_ie_lock();
+
+    if (*index == MLAN_MGMT_IE_INVALID_IDX)
+    {
+        status = mgmt_ie_add(priv, ie_mask, ie_buf, ie_len, index);
+    }
+    else
+    {
+        status = mgmt_ie_update(priv, ie_mask, ie_buf, ie_len, index);
+    }
+
+    if (status == MLAN_STATUS_SUCCESS)
+    {
+        status = mgmt_ie_commit_dirty(priv);
+    }
+
+    wrapper_mgmt_ie_unlock();
+
+    LEAVE();
+    return status;
+}
+
+/**
+ * @brief Apply multiple IE set/clear operations atomically in a single batch.
+ *
+ * Iterates @p reqs[0..req_cnt-1] and for each entry:
+ *  - MGMT_IE_BATCH_SET:   calls mgmt_ie_add() or mgmt_ie_update() depending
+ *                         on whether *reqs[i].index is MLAN_MGMT_IE_INVALID_IDX.
+ *  - MGMT_IE_BATCH_CLEAR: calls mgmt_ie_clear().
+ *
+ * @param priv     Pointer to the mlan_private driver data struct
+ * @param reqs     Array of batch request descriptors
+ * @param req_cnt  Number of entries in @p reqs
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+mlan_status wifi_mgmt_ie_set_batch(mlan_private *priv, mgmt_ie_batch_req *reqs, t_u8 req_cnt)
+{
+    mlan_status status = MLAN_STATUS_SUCCESS;
+    t_u8 i = 0;
+
+    ENTER();
+
+    if (!priv || !reqs || req_cnt == 0)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    wrapper_mgmt_ie_lock();
+
+    for (i = 0; i < req_cnt; i++)
+    {
+        if (reqs[i].op == MGMT_IE_BATCH_SET)
+        {
+            if (*reqs[i].index == MLAN_MGMT_IE_INVALID_IDX)
+            {
+                status = mgmt_ie_add(priv, reqs[i].ie_mask, reqs[i].ie_buf,
+                                        reqs[i].ie_len, reqs[i].index);
+            }
+            else
+            {
+                status = mgmt_ie_update(priv, reqs[i].ie_mask, (t_u8 *)reqs[i].ie_buf,
+                                        reqs[i].ie_len, reqs[i].index);
+            }
+        }
+        else /* MGMT_IE_BATCH_CLEAR */
+        {
+            status = mgmt_ie_clear(priv, reqs[i].index);
+        }
+
+        if (status != MLAN_STATUS_SUCCESS)
+        {
+            wifi_e("Failed to process request for index %d", i);
+            goto out;
+        }
+    }
+
+    status = mgmt_ie_commit_dirty(priv);
+    if (status != MLAN_STATUS_SUCCESS)
+    {
+        wifi_e("Failed to commit management IE changes");
+        goto out;
+    }
+
+out:
+    wrapper_mgmt_ie_unlock();
+
+    LEAVE();
+    return status;
+}
+
+/**
+ * @brief Clear a mgmt IE entry
+ *
+ * On success *@p index is set to MLAN_MGMT_IE_INVALID_IDX.
+ *
+ * @param priv   Pointer to the mlan_private driver data struct
+ * @param index  IN/OUT: DRV index of the IE to clear
+ *
+ * @return       MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+mlan_status wifi_mgmt_ie_clear(mlan_private *priv, t_u16 *index)
+{
+    mlan_status status = MLAN_STATUS_SUCCESS;
+
+    ENTER();
+
+    if (!priv || !index || *index == MLAN_MGMT_IE_INVALID_IDX || *index >= MAX_MGMT_IE_DRV_INDEX)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    wrapper_mgmt_ie_lock();
+
+    status = mgmt_ie_clear(priv, index);
+    if (status == MLAN_STATUS_SUCCESS)
+    {
+        status = mgmt_ie_commit_dirty(priv);
+    }
+
+    wrapper_mgmt_ie_unlock();
+
+    LEAVE();
+    return status;
+}
+
+/**
+ * @brief Replace a specific IE element within the stored MGMT IEs of an interface.
+ *
+ * Scans all DRV IE entries belonging to @p priv's bss_type.  For each entry,
+ * parses the IE byte stream looking for an element whose element_id matches
+ * @p ie_id.  For VENDOR_SPECIFIC_221 (0xDD), additionally checks that the OUI
+ * and OUI type match @p oui[0..3].
+ *
+ * On match, one of three replacement strategies is applied:
+ *
+ *  1. COUNTRY_INFO (special path):
+ *     - Fetches the current FW buffer content from firmware via mgmt_ie_fetch().
+ *     - Filters it through mgmt_ie_filter_beacon() to strip WPS/P2P/WFD/vendor IEs.
+ *     - Rebuilds the IE stream, substituting the new COUNTRY_INFO element.
+ *     - Calls mgmt_ie_update() with the reconstructed buffer.
+ *
+ *  2. Same-length replacement (cur_ie_len == ie_len):
+ *     - Overwrites the IE bytes in-place with memcpy().
+ *     - Marks the FW buffer dirty.
+ *
+ *  3. Different-length replacement:
+ *     - Reconstructs the DRV entry's IE stream in a temporary buffer
+ *       (prefix + new IE + suffix).
+ *     - Calls mgmt_ie_update() with the reconstructed buffer.
+ *
+ * After processing all matching entries, calls mgmt_ie_commit_dirty() to
+ * download all dirty FW buffers to firmware.
+ *
+ * @param priv    Pointer to the mlan_private driver data struct
+ * @param ie_buf  New IE data
+ * @param ie_len  Length of @p ie_buf in bytes
+ * @param ie_id   IEEE 802.11 element ID of the IE to replace
+ * @param oui     4-byte OUI+type array for VENDOR_SPECIFIC_221 matching;
+ *                ignored (may be NULL) for non-vendor IEs
+ *
+ * @return        MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+mlan_status wifi_mgmt_ie_replace_elem(mlan_private *priv, t_u8 *ie_buf, t_u16 ie_len, IEEEtypes_ElementId_e ie_id, t_u8 *oui)
+{
+    mlan_status status          = MLAN_STATUS_SUCCESS;
+    mlan_adapter *pmadapter     = MNULL;
+    custom_ie_entry *pmgmt_ie   = MNULL;
+    custom_ie_hdr *pmgmt_buffer = MNULL;
+    t_u16 drv_idx    = MLAN_MGMT_IE_INVALID_IDX;
+    t_u16 cur_fw_idx = MLAN_MGMT_IE_INVALID_IDX;
+    t_u8 *cur_mgmt_ie_buf = MNULL;
+    t_u16 cur_mgmt_ie_len = 0;
+    t_u8 *tmp_ie_buf    = MNULL;
+    t_u16 tmp_ie_len    = 0;
+    t_u16 tmp_ie_offset = 0;
+    IEEEtypes_Header_t *cur_ie              = MNULL;
+    IEEEtypes_VendorHeader_t *cur_vendor_ie = MNULL;
+    t_u16 cur_ie_len = 0;
+    t_u8 i = 0;
+
+    ENTER();
+
+    if (!priv || !ie_buf || ie_len == 0)
+    {
+        wifi_e("Invalid parameters");
+        LEAVE();
+        return MLAN_STATUS_FAILURE;
+    }
+
+    wrapper_mgmt_ie_lock();
+
+    tmp_ie_buf = wrapper_buffer_malloc(sizeof(tlvbuf_custom_ie) + sizeof(custom_ie));
+    if (!tmp_ie_buf)
+    {
+        wifi_e("Failed to allocate memory for IE buffer");
+        status = MLAN_STATUS_FAILURE;
+        goto out;
+    }
+
+    pmadapter = priv->adapter;
+    pmgmt_ie  = pmadapter->mgmt_ie;
+
+    /* Scan every DRV IE entry that belongs to this interface */
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        if ((pmgmt_ie[i].bss_type == priv->bss_type) &&
+            (pmgmt_ie[i].cust_ie != MNULL))
+        {
+            t_u8 match_found = 0;
+            pmgmt_buffer    = pmgmt_ie[i].cust_ie;
+            cur_fw_idx      = pmgmt_buffer->ie_index;
+            /* Narrow the search to the byte range owned by this DRV entry */
+            cur_mgmt_ie_buf = pmgmt_buffer->ie_buf + pmgmt_ie[i].ie_offset;
+            cur_mgmt_ie_len = pmgmt_ie[i].cur_ie_len;
+
+            tmp_ie_offset = 0;
+
+             /* Walk the sub-IE TLV stream within this DRV entry's range */
+            while (tmp_ie_offset < cur_mgmt_ie_len)
+            {
+                cur_ie = (IEEEtypes_Header_t *)(cur_mgmt_ie_buf + tmp_ie_offset);
+                cur_ie_len = cur_ie->len + 2U;
+
+                if (cur_ie->element_id == ie_id)
+                {
+                    wifi_d("Found matching IE [%d] at offset %d", i, tmp_ie_offset);
+                    if (ie_id == VENDOR_SPECIFIC_221)
+                    {
+                        /* For vendor IEs, also verify OUI and OUI type */
+                        cur_vendor_ie = (IEEEtypes_VendorHeader_t *)cur_ie;
+                        if (!memcmp(cur_vendor_ie->oui, oui, 3) &&
+                            (cur_vendor_ie->oui_type == oui[3]))
+                        {
+                            match_found = 1;
+                        }
+                    }
+                    else
+                    {
+                        match_found = 1;
+                    }
+
+                    if (match_found)
+                    {
+                        wifi_d("Matched IE found, replacing IE");
+                        drv_idx = i;
+                        //TODO: ECSA improvement
+                        if (cur_ie->element_id == COUNTRY_INFO)
+                        {
+                            wifi_d("Update COUNTRY_INFO IE");
+                            /*
+                             * Fetch the current FW buffer so we can rebuild the
+                             * entire beacon IE stream with the new COUNTRY_INFO
+                             * element substituted in place.
+                             */
+                            status = mgmt_ie_fetch(priv, tmp_ie_buf, cur_fw_idx);
+                            if (status != MLAN_STATUS_SUCCESS)
+                            {
+                                wifi_e("Failed to get custom ie, index = %d", cur_fw_idx);
+                                goto out;
+                            }
+
+                            tmp_ie_len = ((tlvbuf_custom_ie *)tmp_ie_buf)->length + sizeof(tlvbuf_custom_ie);
+                            if ((tmp_ie_len < (sizeof(tlvbuf_custom_ie) + MLAN_CUSTOM_IE_HDR_SIZE)) ||
+                                tmp_ie_len > sizeof(tlvbuf_custom_ie) + sizeof(custom_ie))
+                            {
+                                wifi_e("%s: get_mgmt_ie index=%d invalid len=%d", __FUNCTION__, cur_fw_idx, tmp_ie_len);
+                                goto out;
+                            }
+                            else
+                            {
+                                wifi_d("Custom IE data from FW:");
+                                // dump_hex(tmp_ie_buf, tmp_ie_len);
+
+                                custom_ie *cu_ie = (custom_ie *)(tmp_ie_buf + sizeof(tlvbuf_custom_ie));
+                                t_u8 *cu_ie_buf = (t_u8 *)cu_ie + MLAN_CUSTOM_IE_HDR_SIZE;
+
+                                t_u8 beacon_ie_buf[MAX_IE_SIZE] = {0};
+                                t_u16 beacon_ie_len             = 0;
+                                t_u8 new_ie_buf[MAX_IE_SIZE]    = {0};
+                                t_u16 new_ie_len                = 0;
+                                t_u8 *new_ie_ptr                = new_ie_buf;
+                                bool country_ie_in_beacon       = false;
+
+                                beacon_ie_len = mgmt_ie_filter_beacon(priv, cu_ie_buf, cu_ie->ie_length, beacon_ie_buf, MAX_IE_SIZE,
+                                                                    IE_MASK_WPS | IE_MASK_WFD | IE_MASK_P2P | IE_MASK_VENDOR);
+                                t_u8 *ptr  = beacon_ie_buf;
+                                t_u16 left = beacon_ie_len;
+                                /*
+                                 * Rebuild the IE stream: copy every element
+                                 * unchanged except COUNTRY_INFO, which is
+                                 * replaced with the new ie_buf.
+                                 */
+                                while (left >= sizeof(IEEEtypes_Header_t))
+                                {
+                                    IEEEtypes_Header_t *cu_ieee_hdr = (IEEEtypes_Header_t *)ptr;
+                                    if (cu_ieee_hdr->element_id != COUNTRY_INFO)
+                                    {
+                                        (void)memcpy(new_ie_ptr, (t_u8 *)cu_ieee_hdr, cu_ieee_hdr->len + 2U);
+                                        new_ie_ptr += (cu_ieee_hdr->len + 2U);
+                                        new_ie_len += (cu_ieee_hdr->len + 2U);
+                                    }
+                                    else
+                                    {
+                                        country_ie_in_beacon = true;
+                                        (void)memcpy(new_ie_ptr, ie_buf, ie_len);
+                                        new_ie_ptr += ie_len;
+                                        new_ie_len += ie_len;
+                                    }
+                                    left -= (cu_ieee_hdr->len + 2U);
+                                    ptr += cu_ieee_hdr->len + 2U;
+                                }
+                                /*
+                                 * If COUNTRY_INFO was not present in the
+                                 * beacon, append it at the end.
+                                 */
+                                if (!country_ie_in_beacon)
+                                {
+                                    (void)memcpy(new_ie_ptr, ie_buf, ie_len);
+                                    new_ie_ptr += ie_len;
+                                    new_ie_len += ie_len;
+                                }
+                                status = mgmt_ie_update(priv, pmgmt_buffer->mgmt_subtype_mask, new_ie_buf, new_ie_len, &drv_idx);
+                                if (status != MLAN_STATUS_SUCCESS)
+                                {
+                                    wifi_e("Failed to update COUNTRY_INFO IE");
+                                    goto out;
+                                }
+                            }
+                        }
+                        else if (cur_ie_len == ie_len)
+                        {
+                            wifi_d("IE length matches, replacing in-place");
+                            /*
+                             * Direct overwrite is safe because the buffer
+                             * capacity and the mgmt buffer layout are unchanged.
+                             */
+                            (void)memcpy(cur_ie, ie_buf, ie_len);
+                            pmgmt_buffer->dirty = 1;
+                        }
+                        else
+                        {
+                            wifi_d("IE length differs, reconstructing IE buffer");
+                            t_u16 new_len = pmgmt_ie[i].cur_ie_len - cur_ie_len + ie_len;
+                            t_u8 *dst = tmp_ie_buf;
+                            t_u8 *src = pmgmt_buffer->ie_buf + pmgmt_ie[i].ie_offset;
+                            /** copy prefix */
+                            (void)memcpy(dst, src, tmp_ie_offset);
+                            dst += tmp_ie_offset;
+                            /** insert new IE */
+                            (void)memcpy(dst, ie_buf, ie_len);
+                            dst += ie_len;
+                            /** copy suffix */
+                            (void)memcpy(dst,
+                                         src + tmp_ie_offset + cur_ie_len,
+                                         pmgmt_ie[i].cur_ie_len - (tmp_ie_offset + cur_ie_len));
+                            status = mgmt_ie_update(priv, pmgmt_buffer->mgmt_subtype_mask, tmp_ie_buf, new_len, &drv_idx);
+                            if (status != MLAN_STATUS_SUCCESS)
+                            {
+                                wifi_e("Failed to update management IE");
+                                status = MLAN_STATUS_FAILURE;
+                                goto out;
+                            }
+                        }
+                        break;
+                    }
+                }
+                tmp_ie_offset += cur_ie_len;
+            }
+        }
+    }
+
+    /* Flush all dirty mgmt buffers accumulated during the replace operations */
+    status = mgmt_ie_commit_dirty(priv);
+    if (status != MLAN_STATUS_SUCCESS)
+    {
+        wifi_e("Failed to commit management IE changes");
+        goto out;
+    }
+
+out:
+    if (tmp_ie_buf != MNULL)
+    {
+        wrapper_buffer_free(tmp_ie_buf);
+    }
+
+    wrapper_mgmt_ie_unlock();
+
+    LEAVE();
+
+    return status;
+}
+
+/**
+ * @brief Populate a single mgmt_ie_batch_req entry for use with wifi_mgmt_ie_set_batch().
+ *
+ * Convenience helper that encodes the SET-or-CLEAR decision into a batch
+ * request struct.
+ *
+ * @param req      Output batch request entry to fill
+ * @param ie_mask  Management frame type mask
+ * @param ie_buf   IE data pointer
+ * @param ie_len   IE data length
+ * @param index    IN/OUT pointer to the DRV index
+ *
+ * @return         MLAN_STATUS_SUCCESS or MLAN_STATUS_FAILURE
+ */
+mlan_status wifi_mgmt_ie_req_fill(mgmt_ie_batch_req *req, t_u16 ie_mask, t_u8 *ie_buf, t_u16 ie_len, t_u16 *index)
+{
+    if (!req || !index)
+    {
+        return MLAN_STATUS_FAILURE;
+    }
+
+    if (*index != MLAN_MGMT_IE_INVALID_IDX && !ie_len)
+    {
+        /*
+         * The IE was previously installed (valid index) and the caller
+         * supplies no data (len == 0), interpret as a CLEAR request.
+         */
+        req->op      = MGMT_IE_BATCH_CLEAR;
+        req->index   = index;
+        req->ie_mask = MGMT_MASK_CLEAR;
+        req->ie_buf  = MNULL;
+        req->ie_len  = 0;
+        return MLAN_STATUS_SUCCESS;
+    }
+    else if (ie_len)
+    {
+        /*
+         * Non-zero data length, SET (add or update).
+         * *index == MLAN_MGMT_IE_INVALID_IDX triggers mgmt_ie_add(),
+         * a valid *index triggers mgmt_ie_update().
+         */
+        req->op      = MGMT_IE_BATCH_SET;
+        req->index   = index;
+        req->ie_mask = ie_mask;
+        req->ie_buf  = ie_buf;
+        req->ie_len  = ie_len;
+        return MLAN_STATUS_SUCCESS;
+    }
+
+    /*
+     * *index is INVALID and ie_len == 0: nothing to do.
+     * The caller should check the return value and skip this entry.
+     */
+    return MLAN_STATUS_FAILURE;
+}
+
+/* -----------------------------------------------------------------------
+ * Debug helpers
+ * ----------------------------------------------------------------------- */
+
+static void ie_dump_hex(const char *title, const t_u8 *buf, t_u16 len)
+{
+    t_u16 i;
+
+    if (!buf || !len)
+    {
+        return;
+    }
+
+    (void)PRINTF("%s (len=%u):\n", title, len);
+
+    for (i = 0; i < len; i++)
+    {
+        if (i % 16 == 0)
+        {
+            (void)PRINTF("%04x: ", i);
+        }
+
+        (void)PRINTF("%02x ", buf[i]);
+
+        if ((i % 16 == 15) || (i == len - 1))
+        {
+            (void)PRINTF("\n");
+        }
+    }
+}
+
+static void ie_dump_mgmt_buffer(pmlan_adapter pmadapter)
+{
+    t_u16 i;
+
+    (void)PRINTF("=========== MGMT BUFFER DUMP ===========\n");
+
+    for (i = 0; i < pmadapter->max_mgmt_buf_count; i++)
+    {
+        custom_ie_hdr *buf = &pmadapter->mgmt_buffer[i];
+
+        if (buf->mgmt_subtype_mask == MLAN_MGMT_IE_INVALID_MASK)
+            continue;
+
+        (void)PRINTF("FW_IDX=%u\n", i);
+        (void)PRINTF("  mask       = 0x%04x\n", buf->mgmt_subtype_mask);
+        (void)PRINTF("  ie_length  = %u\n", buf->ie_length);
+        (void)PRINTF("  ie_buf     = %p\n", buf->ie_buf);
+
+        if (buf->ie_buf && buf->ie_length > 0)
+        {
+            ie_dump_hex("  IE DATA", buf->ie_buf, buf->ie_length);
+        }
+    }
+}
+
+static void ie_dump_mgmt_ie(pmlan_adapter pmadapter)
+{
+    t_u16 i;
+
+    (void)PRINTF("\n=========== MGMT IE (DRV) DUMP ===========\n");
+
+    (void)PRINTF("--------------------------------------------------------------------------------\n");
+    (void)PRINTF("| %-7s | %-7s | %-10s | %-10s | %-8s | %-8s |\n",
+           "DRV_IDX", "FW_IDX", "MASK", "BSS_TYPE", "OFFSET", "LEN");
+    (void)PRINTF("--------------------------------------------------------------------------------\n");
+
+    for (i = 0; i < MAX_MGMT_IE_DRV_INDEX; i++)
+    {
+        custom_ie_entry *ie = &pmadapter->mgmt_ie[i];
+
+        if (!ie->cust_ie)
+        {
+            continue;
+        }
+
+        (void)PRINTF("| %-7u | %-7u | 0x%08x | %-10u | %-8u | %-8u |\n",
+               i,
+               ie->cust_ie->ie_index,
+               ie->cust_ie->mgmt_subtype_mask,
+               ie->bss_type,
+               ie->ie_offset,
+               ie->cur_ie_len);
+    }
+
+    (void)PRINTF("--------------------------------------------------------------------------------\n\n");
+}
+
+static void ie_dump_buf_pool(pmlan_buf_handle handle)
+{
+    t_u32 i;
+    pmlan_buf_class cls;
+    pmlan_buf_block blk;
+    t_u32 free_cnt;
+
+    (void)PRINTF("=========== BUF POOL DUMP ===========\n");
+
+    if (!handle)
+        return;
+
+    (void)PRINTF("mem_base=%p size=%u\n", handle->mem_base, handle->mem_size);
+
+    for (i = 0; i < handle->class_num; i++)
+    {
+        cls = &handle->classes[i];
+        free_cnt = 0;
+
+        blk = cls->free_list;
+        while (blk)
+        {
+            free_cnt++;
+            blk = blk->next;
+        }
+
+        (void)PRINTF("CLASS[%u]\n", i);
+        (void)PRINTF("  buf_size   = %u\n", cls->buf_size);
+        (void)PRINTF("  total      = %u\n", cls->total);
+        (void)PRINTF("  free       = %u\n", free_cnt);
+        (void)PRINTF("  used       = %u\n", cls->total - free_cnt);
+    }
+}
+
+static void ie_dump_map(pmlan_adapter pmadapter)
+{
+    t_u16 fw, drv;
+    t_u8 has_ref;
+
+    (void)PRINTF("=========== MGMT IE MAP (VISUAL) ===========\n\n");
+
+    for (fw = 0; fw < pmadapter->max_mgmt_buf_count; fw++)
+    {
+        custom_ie_hdr *buf = &pmadapter->mgmt_buffer[fw];
+
+        if (buf->mgmt_subtype_mask == MLAN_MGMT_IE_INVALID_MASK)
+        {
+            continue;
+        }
+
+        (void)PRINTF("FW[%02u]\n", fw);
+        has_ref = 0;
+        for (drv = 0; drv < MAX_MGMT_IE_DRV_INDEX; drv++)
+        {
+            custom_ie_entry *ie = &pmadapter->mgmt_ie[drv];
+
+            if (ie->cust_ie &&
+                ie->cust_ie->ie_index == fw)
+            {
+                (void)PRINTF("   └── DRV[%02u]\n", drv);
+                has_ref = 1;
+            }
+        }
+
+        if (!has_ref)
+        {
+            (void)PRINTF("   └── (no drv)\n");
+        }
+
+        (void)PRINTF("\n");
+    }
+}
+
+/**
+ * @brief Dump all MGMT IE entries for debugging purposes.
+ *
+ * Prints the contents of the MGMT IE table for all interfaces managed by
+ * the given mlan adapter. Intended for debug use only.
+ *
+ * @param pmadapter    Pointer to the mlan adapter structure
+ */
+void wifi_mgmt_ie_dump(pmlan_adapter pmadapter)
+{
+    if (!pmadapter)
+        return;
+
+    (void)PRINTF("\n\n========== WIFI MGMT IE DUMP ==========\n");
+    ie_dump_buf_pool(&s_mgmt_buf_handle);
+    ie_dump_mgmt_buffer(pmadapter);
+    ie_dump_mgmt_ie(pmadapter);
+    ie_dump_map(pmadapter);
+    (void)PRINTF("=============================================\n\n");
+}

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_misc.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_misc.c
@@ -1094,7 +1094,7 @@ done:
 }
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 /**
  *  @brief Configure GPIO independent reset
  *

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
@@ -117,6 +117,25 @@ bool is_split_scan_complete(void)
     return (split_scan_in_progress == false);
 }
 
+void wlan_set_split_scan_status(bool in_progress)
+{
+    split_scan_in_progress = in_progress;
+}
+
+bool wlan_get_split_scan_status(void)
+{
+    return split_scan_in_progress;
+}
+
+void wlan_set_abort_split_scan(bool abort)
+{
+    abort_split_scan = abort;
+}
+
+bool wlan_get_abort_split_scan(void)
+{
+    return abort_split_scan;
+}
 /*
  * wmsdk: Split scan needs to be aborted at times by the application. This
  * API will help the caller do that.
@@ -132,15 +151,16 @@ void wlan_abort_split_scan(void)
     }
 #endif
     /*Also check the state of supplicant scan, if it is in progress, abort it*/
-    if ((split_scan_in_progress == true)
+    if ((wlan_get_split_scan_status() == true)
 #if CONFIG_WPA_SUPP
         || (supp_scan_in_process == true)
 #endif
         )
     {
-        if(split_scan_in_progress)
+        if(wlan_get_split_scan_status())
         {
-            abort_split_scan = true;
+            wlan_set_abort_split_scan(true);
+            wlan_set_split_scan_status(false);
         }
 #if CONFIG_WPA_SUPP
         if (wm_wifi.supp_if_callbk_fns->scan_done_callbk_fn)
@@ -905,7 +925,7 @@ static mlan_status wlan_scan_channel_list(IN mlan_private *pmpriv,
          * Fw will delay all events if handshake is not done
          * yet after ps sleep event.
          */
-        if (mlan_adap->ps_state == PS_STATE_PRE_SLEEP && split_scan_in_progress)
+        if (mlan_adap->ps_state == PS_STATE_PRE_SLEEP && wlan_get_split_scan_status())
         {
             send_sleep_confirm_command((mlan_bss_type)WLAN_BSS_TYPE_STA);
         }
@@ -916,7 +936,7 @@ static mlan_status wlan_scan_channel_list(IN mlan_private *pmpriv,
                send event to the WLC manager. Since the event is send
                only after command response we can be sure that there
                is no race condition */
-            split_scan_in_progress = false;
+            wlan_set_split_scan_status(false);
         }
 
         /* Send the scan command to the firmware with the specified cfg */
@@ -941,14 +961,14 @@ static mlan_status wlan_scan_channel_list(IN mlan_private *pmpriv,
             OSA_TimeDelay((uint32_t)get_split_scan_delay_ms());
         }
 
-        if (abort_split_scan)
+        if (wlan_get_abort_split_scan())
         {
 #if CONFIG_WPA_SUPP
             BSSDescriptor_t *bss_entry = NULL;
             int i;
 #endif
-            abort_split_scan       = false;
-            split_scan_in_progress = false;
+            wlan_set_abort_split_scan(false);
+            wlan_set_split_scan_status(false);
 #if CONFIG_WPA_SUPP
             for (i = 0; i < pmadapter->num_in_scan_table; i++)
             {
@@ -971,7 +991,7 @@ static mlan_status wlan_scan_channel_list(IN mlan_private *pmpriv,
     /* Do sleep confirm handshake if sleep event is received while preparing
      * to send scan cmd for the last channel or in case scan cmd was already sent
      * for the last channel */
-    if (mlan_adap->ps_state == PS_STATE_PRE_SLEEP && (split_scan_in_progress == false))
+    if (mlan_adap->ps_state == PS_STATE_PRE_SLEEP && is_split_scan_complete())
     {
         send_sleep_confirm_command((mlan_bss_type)WLAN_BSS_TYPE_STA);
     }
@@ -1267,31 +1287,28 @@ static mlan_status wlan_scan_setup_scan_config(IN mlan_private *pmpriv,
 #if CONFIG_SCAN_WITH_RSSIFILTER
     /*
      * Append rssi threshold tlv
-     *
      * Note: According to the value of rssi_threshold, it is divided into three situations:
      *     rssi_threshold  |  rssi_threshold_enable  |  Whether to carry TLV
      *           <0        |          MTRUE          |          Yes
      *            0        |          MFALSE         |          No
      *           >0        |          MFALSE         |          Yes
      */
-    if (rssi_threshold)
-    {
-        prssi_threshold_tlv              = (MrvlIEtypes_RssiThresholdParamSet_t *)ptlv_pos;
-        prssi_threshold_tlv->header.type = wlan_cpu_to_le16(TLV_TYPE_RSSI_THRESHOLD);
-        prssi_threshold_tlv->header.len =
-            (t_u16)(sizeof(prssi_threshold_tlv->enable) + sizeof(prssi_threshold_tlv->rssi_threshold) +
-                    sizeof(prssi_threshold_tlv->reserved));
-        prssi_threshold_tlv->enable         = rssi_threshold_enable;
-        prssi_threshold_tlv->rssi_threshold = rssi_threshold;
+    prssi_threshold_tlv              = (MrvlIEtypes_RssiThresholdParamSet_t *)ptlv_pos;
+    prssi_threshold_tlv->header.type = wlan_cpu_to_le16(TLV_TYPE_RSSI_THRESHOLD);
+    prssi_threshold_tlv->header.len =
+        (t_u16)(sizeof(prssi_threshold_tlv->enable) + sizeof(prssi_threshold_tlv->rssi_threshold) +
+                sizeof(prssi_threshold_tlv->reserved));
+    prssi_threshold_tlv->enable         = rssi_threshold_enable;
+    prssi_threshold_tlv->rssi_threshold = rssi_threshold;
 
-        ptlv_pos += sizeof(prssi_threshold_tlv->header) + prssi_threshold_tlv->header.len;
+    ptlv_pos += sizeof(prssi_threshold_tlv->header) + prssi_threshold_tlv->header.len;
 
-        prssi_threshold_tlv->header.len = wlan_cpu_to_le16(prssi_threshold_tlv->header.len);
+    prssi_threshold_tlv->header.len = wlan_cpu_to_le16(prssi_threshold_tlv->header.len);
 
-        pmadapter->rssi_threshold = (rssi_threshold < 0 ? rssi_threshold : 0);
+    pmadapter->rssi_threshold = (rssi_threshold < 0 ? rssi_threshold : 0);
 
-        PRINTM(MINFO, "SCAN_CMD: Rssi threshold = %d\n", rssi_threshold);
-    }
+    PRINTM(MINFO, "SCAN_CMD: Rssi threshold = %d\n", rssi_threshold);
+
 #endif
 
 #if CONFIG_WPA_SUPP
@@ -2719,7 +2736,7 @@ mlan_status wlan_scan_networks(IN mlan_private *pmpriv,
     pmadapter->idx_chan_stats = 0;
 #endif
 
-    split_scan_in_progress = true;
+    wlan_set_split_scan_status(true);
     ret = wlan_scan_channel_list(pmpriv, pioctl_buf, max_chan_per_scan, filtered_scan, &pscan_cfg_out->config,
                                  pchan_list_out, pscan_chan_list);
 #if !CONFIG_MEM_POOLS

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_cmd.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_cmd.c
@@ -1420,6 +1420,38 @@ static mlan_status wlan_cmd_mgmt_ie_list(IN pmlan_private pmpriv,
             cmd_eeprom->value      = 0;
             break;
         }
+        case HostCmd_CMD_TARGET_ACCESS:
+        {
+            HostCmd_DS_TARGET_ACCESS *target;
+            cmd->size          = wlan_cpu_to_le16(sizeof(HostCmd_DS_TARGET_ACCESS) + S_DS_GEN);
+            target             = (HostCmd_DS_TARGET_ACCESS *)&cmd->params.target;
+            target->action     = wlan_cpu_to_le16(cmd_action);
+            target->csu_target = wlan_cpu_to_le16(MLAN_CSU_TARGET_PSU);
+            target->address    = wlan_cpu_to_le16((t_u16)reg_rw->offset);
+            target->data       = (t_u8)reg_rw->value;
+            break;
+        }
+        case HostCmd_CMD_BCA_REG_ACCESS:
+        {
+            HostCmd_DS_BCA_REG_ACCESS *bca_reg;
+            cmd->size       = wlan_cpu_to_le16(sizeof(HostCmd_DS_BCA_REG_ACCESS) + S_DS_GEN);
+            bca_reg         = (HostCmd_DS_BCA_REG_ACCESS *)&cmd->params.bca_reg;
+            bca_reg->action = wlan_cpu_to_le16(cmd_action);
+            bca_reg->offset = wlan_cpu_to_le16((t_u16)reg_rw->offset);
+            bca_reg->value  = wlan_cpu_to_le32(reg_rw->value);
+            break;
+        }
+        case HostCmd_CMD_REG_ACCESS:
+        {
+            HostCmd_DS_REG_ACCESS *reg;
+            cmd->size     = wlan_cpu_to_le16(sizeof(HostCmd_DS_REG_ACCESS) + S_DS_GEN);
+            reg           = (HostCmd_DS_REG_ACCESS *)&cmd->params.reg;
+            reg->action   = wlan_cpu_to_le16(cmd_action);
+            reg->reg_type = wlan_cpu_to_le16((t_u16)reg_rw->type);
+            reg->offset   = wlan_cpu_to_le16((t_u16)reg_rw->offset);
+            reg->value    = wlan_cpu_to_le32(reg_rw->value);
+            break;
+        }
         default:
             invalid_hostcmd = MTRUE;
             break;
@@ -2337,7 +2369,7 @@ mlan_status wlan_ops_sta_prepare_cmd(IN t_void *priv,
             ret = wlan_cmd_cck_desense_cfg(pmpriv, cmd_ptr, cmd_action, pdata_buf);
             break;
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
         case HostCmd_CMD_INDEPENDENT_RESET_CFG:
             ret = wlan_cmd_ind_rst_cfg(cmd_ptr, cmd_action, pdata_buf);
             break;

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_cmdresp.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_cmdresp.c
@@ -940,7 +940,7 @@ mlan_status wlan_ops_sta_process_cmdresp(IN t_void *priv, IN t_u16 cmdresp_no, I
             ret = wlan_ret_host_clock_cfg(pmpriv, resp, pioctl_buf);
             break;
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
         case HostCmd_CMD_INDEPENDENT_RESET_CFG:
             ret = wlan_ret_ind_rst_cfg(pmpriv, resp, pioctl_buf);
             break;

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_ioctl.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_sta_ioctl.c
@@ -1492,7 +1492,7 @@ static mlan_status wlan_misc_cfg_ioctl(IN pmlan_adapter pmadapter, IN pmlan_ioct
             status = wlan_misc_ioctl_rf_test_cfg(pmadapter, pioctl_req);
             break;
 #endif /* CONFIG_RF_TEST_MODE */
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
         case MLAN_OID_MISC_IND_RST_CFG:
             status = wlan_misc_ioctl_ind_rst_cfg(pmadapter, pioctl_req);
             break;

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-internal.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-internal.h
@@ -224,7 +224,6 @@ typedef struct
 } wm_wifi_t;
 
 extern wm_wifi_t wm_wifi;
-extern bool split_scan_in_progress;
 
 /* fixme: This structure seems to have been removed from mlan. This was
    copied from userif_ext.h file temporarily. Change the handling of events to
@@ -410,12 +409,6 @@ void wifi_imu_unlock(void);
 #else
 int wifi_sdio_lock(void);
 void wifi_sdio_unlock(void);
-#endif
-
-#if CONFIG_WIFI_IND_RESET
-bool wifi_ind_reset_in_progress(void);
-void wifi_ind_reset_start(void);
-void wifi_ind_reset_stop(void);
 #endif
 
 mlan_status wrapper_wlan_cmd_mgmt_ie(int bss_type, void *buffer, unsigned int len, t_u16 action);

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
@@ -41,7 +41,7 @@ SDK_ALIGN(static uint8_t vdll_cmd_buf[WIFI_FW_CMDBUF_SIZE], 32);
 static uint8_t sleep_cfm_cmd_buf[WIFI_FW_CMDBUF_SIZE] = {0};
 static int seqnum;
 // static int pm_handle;
-#ifdef IW610
+#if defined(SD9177) || defined(IW610)
 bool cal_data_valid_fw;
 #endif
 /*
@@ -745,14 +745,6 @@ static mlan_status wifi_send_fw_data_sg(t_u8 *data, t_u32 txlen)
     t_u32 tx_blocks = 0, buflen = 0;
     bool ret;
 
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data sent during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return MLAN_STATUS_SUCCESS;
-    }
-#endif
-
     if (data == NULL || txlen == 0)
         return MLAN_STATUS_FAILURE;
 
@@ -852,14 +844,6 @@ static mlan_status wifi_send_fw_data(t_u8 *data, t_u32 txlen)
     uint32_t resp;
     bool ret;
 
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data sent during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return WM_SUCCESS;
-    }
-#endif
-
     if (data == NULL || txlen == 0)
         return MLAN_STATUS_FAILURE;
 
@@ -940,25 +924,6 @@ void wifi_sdio_unlock(void)
 {
     (void)OSA_MutexUnlock((osa_mutex_handle_t)txrx_mutex);
 }
-
-#if CONFIG_WIFI_IND_RESET
-static bool ind_reset_in_progress = false;
-
-bool wifi_ind_reset_in_progress(void)
-{
-    return ind_reset_in_progress;
-}
-
-void wifi_ind_reset_start(void)
-{
-    ind_reset_in_progress = true;
-}
-
-void wifi_ind_reset_stop(void)
-{
-   ind_reset_in_progress = false;
-}
-#endif
 
 static int wifi_sdio_get_command_resp_sem(unsigned long wait)
 {
@@ -1283,7 +1248,7 @@ static mlan_status wlan_handle_cmd_resp_packet(t_u8 *pmbuf)
 #endif
         case HostCmd_CMD_GET_HW_SPEC:
             (void)wlan_ret_get_hw_spec((mlan_private *)mlan_adap->priv[0], (HostCmd_DS_COMMAND *)(void *)cmdresp, NULL);
-#ifdef IW610
+#if defined(SD9177) || defined(IW610)
 #if !defined(OVERRIDE_CALIBRATION_DATA)
             t_u32 fw_cap_ext;
             fw_cap_ext = mlan_adap->priv[0]->adapter->fw_cap_ext;
@@ -1450,14 +1415,6 @@ static t_u8 *wlan_read_rcv_packet(t_u32 port, t_u32 rxlen, t_u32 rx_blocks, t_u3
     t_u32 blksize = MLAN_SDIO_BLOCK_SIZE;
     int i = 0;
 
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data received during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return NULL;
-    }
-#endif
-
     /* cmd, evt or single port data packet */
     if ((aggr == false) && (port & (CMD_PORT_SLCT | MLAN_SDIO_BYTE_MODE_MASK)))
     {
@@ -1506,14 +1463,6 @@ static t_u8 *wlan_read_rcv_packet(t_u32 port, t_u32 rxlen, t_u32 rx_blocks, t_u3
     t_u32 blksize = MLAN_SDIO_BLOCK_SIZE;
     uint32_t resp;
     int ret;
-
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data received during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return WM_SUCCESS;
-    }
-#endif
 
 #if CONFIG_SDIO_MULTI_PORT_RX_AGGR
     int i = 0;
@@ -2132,7 +2081,7 @@ static void wlan_fw_init_cfg(void)
     wlan_get_hw_spec();
 
     if (cal_data_valid
-#ifdef IW610
+#if defined(SD9177) || defined(IW610)
         && !cal_data_valid_fw
 #endif
     )
@@ -2447,14 +2396,6 @@ mlan_status wlan_flush_wmm_pkt(t_u8 pkt_count)
     t_u32 port_count = 0;
 #endif
 
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data sent during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return MLAN_STATUS_SUCCESS;
-    }
-#endif
-
     if (pkt_count == 0 || ports == 0)
         return MLAN_STATUS_SUCCESS;
 
@@ -2500,14 +2441,6 @@ static mlan_status wifi_tx_data(t_u8 start_port, t_u8 ports, t_u8 pkt_cnt, t_u32
     bool ret;
 #if defined(SD8978) || defined(SD8987) || defined(SD8997) || defined(SD9097) || defined(SD9098) || defined(SD9177) || defined(IW610)
     t_u32 port_count = 0;
-#endif
-
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data sent during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return WM_SUCCESS;
-    }
 #endif
 
 #if CONFIG_HOST_SLEEP
@@ -2611,14 +2544,6 @@ mlan_status wlan_xmit_wmm_pkt(t_u8 interface, t_u32 txlen, t_u8 *tx_buf)
 mlan_status wlan_flush_wmm_pkt(t_u8 pkt_count)
 {
     int ret;
-
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any data sent during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        return WM_SUCCESS;
-    }
-#endif
 
     if (pkt_count == 0)
         return MLAN_STATUS_SUCCESS;
@@ -3877,47 +3802,47 @@ mlan_status sd_wifi_init(enum wlan_type type, const uint8_t *fw_start_addr, cons
     return ret;
 }
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 mlan_status sd_wifi_reinit(enum wlan_type type, const uint8_t *fw_start_addr, const size_t size, uint8_t fw_reload)
 {
     mlan_status ret = MLAN_STATUS_SUCCESS;
+    uint32_t resp;
 
-#if (CONFIG_WIFI_IND_RESET)
-    if (wifi_reset_in_progress() == true)
+    /* During wifi reset, need to initializes
+       the wifi driver struct */
+    ret = sd_wifi_preinit();
+    if (ret != MLAN_STATUS_SUCCESS)
     {
-        /* During wifi reset, need to initializes
-           the wifi driver struct */
-        ret = sd_wifi_preinit();
-        if (ret != MLAN_STATUS_SUCCESS)
-        {
-            return MLAN_STATUS_FAILURE;
-        }
-        else
-        { /* Do Nothing */
-        }
-
-        mlan_adap->fw_start_addr = fw_start_addr;
+        return MLAN_STATUS_FAILURE;
     }
-    else
-    { /* Do Nothing */
-    }
-#endif
 
+    mlan_adap->fw_start_addr = fw_start_addr;
+    wifi_wake_up_card(&resp);
+#if CONFIG_WIFI_IND_OOB_RESET
     if (fw_reload == FW_RELOAD_NO_EMULATION)
     {
+        (void)PRINTF("Wi-Fi out-of-band reload\r\n");
+        sdio_oob_reset();
         OSA_SR_ALLOC();
         OSA_ENTER_CRITICAL();
 
-        /* Allow interrupt handler to deliver us a packet */
+        /* Block interrupt handler to deliver us a packet */
         g_txrx_flag = false;
 
         sdio_disable_interrupt();
 
         OSA_EXIT_CRITICAL();
     }
+    else
+#endif
+    {
+        (void)PRINTF("Wi-Fi in-band reload\r\n");
+        fw_reload = FW_RELOAD_SDIO_INBAND_RESET;
+    }
 
     ret = (mlan_status)firmware_download(fw_start_addr, size, intf, fw_reload);
 
+#if CONFIG_WIFI_IND_OOB_RESET
     if (ret != MLAN_STATUS_FAILURE)
     {
         if (fw_reload == FW_RELOAD_NO_EMULATION)
@@ -3932,6 +3857,7 @@ mlan_status sd_wifi_reinit(enum wlan_type type, const uint8_t *fw_start_addr, co
             OSA_EXIT_CRITICAL();
         }
     }
+#endif
 
     if (wifi_shutdown_enable)
     {
@@ -3967,7 +3893,7 @@ void sd_wifi_deinit(void)
     sg_data_list_clear_rx();
     sg_data_list_clear_tx();
 #endif
-#if (CONFIG_WIFI_IND_DNLD) && (CONFIG_WIFI_IND_RESET)
+#if CONFIG_WIFI_IND_RESET
     if (wifi_reset_in_progress() == true)
     { /* wifi_reset is based on inband IR, which does not do SDIO device re-enumerate,
         so could not deinit SD Host and SD Card */

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.h
@@ -88,7 +88,7 @@ extern bool mac_addr_valid;
 
 mlan_status sd_wifi_init(enum wlan_type type, const uint8_t *fw_start_addr, const size_t size);
 
-#if (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 mlan_status sd_wifi_reinit(enum wlan_type type, const uint8_t *fw_start_addr, const size_t size, uint8_t fw_reload);
 #endif
 

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-uap.c
@@ -2796,201 +2796,158 @@ static int wifi_nxp_set_mgmt_ies(mlan_private *priv,
                                  char *assocresp_ies,
                                  unsigned short assocresp_ies_len)
 {
-    int ret        = WM_SUCCESS;
-    const t_u8 *ie = NULL;
-    t_u8 ie_buffer[MAX_IE_SIZE];
-    t_u16 ie_len, ie_length = 0;
-    custom_ie *beacon_ies_data     = NULL;
-    custom_ie *beacon_wps_ies_data = NULL;
-    custom_ie *proberesp_ies_data  = NULL;
-    custom_ie *assocresp_ies_data  = NULL;
+    int ret = WM_SUCCESS;
+    /*
+     * Allocate a single contiguous buffer to hold the filtered IE data for
+     * beacon vendor, beacon, beacon-wps, proberesp-p2p and proberesp IEs.
+     * Each filtered result is written at ie_offset and the pointer is stored
+     * directly in reqs[].ie_buf.
+     *
+     * assocresp_ies is used directly from the caller's buffer (not copied
+     * here) because it is already a contiguous, unfiltered blob and the
+     * caller's buffer is guaranteed to be valid for the duration of this
+     * function call. It is therefore NOT included in total_size.
+     */
+#define MGMT_IE_BATCH_CNT 6
+    t_u8 *ie_bufs = NULL;
+    t_u16 ie_len, ie_offset;
+    t_u32 total_size;
+    mgmt_ie_batch_req reqs[MGMT_IE_BATCH_CNT] = {0};
+    t_u8 req_cnt;
 
-    beacon_ies_data     = (custom_ie *)OSA_MemoryAllocate(sizeof(custom_ie));
-    beacon_wps_ies_data = (custom_ie *)OSA_MemoryAllocate(sizeof(custom_ie));
-    proberesp_ies_data  = (custom_ie *)OSA_MemoryAllocate(sizeof(custom_ie));
-
-    assocresp_ies_data = (custom_ie *)OSA_MemoryAllocate(sizeof(custom_ie));
-
-    if ((!beacon_ies_data) || (!beacon_wps_ies_data) || (!proberesp_ies_data) || (!assocresp_ies_data))
+    total_size = tail_ies_len + beacon_ies_len + proberesp_ies_len;
+    if (total_size > 0)
     {
-        if (beacon_ies_data)
+        ie_bufs = (t_u8 *)OSA_MemoryAllocate(total_size);
+        if (!ie_bufs)
         {
-            OSA_MemoryFree(beacon_ies_data);
+            return -WM_FAIL;
         }
-        if (beacon_wps_ies_data)
-        {
-            OSA_MemoryFree(beacon_wps_ies_data);
-        }
-        if (proberesp_ies_data)
-        {
-            OSA_MemoryFree(proberesp_ies_data);
-        }
-        if (assocresp_ies_data)
-        {
-            OSA_MemoryFree(assocresp_ies_data);
-        }
-        return -WM_FAIL;
     }
 
-    ie        = (const t_u8 *)tail_ies;
-    ie_len    = tail_ies_len;
-    ie_length = 0;
+#define IE_BUF(offset) (ie_bufs + (offset))
 
-    if ((ie != NULL) && (ie_len != 0U))
+    req_cnt   = 0;
+    ie_offset = 0;
+
+    /** beacon vendor ies */
+    ie_len = 0;
+    if ((tail_ies != NULL) && (tail_ies_len != 0U))
     {
-        if (priv->beacon_vendor_index != -1)
-        {
-            ret = wifi_clear_mgmt_ie2(MLAN_BSS_TYPE_UAP, priv->beacon_vendor_index);
-            if (ret != WM_SUCCESS)
-            {
-                wuap_e("Clear uAP vendor IE failed");
-                ret = -WM_FAIL;
-                goto done;
-            }
-            priv->beacon_vendor_index = -1;
-        }
-
-        ie_length = wifi_get_specific_ie(ie, ie_len, ie_buffer, MAX_IE_SIZE, IE_MASK_VENDOR);
+        ie_len = wifi_get_specific_ie((const t_u8 *)tail_ies, tail_ies_len,
+                                    IE_BUF(ie_offset), MAX_IE_SIZE, IE_MASK_VENDOR);
 #if CONFIG_WIFI_IO_DUMP
         PRINTF("VENDOR IE\r\n");
-        dump_hex(ie_buffer, ie_length);
+        dump_hex(IE_BUF(ie_offset), ie_len);
 #endif
+    }
 
-        if (ie_length)
-        {
-            priv->beacon_vendor_index =
-                wifi_set_mgmt_ie2(MLAN_BSS_TYPE_UAP, MGMT_MASK_BEACON | MGMT_MASK_ASSOC_RESP | MGMT_MASK_PROBE_RESP,
-                                  (void *)ie_buffer, ie_length);
+    ret = wifi_mgmt_ie_req_fill(&reqs[req_cnt], MGMT_MASK_BEACON | MGMT_MASK_ASSOC_RESP | MGMT_MASK_PROBE_RESP,
+                                IE_BUF(ie_offset), ie_len, &priv->beacon_vendor_index);
+    if (ret == WM_SUCCESS)
+    {
+        ie_offset += ie_len;
+        req_cnt++;
+    }
 
-            if (priv->beacon_vendor_index == -1)
-            {
-                wuap_e("Set uAP vendor IE failed");
-                ret = -WM_FAIL;
-                goto done;
-            }
-        }
-
-        ie_length = wifi_filter_beacon_ies(priv, ie, ie_len, ie_buffer, MAX_IE_SIZE,
-                                           IE_MASK_WPS | IE_MASK_WFD | IE_MASK_P2P | IE_MASK_VENDOR,
-                                           (const t_u8 *)proberesp_ies, proberesp_ies_len);
+    /** beacon ies */
+    ie_len = 0;
+    if ((tail_ies != NULL) && (tail_ies_len != 0U))
+    {
+        ie_len = wifi_filter_beacon_ies(priv, (const t_u8 *)tail_ies, tail_ies_len,
+                                        IE_BUF(ie_offset), MAX_IE_SIZE, IE_MASK_WPS | IE_MASK_WFD | IE_MASK_P2P | IE_MASK_VENDOR,
+                                        (const t_u8 *)proberesp_ies, proberesp_ies_len);
 #if CONFIG_WIFI_IO_DUMP
         PRINTF("Beacon IE\r\n");
-        dump_hex(ie_buffer, ie_length);
+        dump_hex(IE_BUF(ie_offset), ie_len);
 #endif
     }
 
-    beacon_ies_data->ie_index = priv->beacon_index;
-
-    if (ie_length)
+    ret = wifi_mgmt_ie_req_fill(&reqs[req_cnt], MGMT_MASK_BEACON | MGMT_MASK_ASSOC_RESP | MGMT_MASK_PROBE_RESP,
+                                IE_BUF(ie_offset), ie_len, &priv->beacon_index);
+    if (ret == WM_SUCCESS)
     {
-        beacon_ies_data->mgmt_subtype_mask = MGMT_MASK_BEACON | MGMT_MASK_ASSOC_RESP | MGMT_MASK_PROBE_RESP;
-        beacon_ies_data->ie_length         = ie_length;
-        memcpy(beacon_ies_data->ie_buffer, (void *)ie_buffer, ie_length);
-    }
-    else
-    {
-        beacon_ies_data->mgmt_subtype_mask = MGMT_MASK_CLEAR;
+        ie_offset += ie_len;
+        req_cnt++;
     }
 
-    ie        = (const t_u8 *)beacon_ies;
-    ie_len    = beacon_ies_len;
-    ie_length = 0;
-
-    if ((ie != NULL) && (ie_len != 0U))
+    /** beacon wps ies */
+    ie_len = 0;
+    if ((beacon_ies != NULL) && (beacon_ies_len != 0U))
     {
-        ie_length = wifi_filter_beacon_ies(priv, ie, ie_len, ie_buffer, MAX_IE_SIZE, IE_MASK_VENDOR, NULL, 0);
+        ie_len = wifi_filter_beacon_ies(priv, (const t_u8 *)beacon_ies, beacon_ies_len,
+                                        IE_BUF(ie_offset), MAX_IE_SIZE, IE_MASK_VENDOR, NULL, 0);
 #if CONFIG_WIFI_IO_DUMP
         PRINTF("Beacon WPS IE\r\n");
-        dump_hex(ie_buffer, ie_length);
+        dump_hex(IE_BUF(ie_offset), ie_len);
 #endif
     }
 
-    beacon_wps_ies_data->ie_index = priv->beacon_wps_index;
-    if (ie_length)
+    ret = wifi_mgmt_ie_req_fill(&reqs[req_cnt], MGMT_MASK_BEACON,
+                                IE_BUF(ie_offset), ie_len, &priv->beacon_wps_index);
+    if (ret == WM_SUCCESS)
     {
-        beacon_wps_ies_data->mgmt_subtype_mask = MGMT_MASK_BEACON;
-        beacon_wps_ies_data->ie_length         = ie_length;
-        memcpy(beacon_wps_ies_data->ie_buffer, (void *)ie_buffer, ie_length);
-    }
-    else
-    {
-        beacon_wps_ies_data->mgmt_subtype_mask = MGMT_MASK_CLEAR;
+        ie_offset += ie_len;
+        req_cnt++;
     }
 
-    ie        = (const t_u8 *)proberesp_ies;
-    ie_len    = proberesp_ies_len;
-    ie_length = 0;
-
-    if ((ie != NULL) && (ie_len != 0U))
+    /** proberesp IE */
+    ie_len = 0;
+    if ((proberesp_ies != NULL) && (proberesp_ies_len != 0U))
     {
-        ie_length =
-            wifi_filter_beacon_ies(priv, ie, ie_len, ie_buffer, MAX_IE_SIZE, IE_MASK_P2P | IE_MASK_VENDOR, NULL, 0);
+        ie_len = wifi_filter_beacon_ies(priv, (const t_u8 *)proberesp_ies, proberesp_ies_len,
+                                        IE_BUF(ie_offset), MAX_IE_SIZE, IE_MASK_P2P | IE_MASK_VENDOR, NULL, 0);
 #if CONFIG_WIFI_IO_DUMP
         PRINTF("ProbeResp IE\r\n");
-        dump_hex(ie_buffer, ie_length);
+        dump_hex(IE_BUF(ie_offset), ie_len);
 #endif
     }
 
-    proberesp_ies_data->ie_index = priv->proberesp_index;
-    if (ie_length)
+    ret = wifi_mgmt_ie_req_fill(&reqs[req_cnt], MGMT_MASK_PROBE_RESP,
+                                IE_BUF(ie_offset), ie_len, &priv->proberesp_index);
+    if (ret == WM_SUCCESS)
     {
-        proberesp_ies_data->mgmt_subtype_mask = MGMT_MASK_PROBE_RESP;
-        proberesp_ies_data->ie_length         = ie_length;
-        memcpy(proberesp_ies_data->ie_buffer, (void *)ie_buffer, ie_length);
-    }
-    else
-    {
-        proberesp_ies_data->mgmt_subtype_mask = MGMT_MASK_CLEAR;
+        ie_offset += ie_len;
+        req_cnt++;
     }
 
-    ie        = (const t_u8 *)assocresp_ies;
-    ie_len    = assocresp_ies_len;
-    ie_length = 0;
-
-    if ((ie != NULL) && (ie_len != 0U))
+    /** assocresp ies */
+    ie_len = assocresp_ies_len;
+    if ((assocresp_ies != NULL) && (assocresp_ies_len != 0U))
     {
 #if CONFIG_WIFI_IO_DUMP
         PRINTF("AssocResp IE\r\n");
-        dump_hex(ie, ie_len);
+        dump_hex(assocresp_ies, assocresp_ies_len);
 #endif
     }
 
-    assocresp_ies_data->ie_index = priv->assocresp_index;
-    if (ie_len)
+    ret = wifi_mgmt_ie_req_fill(&reqs[req_cnt], MGMT_MASK_ASSOC_RESP,
+                                (t_u8 *)assocresp_ies, assocresp_ies_len, &priv->assocresp_index);
+    if (ret == WM_SUCCESS)
     {
-        assocresp_ies_data->mgmt_subtype_mask = MGMT_MASK_ASSOC_RESP;
-        assocresp_ies_data->ie_length         = ie_len;
-        memcpy(assocresp_ies_data->ie_buffer, (void *)ie, ie_len);
-    }
-    else
-    {
-        assocresp_ies_data->mgmt_subtype_mask = MGMT_MASK_CLEAR;
+        req_cnt++;
     }
 
-    ret = wifi_set_custom_ie(beacon_ies_data, beacon_wps_ies_data, proberesp_ies_data, assocresp_ies_data);
-    if (ret != WM_SUCCESS)
+    if (req_cnt == 0)
     {
-        ret = -WM_FAIL;
+        ret = WM_SUCCESS;
         goto done;
     }
-    ret = WM_SUCCESS;
+
+    ret = wifi_mgmt_ie_set_batch(priv, reqs, req_cnt);
+    if (ret != WM_SUCCESS)
+    {
+        wuap_e("Set mgmt IEs batch failed");
+        ret = -WM_FAIL;
+    }
+
 done:
-    if (beacon_ies_data)
+    if (ie_bufs)
     {
-        OSA_MemoryFree(beacon_ies_data);
+        OSA_MemoryFree(ie_bufs);
     }
-    if (beacon_wps_ies_data)
-    {
-        OSA_MemoryFree(beacon_wps_ies_data);
-    }
-    if (proberesp_ies_data)
-    {
-        OSA_MemoryFree(proberesp_ies_data);
-    }
-    if (assocresp_ies_data)
-    {
-        OSA_MemoryFree(assocresp_ies_data);
-    }
+
+#undef IE_BUF
 
     return ret;
 }
@@ -4213,21 +4170,10 @@ int wifi_nxp_stop_ap()
 
     (void)wifi_set_rx_mgmt_indication(MLAN_BSS_TYPE_UAP, 0);
 
-    if (priv->beacon_vendor_index != -1)
-    {
-        ret = wifi_clear_mgmt_ie2(MLAN_BSS_TYPE_UAP, priv->beacon_vendor_index);
-        if (ret != WM_SUCCESS)
-        {
-            wuap_e("Clear uAP vendor IE failed");
-            return -WM_FAIL;
-        }
-        priv->beacon_vendor_index = -1;
-    }
-
     ret = wifi_nxp_set_mgmt_ies(priv, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
     if (ret != WM_SUCCESS)
     {
-        wuap_e("Set uAP mgmt ie failed");
+        wuap_e("Clear uAP mgmt ie failed");
         ret = -WM_FAIL;
         goto done;
     }

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -417,106 +417,6 @@ static void send_sleep_cfm_no_wait(void)
 #endif
 }
 
-#if (CONFIG_WIFI_IND_DNLD)
-t_u8 wifi_rx_block_cnt;
-t_u8 wifi_tx_block_cnt;
-
-int wlan_process_hang(uint8_t fw_reload)
-{
-    int i, ret = WM_SUCCESS, poll_num = 10;
-
-    if (mlan_adap->in_reset == true)
-    {
-        wifi_d("Already in process hanging");
-        return WM_SUCCESS;
-    }
-
-    wifi_d("Start to process hanging");
-
-#if CONFIG_WIFI_IND_RESET
-    if (fw_reload == FW_RELOAD_NO_EMULATION)
-    {
-        if(wlan_sdio_check_fw_status(poll_num) == true)
-        {
-            PRINTF("WLAN FW already running! Skip FW download\r\n");
-            PRINTF("FW download skipped because fly wire is not connected from MCU to Wi-Fi SoC\r\n");
-
-            return -WM_FAIL;
-        }
-    }
-    wifi_ind_reset_start();
-#endif
-
-    /* Block TX data */
-    wifi_set_tx_status(WIFI_DATA_BLOCK);
-    /* Block RX data */
-    wifi_set_rx_status(WIFI_DATA_BLOCK);
-
-    if (is_split_scan_complete() == false)
-    {
-        wifi_user_scan_config_cleanup();
-        (void)wifi_event_completion(WIFI_EVENT_SCAN_RESULT, WIFI_EVENT_REASON_FAILURE, NULL);
-    }
-
-    mlan_adap->in_reset = true;
-    for (i = 0; i < (int)(MIN(MLAN_MAX_BSS_NUM, mlan_adap->priv_num)); i++)
-    {
-        if (mlan_adap->priv[i]->media_connected == MTRUE)
-        {
-            mlan_adap->priv[i]->media_connected = MFALSE;
-
-            if (mlan_adap->priv[i]->bss_type == MLAN_BSS_TYPE_STA)
-            {
-            }
-#if UAP_SUPPORT
-            else if (mlan_adap->priv[i]->bss_type == MLAN_BSS_TYPE_UAP)
-            {
-                mlan_adap->priv[i]->uap_bss_started = MFALSE;
-            }
-#endif
-        }
-
-        if (mlan_adap->priv[i])
-        {
-            wlan_clean_txrx(mlan_adap->priv[i]);
-        }
-    }
-
-    (void)wifi_event_completion(WIFI_EVENT_FW_HANG, WIFI_EVENT_REASON_SUCCESS, NULL);
-
-    ret = wifi_reinit(wm_wifi.fw_start_addr, wm_wifi.size, fw_reload);
-
-    if (ret != WM_SUCCESS && ret != -WIFI_ERROR_FW_DNLD_SKIP)
-    {
-        ASSERT(0);
-    }
-
-    /* Unblock TX data */
-    wifi_set_tx_status(WIFI_DATA_RUNNING);
-    /* Unblock RX data */
-    wifi_set_rx_status(WIFI_DATA_RUNNING);
-    mlan_adap->in_reset = false;
-    wifi_tx_block_cnt   = 0;
-    wifi_rx_block_cnt   = 0;
-
-    /* Put sleep_rwlock before resetting FW to avoid wakeing up FW
-       before enabling ieee-ps/deep-ps */
-    if (mlan_adap->ps_state == PS_STATE_SLEEP)
-    {
-        OSA_RWLockWriteUnlock(&sleep_rwlock);
-        mlan_adap->ps_state = PS_STATE_AWAKE;
-    }
-
-    /* Only send FW_RESET event if FW was actually reloaded */
-    if (ret == WM_SUCCESS)
-    {
-        (void)wifi_event_completion(WIFI_EVENT_FW_RESET, WIFI_EVENT_REASON_SUCCESS, NULL);
-    }
-
-    return ret;
-}
-#endif
-
 int wifi_wait_for_cmdresp(void *cmd_resp_priv)
 {
     int ret;
@@ -542,15 +442,6 @@ resend:
 #endif
 
 #endif /* CONFIG_ENABLE_WARNING_LOGS || CONFIG_WIFI_CMD_RESP_DEBUG*/
-#endif
-
-#if CONFIG_WIFI_IND_RESET
-    /* IR is in progress so any CMD coming during progress should be ignored */
-    if (wifi_ind_reset_in_progress() == true)
-    {
-        (void)wifi_put_command_lock();
-        return WM_SUCCESS;
-    }
 #endif
 
     if (cmd->size > WIFI_FW_CMDBUF_SIZE)
@@ -698,10 +589,7 @@ resend:
 #ifdef RW610
         wifi_recovery_enable = true;
 #else
-        /* assert as command flow cannot work anymore */
-#if CONFIG_WIFI_IND_DNLD
-        wlan_process_hang(FW_RELOAD_SDIO_INBAND_RESET);
-#endif /* CONFIG_WIFI_IND_DNLD */
+        wlan_reset_async();
 #endif /* RW610 */
 #else
         ASSERT(0);
@@ -1520,6 +1408,8 @@ static void wifi_core_deinit(void)
     wifi_wmm_buf_pool_deinit();
     wifi_bypass_txq_deinit();
 
+    wifi_mgmt_ie_deinit();
+
     (void)OSA_SemaphoreDestroy((osa_semaphore_handle_t)txbuf_sem);
 #endif
 
@@ -1563,9 +1453,6 @@ int wifi_init(const uint8_t *fw_start_addr, const size_t size)
     }
 
     (void)memset(&wm_wifi, 0, sizeof(wm_wifi_t));
-
-    wm_wifi.fw_start_addr = fw_start_addr;
-    wm_wifi.size          = size;
 
 #if defined(RW610)
     ret = (int)imu_wifi_init(WLAN_TYPE_NORMAL, fw_start_addr, size);
@@ -1629,28 +1516,33 @@ int wifi_init(const uint8_t *fw_start_addr, const size_t size)
     return ret;
 }
 
-#if (CONFIG_WIFI_IND_DNLD)
-int wifi_reinit(const uint8_t *fw_start_addr, const size_t size, uint8_t fw_reload)
+#if CONFIG_WIFI_IND_RESET
+static uint8_t ir_mode;
+
+void wifi_reset_mode_set(uint8_t mode)
+{
+    ir_mode = mode;
+}
+
+uint8_t wifi_reset_mode_get(void)
+{
+    return ir_mode;
+}
+
+int wifi_reinit(const uint8_t *fw_start_addr, const size_t size)
 {
     int ret = WM_SUCCESS;
+    uint8_t fw_reload = wifi_reset_mode_get() == 1 ?
+                        FW_RELOAD_NO_EMULATION : FW_RELOAD_SDIO_INBAND_RESET;
 
-#if CONFIG_WIFI_IND_RESET
-    if (wifi_reset_in_progress() == true)
+    if (wm_wifi.wifi_init_done != 0U)
     {
-        (void)memset(&wm_wifi, 0, sizeof(wm_wifi_t));
+        return WM_SUCCESS;
+    }
 
-        wm_wifi.fw_start_addr = fw_start_addr;
-        wm_wifi.size          = size;
-    }
-    else
-    { /* Do Nothing */
-    }
-#endif
+    (void)memset(&wm_wifi, 0, sizeof(wm_wifi_t));
 
     ret = (int)sd_wifi_reinit(WLAN_TYPE_NORMAL, fw_start_addr, size, fw_reload);
-#if CONFIG_WIFI_IND_RESET
-    wifi_ind_reset_stop();
-#endif
     if (ret != WM_SUCCESS)
     {
         if (ret != MLAN_STATUS_FW_DNLD_SKIP)
@@ -1687,18 +1579,14 @@ int wifi_reinit(const uint8_t *fw_start_addr, const size_t size, uint8_t fw_relo
         }
         return ret;
     }
+
 #ifndef RW610
-#if CONFIG_WIFI_IND_RESET
-    if (wifi_reset_in_progress() == true)
+    ret = wifi_core_init();
+    if (ret != WM_SUCCESS)
     {
-        ret = wifi_core_init();
-        if (ret != WM_SUCCESS)
-        {
-            wifi_e("wifi core re-init failed. status code %d", ret);
-            return ret;
-        }
+        wifi_e("wifi core re-init failed. status code %d", ret);
+        return ret;
     }
-#endif
 
     ret = (int)sd_wifi_post_init(WLAN_TYPE_NORMAL);
     if (ret != WM_SUCCESS)

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/rtos_wpa_supp_if.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/rtos_wpa_supp_if.h
@@ -162,7 +162,7 @@ void wifi_nxp_wpa_supp_event_proc_eapol_rx(void *if_priv,
 #endif
 void wifi_nxp_wpa_supp_event_proc_dfs_cac_started(void *if_priv, nxp_wifi_dfs_cac_info *dfs_cac_info);
 void wifi_nxp_wpa_supp_event_proc_dfs_cac_finished(void *if_priv, nxp_wifi_dfs_cac_info *dfs_cac_info);
-void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 *curr_rssi);
+void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 curr_rssi);
 #if CONFIG_WIFI_SOFTAP_SUPPORT
 int wifi_nxp_wpa_supp_init_ap(void *if_priv, struct wpa_driver_associate_params *params);
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/wifi_nxp_internal.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/wifi_nxp_internal.h
@@ -614,7 +614,7 @@ typedef MLAN_PACK_START struct _wifi_nxp_callbk_fns
     void (*dfs_cac_started_callbk_fn)(void *if_priv, nxp_wifi_dfs_cac_info *ch_switch_info);
     void (*dfs_cac_finished_callbk_fn)(void *if_priv, nxp_wifi_dfs_cac_info *ch_switch_info);
     int (*is_supp_scan_in_progress_callbk_fn)(void *if_priv);
-    void (*signal_change_callbk_fn)(void *if_priv, t_s16 *rssi);
+    void (*signal_change_callbk_fn)(void *if_priv, t_s16 rssi);
     void (*sched_scan_done_callbk_fn)(void *if_priv);
     void (*sched_scan_stopped_callbk_fn)(void *if_priv);
 } MLAN_PACK_END wifi_nxp_callbk_fns_t;

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -2025,9 +2025,6 @@ int wifi_nxp_wpa_supp_set_supp_port(void *if_priv, int authorized, char *bssid)
         wifi_user_scan_config_cleanup();
     }
 
-#if CONFIG_ROAMING
-    wlan_subscribe_rssi_low_event();
-#endif
     ret = 0;
 out:
     return ret;
@@ -2694,6 +2691,7 @@ int wifi_nxp_wpa_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
         capa->flags |= WPA_DRIVER_FLAGS_AP;
         capa->flags |= WPA_DRIVER_FLAGS_AP_MLME;
         capa->flags |= WPA_DRIVER_FLAGS_AP_TEARDOWN_SUPPORT;
+        capa->flags |= WPA_DRIVER_FLAGS_DEAUTH_TX_STATUS;
         capa->flags |= WPA_DRIVER_FLAGS_AP_CSA;
         capa->flags2 |= WPA_DRIVER_FLAGS2_AP_SME;
     }
@@ -3020,7 +3018,7 @@ void wifi_nxp_wpa_supp_event_proc_dfs_cac_finished(void *if_priv, nxp_wifi_dfs_c
     }
 }
 
-void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 *curr_rssi)
+void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 curr_rssi)
 {
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
     union wpa_event_data event;
@@ -3034,7 +3032,7 @@ void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 *curr_rssi)
     }
     memset(&event, 0, sizeof(event));
     event.signal_change.above_threshold = 0;
-    event.signal_change.data.signal = abs(*curr_rssi);
+    event.signal_change.data.signal = abs(curr_rssi);
 
     wifi_if_ctx_rtos->supp_callbk_fns.signal_change(wifi_if_ctx_rtos->supp_drv_if_ctx, &event);
 }

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp_internal.c
@@ -164,13 +164,6 @@ void wifi_process_mgmt_tx_status(struct wifi_message *msg)
             wm_wifi.supp_if_callbk_fns->mgmt_tx_status_callbk_fn(wm_wifi.if_priv, resp, resp->frame.frame_len, msg->reason);
         }
     }
-
-#if CONFIG_ROAMING
-    if (msg->reason != WIFI_EVENT_REASON_SUCCESS)
-    {
-        wlan_subscribe_rssi_low_event();
-    }
-#endif
 }
 
 int wifi_setup_ht_cap(t_u16 *ht_capab, t_u8 *pmcs_set, t_u8 *a_mpdu_params, t_u8 band)

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -2,7 +2,7 @@
  *
  *  @brief  This file provides Core WLAN definition
  *
- *  Copyright 2008-2025 NXP
+ *  Copyright 2008-2026 NXP
  *
  *  SPDX-License-Identifier: BSD-3-Clause
  *
@@ -84,40 +84,17 @@
 #include "app_notify.h"
 #endif
 
-#if CONFIG_WIFI_IND_OOB_RESET
-#include "fsl_gpio.h"
-
-#if defined(CONFIG_SOC_PART_NUMBER_MIMXRT1062DVL6A)
-#if defined(SD8978) || defined(SD8987)
-/* IR-OOB TRIGGER Connect Fly-Wire between J16.1 and J108.4 for 1XK-M2, 1ZM-M2*/
-#define IR_OUTBAND_TRIGGER_GPIO			GPIO1
-#define IR_OUTBAND_TRIGGER_GPIO_PIN		(23U)
-#define IR_OUTBAND_TRIGGER_GPIO_NAME   "GPIO1"
-//#define IOMUXC_GPIO_IR_OUTBAND_TRIGGER IOMUXC_GPIO_AD_B1_07_GPIO1_IO23
-#elif defined(SD9177) || defined(IW610)
-/* IR-OOB TRIGGER for 2EL-M2, Internal Routing to M2 Slot*/
-#define IR_OUTBAND_TRIGGER_GPIO			GPIO1
-#define IR_OUTBAND_TRIGGER_GPIO_PIN		(24U)
-#define IR_OUTBAND_TRIGGER_GPIO_NAME   "GPIO1"
-//#define IOMUXC_GPIO_IR_OUTBAND_TRIGGER IOMUXC_GPIO_AD_B1_08_GPIO1_IO24
-#endif
-
-#elif defined(SOC_PART_NUMBER_MIMXRT1176DVMAA) // For RT1170
-/* IR OUT-BAND TRIGGER GPIO*/
-/*Output GPIO J9 PIN2 (IOMUXC_GPIO_DISP_B2_11) for RT1170-EVKA/B*/
-#define IR_OUTBAND_TRIGGER_GPIO   		GPIO5
-#define IR_OUTBAND_TRIGGER_GPIO_PIN   	(12U)
-#define IR_OUTBAND_TRIGGER_GPIO_NAME  	"GPIO5"
-
-#endif /* (defined(CONFIG_SOC_PART_NUMBER_MIMXRT1062DVL6A) */
-#endif
-
 #define DELAYED_SLP_CFM_DUR 10U
 #define BAD_MIC_TIMEOUT     (60 * 1000)
 
 #if CONFIG_WPA_SUPP
 #define SUPP_STATUS_TIMEOUT (2 * 1000)
 #define ROAM_SCAN_TIMEOUT   (60 * 1000)
+#endif
+
+#if CONFIG_ROAMING
+#define WLAN_ROAMING_COOLDOWN 2000
+#define WLAN_ROAMING_RSSI_DEFAULT_THRESHOLD -70
 #endif
 
 #define WL_ID_CONNECT      "wifi_connect"
@@ -255,10 +232,9 @@ extern WPS_DATA wps_global;
     }
 
 OSA_MUTEX_HANDLE_DEFINE(reset_lock);
-#if defined(RW610) || defined(IW610)|| defined(SD9177) || defined(SD8978)
+
 /* Mon thread */
 static bool mon_thread_init = 0;
-#endif
 
 #if CONFIG_HOST_SLEEP
 #if CONFIG_POWER_MANAGER
@@ -287,6 +263,7 @@ int is_hs_handshake_done = 0;
 bool skip_hs_handshake = false;
 
 extern OSA_SEMAPHORE_HANDLE_DEFINE(wakelock);
+static bool wakelock_init = 0;
 extern int wakeup_by;
 
 bool wlan_is_manual = false;
@@ -322,9 +299,6 @@ enum user_request_type
     CM_STA_USER_REQUEST_CONNECT = WIFI_EVENT_LAST + 1,
     CM_STA_USER_REQUEST_DISCONNECT,
     CM_STA_USER_REQUEST_SCAN,
-#if (CONFIG_11K) || (CONFIG_11V)
-    CM_STA_USER_REQUEST_SET_RSSI_THRESHOLD,
-#endif
     CM_STA_USER_REQUEST_PS_ENTER,
     CM_STA_USER_REQUEST_PS_EXIT,
 #if CONFIG_CPU_LOADING
@@ -434,7 +408,7 @@ static struct wps_config wps_conf = {
     .prov_session            = PROV_NON_SESSION_ATTEMPT,
 };
 #endif /* CONFIG_WPS2 */
-#if defined(RW610) || defined(IW610) || defined(SD9177) || defined(SD8978)
+
 static void wlcmgr_mon_task(osa_task_param_t arg);
 
 /* OSA_TASKS: name, priority, instances, stackSz, useFloat */
@@ -446,7 +420,6 @@ static OSA_TASK_DEFINE(wlcmgr_mon_task, CONFIG_NXP_WIFI_MON_TASK_PRIO , 1, CONFI
  */
 OSA_MSGQ_HANDLE_DEFINE(mon_thread_events, MAX_EVENTS, sizeof(struct wlan_message));
 
-#endif
 typedef enum
 {
     WLCMGR_INACTIVE,
@@ -455,6 +428,16 @@ typedef enum
     WLCMGR_THREAD_STOPPED,
     WLCMGR_THREAD_DELETED,
 } wlcmgr_status_t;
+
+#if CONFIG_ROAMING
+struct roaming_report_state {
+    uint8_t bitmap;              /* bit0: RSSI_LOW, bit1: SNR_LOW, 0=disabled */
+    uint8_t rssi_low_threshold;
+    uint8_t snr_low_threshold;
+    bool subscribed;
+    OSA_TIMER_HANDLE_DEFINE(roaming_timer);
+};
+#endif
 
 static struct
 {
@@ -589,7 +572,7 @@ static struct
 #endif
     bool hidden_scan_on : 1;
 #if CONFIG_ROAMING
-    bool roaming_enabled : 1;
+    struct roaming_report_state roaming_report;
 #endif
 #if CONFIG_11R
     bool ft_bss : 1;
@@ -619,14 +602,12 @@ static struct
     wlan_nlist_report_param nlist_rep_param;
     wlan_rrm_neighbor_report_t nbr_rpt;
 #endif
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_11R) || (CONFIG_ROAMING)
-    uint8_t rssi_low_threshold;
-#endif
-    uint8_t ind_reset;
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
-    uint8_t ir_mode;
-#endif
     bool internal : 1;
+#if CONFIG_WIFI_GET_LOG
+    /* Wi-Fi diagnostic statistics */
+    uint32_t diag_disc_count;
+    uint32_t diag_disc_timestamp;
+#endif
 } wlan;
 
 OSA_TASK_HANDLE_DEFINE(wlcmgr_mon_task_Handle);
@@ -719,6 +700,15 @@ static void dbg_lock_info(void)
 #if CONFIG_WLS_CSI_PROC
 t_u8 g_csi_event_for_wls;
 #endif
+
+static void wlan_diag_on_disconnect(void)
+{
+#if CONFIG_WIFI_GET_LOG
+    uint32_t count           = wlan.diag_disc_count;
+    wlan.diag_disc_count     = (count >= UINT32_MAX) ? 0U : (uint32_t)(count + 1U);
+    wlan.diag_disc_timestamp = (uint32_t)k_uptime_get_32();
+#endif
+}
 
 /*
  * Utility Functions
@@ -3105,13 +3095,6 @@ static void wlcm_process_scan_result_event(struct wifi_message *msg, enum cm_sta
         if (wlan.enable_11k == 1U)
         {
             wifi_scan_done(msg);
-            /*
-             * Subscribe EVENT_RSSI_LOW if roaming is enabled.
-             * Do this here in case roaming is not happened or failed in wpa_supplicant.
-             */
-#if CONFIG_ROAMING
-            wlan_subscribe_rssi_low_event();
-#endif
         }
 #endif
 #endif
@@ -3137,13 +3120,6 @@ static void wlcm_process_scan_result_event(struct wifi_message *msg, enum cm_sta
         wifi_scan_done(msg);
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
         /*
-         * Subscribe EVENT_RSSI_LOW if roaming is enabled.
-         * Do this here in case roaming is not happened or failed in wpa_supplicant.
-         */
-#if CONFIG_ROAMING
-        wlan_subscribe_rssi_low_event();
-#endif
-        /*
         * Zephyr l2 mgmt scan needs call report_scan_results() to clear scan callback.
         *
         * If wlan.sta_state is modified to non-CM_STA_SCANNING_USER before receiving
@@ -3163,13 +3139,6 @@ static void wlcm_process_scan_result_event(struct wifi_message *msg, enum cm_sta
             {
                 wlcm_d("SM: returned to %s", dbg_sta_state_name(*next));
                 handle_scan_results();
-#if CONFIG_ROAMING
-                /*
-                 * Subscribe EVENT_RSSI_LOW if roaming is enabled.
-                 * Do this here in case roaming is not happened.
-                 */
-                wlan_subscribe_rssi_low_event();
-#endif
                 *next = wlan.sta_state;
                 return;
             }
@@ -4063,10 +4032,6 @@ static void wlcm_process_authentication_event(struct wifi_message *msg,
 #endif
 #endif
 
-#if CONFIG_ROAMING
-            wlan_subscribe_rssi_low_event();
-#endif
-
 #if CONFIG_WPA_SUPP
 #if CONFIG_11R
             wlan.same_ess = wifi_same_ess_ft();
@@ -4210,45 +4175,37 @@ static void wlcm_process_authentication_event(struct wifi_message *msg,
     }
 }
 
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
-static void wlcm_process_rssi_low_event(struct wifi_message *msg)
-{
-    t_s16 curr_rssi = *(t_s16 *)msg->data;
-
-    wm_wifi.supp_if_callbk_fns->signal_change_callbk_fn(wm_wifi.if_priv, &curr_rssi);
-#if !CONFIG_MEM_POOLS
-    OSA_MemoryFree(msg->data);
-#else
-    OSA_MemoryPoolFree(buf_32_MemoryPool, msg->data);
-#endif
-}
-#else
+#if CONFIG_ROAMING && !CONFIG_WIFI_NM_WPA_SUPPLICANT
 /** Try to roaming if enabled based on priority:
  * 1. 11R roaming (full channel scan)
  * 2. 11K roaming
  * 3. 11V roaming
  * 4. Legacy roaming (full channel scan)
- *
- * If not trigger roaming, subscribe RSSI low event again
  */
-static void wlcm_process_rssi_low_event(struct wifi_message *msg, enum cm_sta_state *next, struct wlan_network *network)
+static void wlcm_process_rssi_low_event(void)
 {
-#if !CONFIG_ROAMING
-    wlcm_d("wlcm_process_rssi_low_event roaming not support");
-    return;
-#else
-    bool set_rssi_threshold = false;
 #if CONFIG_BG_SCAN || CONFIG_11K || CONFIG_11V
     int ret;
 #endif
+#if CONFIG_BG_SCAN || CONFIG_11K || CONFIG_11V || CONFIG_11R
+    struct wlan_network *network;
+#endif
 
-    if (wlan.roaming_enabled == false)
+    if (!wlan_get_roaming_status())
     {
         wlcm_d("wlcm_process_rssi_low_event roaming disabled");
         return;
     }
 
+#if CONFIG_BG_SCAN || CONFIG_11K || CONFIG_11V || CONFIG_11R
+    if (wlan.cur_network_idx < 0 || wlan.cur_network_idx >= WLAN_MAX_KNOWN_NETWORKS)
+    {
+        wlcm_d("wlcm_process_rssi_low_event cur network idx invalid");
+        return;
+    }
+
+    network = &wlan.networks[wlan.cur_network_idx];
+#endif
 #if CONFIG_11R
     if (wlan.roam_reassoc == false)
     {
@@ -4267,13 +4224,11 @@ static void wlcm_process_rssi_low_event(struct wifi_message *msg, enum cm_sta_st
             }
 #endif
             wlan.roam_reassoc = false;
-            set_rssi_threshold = true;
         }
     }
     else
     {
         wlcm_d("11R Roaming already in progress");
-        (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
         return;
     }
 #endif
@@ -4287,7 +4242,6 @@ static void wlcm_process_rssi_low_event(struct wifi_message *msg, enum cm_sta_st
             wlcm_d("Sent 11K neighbor request");
             return;
         }
-        set_rssi_threshold = true;
     }
 #endif /* CONFIG_11K */
 
@@ -4300,7 +4254,6 @@ static void wlcm_process_rssi_low_event(struct wifi_message *msg, enum cm_sta_st
             wlcm_d("Sent 11V bss transition query");
             return;
         }
-        set_rssi_threshold = true;
     }
 #endif /* CONFIG_11V */
 
@@ -4316,21 +4269,12 @@ static void wlcm_process_rssi_low_event(struct wifi_message *msg, enum cm_sta_st
         }
 #endif
         wlan.roam_reassoc = false;
-        set_rssi_threshold = true;
     }
     else
     {
         wlcm_d("Roaming already in progress");
-        set_rssi_threshold = true;
     }
-
-    if (set_rssi_threshold == true)
-    {
-        (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-    }
-#endif /* CONFIG_ROAMING */
 }
-#endif
 #endif
 
 #if (CONFIG_11K) || (CONFIG_11V)
@@ -4788,6 +4732,8 @@ static void wlcm_process_link_loss_event(struct wifi_message *msg,
      * this as a connection attempt failure via do_connect_fail() and
      * proceed accordingly.
      */
+    wlan_diag_on_disconnect();
+
 #if CONFIG_WMSTATS
     g_wm_stats.wm_lloss++;
 #endif /* CONFIG_WMSTATS */
@@ -4927,6 +4873,8 @@ static void wlcm_process_disassoc_event(struct wifi_message *msg, enum cm_sta_st
      * this as a connection attempt failure via do_connect_fail() and
      * proceed accordingly.
      */
+    wlan_diag_on_disconnect();
+
 #if CONFIG_WPA2_ENTP
     if (wlan_get_prov_session() == PROV_ENTP_SESSION_ATTEMPT)
     {
@@ -4964,6 +4912,8 @@ static void wlcm_process_deauthentication_event(struct wifi_message *msg,
                                                 enum cm_sta_state *next,
                                                 struct wlan_network *network)
 {
+    wlan_diag_on_disconnect();
+
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
     struct netif *netif = net_get_sta_interface();
     struct wifi_connect_req_params params = {0};
@@ -5406,38 +5356,6 @@ static void wpa_supplicant_msg_cb(const char *buf, size_t len)
 
     wlcm_d("%s: %s", __func__, buf);
 
-#if CONFIG_WPA_SUPP && CONFIG_ROAMING
-    if (strstr(buf, "selected current BSS ") != NULL)
-    {
-        t_u8 addr[MLAN_MAC_ADDR_LENGTH];
-
-        s = strstr(buf, "BSS");
-        if (s == NULL)
-        {
-            return;
-        }
-
-        s = s + 4;
-        if (hwaddr_aton(s, addr))
-        {
-            return;
-        }
-
-        if (memcmp(addr, network->bssid, MLAN_MAC_ADDR_LENGTH) == 0)
-        {
-            (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-            wlan.roam_reassoc = false;
-        }
-        return;
-    }
-    if (strstr(buf, "Skip roam ") != NULL)
-    {
-        (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-        wlan.roam_reassoc = false;
-        return;
-    }
-#endif
-
     if (strstr(buf, WPA_EVENT_SCAN_FAILED))
     {
         wlcm_process_scan_failed();
@@ -5451,24 +5369,14 @@ static void wpa_supplicant_msg_cb(const char *buf, size_t len)
     {
         wlcm_d("No suitable network was found");
 
-        if (wlan.roam_reassoc == true)
-        {
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-            (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-            wlan.roam_reassoc = false;
-#endif
-        }
-        else
-        {
-            wlan.scan_count++;
+        wlan.scan_count++;
 
-            do_connect_failed(WLAN_REASON_NETWORK_NOT_FOUND);
+        do_connect_failed(WLAN_REASON_NETWORK_NOT_FOUND);
 
-            if (wlan.scan_count > WLAN_RESCAN_LIMIT)
-            {
-                wlan.cur_network_idx = -1;
-                (void)wpa_supp_disable(sta_netif, network);
-            }
+        if (wlan.scan_count > WLAN_RESCAN_LIMIT)
+        {
+            wlan.cur_network_idx = -1;
+            (void)wpa_supp_disable(sta_netif, network);
         }
     }
     else if (strstr(buf, WPA_EVENT_AUTH_REJECT))
@@ -5924,6 +5832,13 @@ static void wlcm_process_init(enum cm_sta_state *next)
 
     (void)wrapper_wlan_cmd_get_hw_spec();
 
+    ret = wifi_mgmt_ie_init();
+    if (ret != WM_SUCCESS)
+    {
+        wlcm_e("wifi_mgmt_ie_init failed");
+        return;
+    }
+
     wlan_ed_mac_ctrl_t wlan_ed_mac_ctrl = {
         0x01,
         CONFIG_NXP_WIFI_ED_OFFSET_2G
@@ -6102,54 +6017,6 @@ static void wlcm_process_net_if_config_event(struct wifi_message *msg, enum cm_s
 
     wlcm_process_init(next);
 }
-
-static void wlcm_request_disconnect(enum cm_sta_state *next, struct wlan_network *curr_nw);
-
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
-static void wlcm_process_fw_hang_event(struct wifi_message *msg, enum cm_sta_state *next)
-{
-#if CONFIG_WPA_SUPP
-    struct netif *netif = net_get_sta_interface();
-#endif
-
-    (void)msg;
-
-    CONNECTION_EVENT(WLAN_REASON_FW_HANG, NULL);
-
-    if (wlan.sta_state > CM_STA_IDLE)
-    {
-#if CONFIG_WPA_SUPP
-        nxp_supp_disconnect((void *)netif);
-#else
-        wlcm_request_disconnect(next, &wlan.networks[wlan.cur_network_idx]);
-        wlan_dhcp_cleanup();
-#endif
-    }
-
-#if UAP_SUPPORT
-    if (is_uap_starting())
-    {
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
-        nxp_net_request_ap_disable();
-#else
-        (void)do_stop(&wlan.networks[wlan.cur_uap_network_idx]);
-#endif
-    }
-#endif
-}
-
-static void wlcm_process_fw_reset_event(struct wifi_message *msg, enum cm_sta_state *next)
-{
-    (void)msg;
-    (void)next;
-
-    wlan.ind_reset = 1;
-
-    wlcm_process_init(next);
-
-    CONNECTION_EVENT(WLAN_REASON_FW_RESET, NULL);
-}
-#endif
 
 #if UAP_SUPPORT
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
@@ -6828,10 +6695,6 @@ static void wifi_process_bg_scan_stopped(struct wifi_message *msg)
 static void wlcm_process_bg_scan_report(void)
 {
     wifi_send_scan_query();
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-    /* Set rssi low threshold and subscribe rssi low event again */
-    (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-#endif
 #if CONFIG_WPA_SUPP
     wm_wifi.supp_if_callbk_fns->sched_scan_done_callbk_fn(wm_wifi.if_priv);
 #endif
@@ -6862,14 +6725,7 @@ static void wlcm_process_get_hw_spec_event(void)
 
     /* Set Tx Power Limits in Wi-Fi firmware */
     (void)wlan_set_wwsm_txpwrlimit();
-
-    if (wlan.ind_reset == 0)
-    {
-        CONNECTION_EVENT(WLAN_REASON_INITIALIZED, NULL);
-    }
-#if CONFIG_WIFI_IND_RESET
-    wlan.ind_reset = 0;
-#endif
+    CONNECTION_EVENT(WLAN_REASON_INITIALIZED, NULL);
 }
 
 static void wlcm_process_mgmt_frame(void *data)
@@ -6944,16 +6800,6 @@ static void wlcm_process_region_power_cfg(struct wifi_message *msg)
 
     OSA_MemoryFree(country_code);
 }
-
-#if (CONFIG_11K) || (CONFIG_11V)
-static void wlcm_set_rssi_low_threshold(enum cm_sta_state *next, struct wlan_network *curr_nw)
-{
-    (void)next;
-    (void)curr_nw;
-
-    (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-}
-#endif
 
 #if CONFIG_WIFI_CHANNEL_LOAD
 static void wlcm_process_chan_load(void *ch_load)
@@ -7041,6 +6887,113 @@ static void wlan_cpu_loading_request()
 }
 #endif
 
+#if CONFIG_ROAMING
+static void roaming_timer_cb(osa_timer_arg_t arg)
+{
+    (void)wifi_event_completion(WIFI_EVENT_ROAMING_TRIGGER,
+                                WIFI_EVENT_REASON_SUCCESS, NULL);
+}
+
+static void roaming_subscribe_process(void)
+{
+    if (wlan.roaming_report.bitmap == 0)
+    {
+        return;
+    }
+    if (wlan.roaming_report.subscribed)
+    {
+        return;
+    }
+    if (!is_sta_connected())
+    {
+        if (is_sta_connecting())
+        {
+            /* Re-trigger timer if not already running */
+            if (!OSA_TimerIsRunning((osa_timer_handle_t)wlan.roaming_report.roaming_timer))
+            {
+                (void)OSA_TimerActivate((osa_timer_handle_t)wlan.roaming_report.roaming_timer);
+            }
+        }
+        return;
+    }
+
+    /* STA connected - subscribe to FW */
+    int ret = wifi_roaming_subscribe_event(wlan.roaming_report.bitmap,
+                  wlan.roaming_report.rssi_low_threshold,
+                  wlan.roaming_report.snr_low_threshold);
+
+    if (ret == WM_SUCCESS)
+    {
+        wlan.roaming_report.subscribed = true;
+        wlcm_d("roaming_report: subscribed (bitmap=0x%x, rssi_th=%d, snr_th=%d)",
+               wlan.roaming_report.bitmap,
+               wlan.roaming_report.rssi_low_threshold,
+               wlan.roaming_report.snr_low_threshold);
+    }
+    else
+    {
+        wlcm_d("roaming_report: cmd failed, disabling");
+        wlan.roaming_report.bitmap = 0;
+    }
+}
+
+static void roaming_report_process(struct wifi_message *msg, enum wifi_event event)
+{
+    if (!wlan.roaming_report.subscribed)
+    {
+        wlcm_d("roaming_report: stale event, drop");
+        goto free_data;
+    }
+
+    /* De-subscribe both from FW */
+    int ret;
+    ret = wifi_roaming_clear_subscribe();
+    if (ret != WM_SUCCESS)
+    {
+        wlcm_d("roaming_report: de-subscribe cmd failed, disabling");
+        wlan.roaming_report.bitmap = 0;
+        goto free_data;
+    }
+    wlan.roaming_report.subscribed = false;
+    wlcm_d("roaming_report: de-subscribed");
+
+    /* Deliver signal change */
+    t_s16 rssi;
+    if (event == WIFI_EVENT_RSSI_LOW)
+    {
+        rssi = *(t_s16 *)msg->data;
+    }
+    else
+    {
+        rssi = WLAN_ROAMING_RSSI_DEFAULT_THRESHOLD;
+    }
+    wlcm_d("roaming_report: signal_change rssi=%d", rssi);
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT
+    wm_wifi.supp_if_callbk_fns->signal_change_callbk_fn(
+        wm_wifi.if_priv, rssi);
+#else
+    wlcm_process_rssi_low_event();
+#endif
+
+    /* Start cooldown timer */
+    if (!OSA_TimerIsRunning((osa_timer_handle_t)wlan.roaming_report.roaming_timer))
+    {
+        (void)OSA_TimerActivate((osa_timer_handle_t)wlan.roaming_report.roaming_timer);
+    }
+
+free_data:
+    if (msg->data != NULL)
+    {
+#if !CONFIG_MEM_POOLS
+        OSA_MemoryFree(msg->data);
+#else
+        OSA_MemoryPoolFree(buf_32_MemoryPool, msg->data);
+#endif
+    }
+}
+#endif
+
 /*
  * Event Handlers
  */
@@ -7099,11 +7052,6 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
         case CM_STA_USER_REQUEST_SCAN:
             wlcm_request_scan(msg, &next);
             break;
-#if (CONFIG_11K) || (CONFIG_11V)
-        case CM_STA_USER_REQUEST_SET_RSSI_THRESHOLD:
-            wlcm_set_rssi_low_threshold(&next, network);
-            break;
-#endif
         case CM_STA_USER_REQUEST_PS_ENTER:
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
             state = wifi_nxp_supp_state();
@@ -7148,17 +7096,6 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
             wlcm_process_scan_result_event(msg, &next);
             break;
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
-        case WIFI_EVENT_FW_HANG:
-            wlcm_d("got event: fw hang");
-            wlcm_process_fw_hang_event(msg, &next);
-            break;
-        case WIFI_EVENT_FW_RESET:
-            wlcm_d("got event: fw reset");
-            wlcm_process_fw_reset_event(msg, &next);
-            break;
-#endif
-
 #if CONFIG_WPA_SUPP
         case WIFI_EVENT_SURVEY_RESULT_GET:
             wifi_survey_result_get(msg);
@@ -7173,6 +7110,12 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
                 CONNECTION_EVENT(WLAN_REASON_ASSOC_SUCCESS, NULL);
             }
             wlcm_process_association_event(msg, &next);
+#if CONFIG_ROAMING
+            if (msg->reason == WIFI_EVENT_REASON_SUCCESS)
+            {
+                roaming_subscribe_process();
+            }
+#endif
             break;
 
 #if CONFIG_WPA_SUPP
@@ -7237,28 +7180,24 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
             break;
         case WIFI_EVENT_RSSI_LOW:
             wlcm_d("got event: rssi low");
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-            wlcm_process_rssi_low_event(msg);
-#endif
-#else
-            if (wlan.cur_network_idx >= WLAN_MAX_KNOWN_NETWORKS)
-                break;
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-            wlcm_process_rssi_low_event(msg, &next, network);
+#if CONFIG_ROAMING
+            roaming_report_process(msg, WIFI_EVENT_RSSI_LOW);
 #else
             CONNECTION_EVENT(WLAN_REASON_RSSI_LOW, NULL);
 #endif
+            break;
+        case WIFI_EVENT_SNR_LOW:
+            wlcm_d("got event: SNR low");
+#if CONFIG_ROAMING
+            roaming_report_process(msg, WIFI_EVENT_SNR_LOW);
+#else
+            CONNECTION_EVENT(WLAN_REASON_RSSI_LOW, NULL);
 #endif
             break;
 #if CONFIG_SUBSCRIBE_EVENT_SUPPORT
         case WIFI_EVENT_RSSI_HIGH:
             wlcm_d("got event: RSSI high");
             CONNECTION_EVENT(WLAN_REASON_RSSI_HIGH, NULL);
-            break;
-        case WIFI_EVENT_SNR_LOW:
-            wlcm_d("got event: SNR low");
-            CONNECTION_EVENT(WLAN_REASON_SNR_LOW, NULL);
             break;
         case WIFI_EVENT_SNR_HIGH:
             wlcm_d("got event: SNR high");
@@ -7295,6 +7234,12 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
         case WIFI_EVENT_FW_PRE_BCN_LOST:
             wlcm_d("got event: PRE_BEACON_LOST");
             CONNECTION_EVENT(WLAN_REASON_PRE_BEACON_LOST, NULL);
+            break;
+#endif
+#if CONFIG_ROAMING
+        case WIFI_EVENT_ROAMING_TRIGGER:
+            wlcm_d("got event: roaming trigger");
+            roaming_subscribe_process();
             break;
 #endif
 #if CONFIG_HOST_SLEEP
@@ -7921,10 +7866,23 @@ int wlan_init(const uint8_t *fw_start_addr, const size_t size)
     OSA_SemaphorePost((osa_semaphore_handle_t)uapsd_sem);
 #endif
 
-#if (CONFIG_WIFI_IND_DNLD) && (CONFIG_WIFI_IND_RESET)
+#if CONFIG_HOST_SLEEP
+    if (!wakelock_init)
+    {
+        status = OSA_SemaphoreCreate((osa_semaphore_handle_t)wakelock, 0);
+        if (status != KOSA_StatusSuccess)
+        {
+            wifi_e("Failed to create wake-lock semaphore");
+            return ret;
+        }
+        wakelock_init = 1;
+    }
+#endif
+
+#if CONFIG_WIFI_IND_RESET
     if (wifi_reset_in_progress() == true)
     {
-        ret = wifi_reinit(fw_start_addr, size, FW_RELOAD_SDIO_INBAND_RESET);
+        ret = wifi_reinit(fw_start_addr, size);
     }
     else
 #endif
@@ -8108,7 +8066,6 @@ static void neighbor_req_timer_cb(osa_timer_arg_t arg)
     if (wlan.neighbor_req == true)
     {
         wlan.neighbor_req = false;
-        (void)send_user_request(CM_STA_USER_REQUEST_SET_RSSI_THRESHOLD, 0);
     }
 }
 #endif
@@ -8183,10 +8140,6 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
     wlan.hidden_scan_on  = false;
 
     wlcm_process_init_params();
-
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_ROAMING)
-    wlan.rssi_low_threshold = 70;
-#endif
 
 #if defined(RW610) || defined(IW610) || defined(SD9177) || defined(SD8978)
     wlan.wakeup_conditions = 0;
@@ -8282,7 +8235,7 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
         }
         reset_mutex_init = 1;
     }
-#if defined(RW610) || defined(IW610) || defined(SD8978) || defined(SD9177)
+
     if (!mon_thread_init)
     {
 
@@ -8329,7 +8282,6 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
     {
         wlcm_e("Unable to create temperature monitor timer");
     }
-#endif
 #endif
 
     wlan.running = 1;
@@ -8405,17 +8357,15 @@ int wlan_start(int (*cb)(enum wlan_event_reason reason, void *data))
 #endif
 #endif
 
-#if CONFIG_WIFI_IND_OOB_RESET
-#ifdef IR_OUTBAND_TRIGGER_GPIO
-    gpio_pin_config_t out_config = {kGPIO_DigitalOutput, 1, kGPIO_NoIntmode};
-
-#if defined(IOMUXC_GPIO_IR_OUTBAND_TRIGGER)
-    IOMUXC_SetPinMux(IOMUXC_GPIO_IR_OUTBAND_TRIGGER, /* GPIO_AD_B0_10 is configured as GPIO1_IO10 */
-                     0U);
-#endif
-    GPIO_PinInit(IR_OUTBAND_TRIGGER_GPIO, IR_OUTBAND_TRIGGER_GPIO_PIN, &out_config);
-#endif
-
+#if CONFIG_ROAMING
+    status = OSA_TimerCreate((osa_timer_handle_t)wlan.roaming_report.roaming_timer,
+                          MSEC_TO_TICK(WLAN_ROAMING_COOLDOWN),
+                          &roaming_timer_cb, NULL, KOSA_TimerOnce, OSA_TIMER_NO_ACTIVATE);
+    if (status != KOSA_StatusSuccess)
+    {
+        wlcm_e("Failed to create roaming_timer");
+        return -WM_FAIL;
+    }
 #endif
 
     wlan_wait_wlmgr_ready();
@@ -8567,6 +8517,16 @@ int wlan_stop(void)
         return WLAN_ERROR_STATE;
     }
 #endif
+#endif
+
+#if CONFIG_ROAMING
+    (void)OSA_TimerDeactivate((osa_timer_handle_t)wlan.roaming_report.roaming_timer);
+    status = OSA_TimerDestroy((osa_timer_handle_t)wlan.roaming_report.roaming_timer);
+    if (status != KOSA_StatusSuccess)
+    {
+        wlcm_w("failed to delete roaming timer: %d.", ret);
+        return WLAN_ERROR_STATE;
+    }
 #endif
 
 #ifdef RW610
@@ -10607,6 +10567,28 @@ int wlan_imu_put_task_lock(void)
 }
 #endif
 
+#if !defined(RW610) && CONFIG_WIFI_RECOVERY
+void wlan_reset_async(void)
+{
+    struct wlan_message msg = {0};
+
+    (void)PRINTF("recovery_enable: wifi_fw_is_hang: %u, reset_in_progress:%u\r\n",
+                 wifi_fw_is_hang(), wifi_reset_in_progress());
+    /* Avoid repeatedly triggering recovery */
+    if (wifi_reset_in_progress())
+    {
+        return;
+    }
+
+    msg.data = NULL;
+    msg.id  = WIFI_RECOVERY_REQ;
+    if (OSA_MsgQPut((osa_msgq_handle_t)mon_thread_events, &msg) != KOSA_StatusSuccess)
+    {
+        (void)PRINTF("Failed to send wifi recovery msg to queue\r\n");
+    }
+}
+#endif
+
 void wlan_reset(cli_reset_option ResetOption)
 {
     if (OSA_MutexLock((osa_mutex_handle_t)reset_lock, 0) != WM_SUCCESS)
@@ -10778,13 +10760,15 @@ void wlan_reset(cli_reset_option ResetOption)
     }
 
     wifi_reset_set_state(false);
+#if CONFIG_WIFI_IND_RESET
+    wifi_reset_mode_set(0);
+#endif
     wlan_uap_bandcfg_recfg();
     OSA_MutexUnlock((osa_mutex_handle_t)reset_lock);
 
     wlcm_w("--- Done ---");
 }
 
-#if defined(RW610) || defined(IW610) || defined(SD9177) || defined(SD8978)
 static void wlcmgr_mon_task(void * data)
 {
 #if CONFIG_HOST_SLEEP
@@ -10802,11 +10786,6 @@ static void wlcmgr_mon_task(void * data)
         wlcm_e("Unable to create wake timer");
     }
 #endif
-     status = OSA_SemaphoreCreate((osa_semaphore_handle_t)wakelock, 0);
-    if (status != KOSA_StatusSuccess)
-    {
-        wifi_e("Failed to create wake-lock semaphore");
-    }
 #endif
     while (1)
     {
@@ -10881,7 +10860,6 @@ static void wlcmgr_mon_task(void * data)
         }
     }
 }
-#endif // RW610
 
 #if CONFIG_NCP_BRIDGE
 int wlan_stop_all_networks(void)
@@ -11998,16 +11976,6 @@ int wlan_set_uap_max_clients(unsigned int max_sta_num)
 #endif
 }
 
-int wlan_get_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t index, void *buf, unsigned int *buf_len)
-{
-    return wifi_get_mgmt_ie((mlan_bss_type)bss_type, index, buf, buf_len);
-}
-
-int wlan_set_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t id, void *buf, unsigned int buf_len)
-{
-    return wifi_set_mgmt_ie((mlan_bss_type)bss_type, id, buf, buf_len);
-}
-
 #ifdef SD8801
 int wlan_get_ext_coex_stats(wlan_ext_coex_stats_t *ext_coex_stats)
 {
@@ -12019,11 +11987,6 @@ int wlan_set_ext_coex_config(const wlan_ext_coex_config_t ext_coex_config)
     return wifi_set_ext_coex_config(&ext_coex_config);
 }
 #endif
-
-int wlan_clear_mgmt_ie(enum wlan_bss_type bss_type, IEEEtypes_ElementId_t index, int mgmt_bitmap_index)
-{
-    return wifi_clear_mgmt_ie((mlan_bss_type)bss_type, index, mgmt_bitmap_index);
-}
 
 int wlan_set_txbfcap(unsigned int tx_bf_cap)
 {
@@ -12238,6 +12201,35 @@ int wlan_uap_get_log(wlan_pkt_stats_t *stats)
         return -WM_E_INVAL;
 
     return wifi_get_log(stats, MLAN_BSS_TYPE_UAP);
+}
+
+int wlan_get_diag(struct wlan_diag *diag)
+{
+    if (!diag)
+        return -WM_E_INVAL;
+
+    /* hw_exception_count: reserved, not yet supported by driver */
+    diag->hw_exception_count = 0U;
+
+    diag->disconnection_count = wlan.diag_disc_count;
+
+    /* Duration is only meaningful while disconnected and after at least
+     * one disconnect event has been recorded. */
+    if (is_sta_connected() || wlan.diag_disc_count == 0U)
+    {
+        diag->disconnection_dur_sec = 0U;
+    }
+    else
+    {
+        uint32_t now_ms   = (uint32_t)k_uptime_get_32();
+        /* Handle 32-bit wrap-around */
+        uint32_t delta_ms = (now_ms >= wlan.diag_disc_timestamp)
+                            ? (now_ms - wlan.diag_disc_timestamp)
+                            : ((UINT32_MAX - wlan.diag_disc_timestamp) + now_ms + 1U);
+        diag->disconnection_dur_sec = delta_ms / 1000U;
+    }
+
+    return WM_SUCCESS;
 }
 #endif
 
@@ -13465,11 +13457,11 @@ void wlan_set_tx_pert(struct wlan_tx_pert_info *tx_pert, mlan_bss_type bss_type)
 #endif
 
 #if CONFIG_TX_RX_HISTOGRAM
-void wlan_set_txrx_histogram(struct wlan_txrx_histogram_info *txrx_histogram, t_u8 *data)
+void wlan_set_txrx_histogram(int bss_type, struct wlan_txrx_histogram_info *txrx_histogram, t_u8 *data)
 {
     int ret = WM_SUCCESS;
 
-    wifi_set_txrx_histogram((void *)txrx_histogram, data);
+    wifi_set_txrx_histogram(bss_type, (void *)txrx_histogram, data);
     if (ret != WM_SUCCESS)
         wlcm_e("Failed to set txrx histogram config.");
     return;
@@ -13477,36 +13469,35 @@ void wlan_set_txrx_histogram(struct wlan_txrx_histogram_info *txrx_histogram, t_
 #endif
 
 #if CONFIG_ROAMING
-int wlan_set_roaming(const int enable, const uint8_t rssi_low_threshold)
+int wlan_set_roaming(const uint8_t bitmap,
+                    const uint8_t rssi_low_threshold,
+                    const uint8_t snr_low_threshold)
 {
-#if !CONFIG_WIFI_NM_WPA_SUPPLICANT
-#if CONFIG_WPA_SUPP
-    struct netif *netif = net_get_sta_interface();
-#endif
-#endif
+    /* Validate */
+    if ((bitmap & 0x01) && rssi_low_threshold == 0)
+    {
+        return -WM_E_INVAL;
+    }
+    if ((bitmap & 0x02) && snr_low_threshold == 0)
+    {
+        return -WM_E_INVAL;
+    }
 
-    wlan.roaming_enabled = enable;
-#if !CONFIG_WIFI_NM_WPA_SUPPLICANT
-#if CONFIG_WPA_SUPP
-    wpa_supp_set_okc(netif, wlan.roaming_enabled == true ? 0 : 1);
-#endif
-#endif
-    wlan.rssi_low_threshold = rssi_low_threshold;
+    /* Update config */
+    wlan.roaming_report.bitmap = bitmap;
+    wlan.roaming_report.rssi_low_threshold = rssi_low_threshold;
+    wlan.roaming_report.snr_low_threshold = snr_low_threshold;
+    wifi_config_roaming((int)bitmap, rssi_low_threshold);
 
-    return wifi_config_roaming(enable, &wlan.rssi_low_threshold);
+    /* Post WIFI_EVENT_ROAMING_TRIGGER to wlcmgr */
+    (void)wifi_event_completion(WIFI_EVENT_ROAMING_TRIGGER,
+                                WIFI_EVENT_REASON_SUCCESS, NULL);
+    return WM_SUCCESS;
 }
 
 int wlan_get_roaming_status(void)
 {
-    return wlan.roaming_enabled;
-}
-
-void wlan_subscribe_rssi_low_event(void)
-{
-    if(wlan.roaming_enabled)
-    {
-        wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-    }
+    return wlan.roaming_report.bitmap != 0;
 }
 #endif
 
@@ -13799,6 +13790,7 @@ int wlan_send_hostcmd(
 int wlan_enable_disable_htc(uint8_t option)
 {
     int ret                 = -WM_FAIL;
+    /* Path 1: Enable/Disable HTC+ CAP bit via debug cmd 0x008B / SUBID 0x0124 */
     uint8_t send_htc_set[]  = {0x8b, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x24, 0x01, 0x01, 0x00, 0x00, 0x00};
     uint8_t debug_resp_buf[32] = {0};
     uint32_t reqd_len       = 0;
@@ -13807,6 +13799,17 @@ int wlan_enable_disable_htc(uint8_t option)
 
     ret = wlan_send_hostcmd(send_htc_set, sizeof(send_htc_set) / sizeof(uint8_t), debug_resp_buf, sizeof(debug_resp_buf),
                             &reqd_len);
+
+    if (ret != WM_SUCCESS)
+    {
+        return ret;
+    }
+
+    /* Path 2: Enable/Disable HTC in TX packets via proper IOCTL path
+     * HostCmd_CMD_11AX_CMD (0x026D) / MLAN_11AXCMD_HTC_SUBID (0x0104)
+     * Equivalent to "mlanutl mlan0 11axcmd enable_htc <option>" in mxmdriver.
+     */
+    ret = wifi_set_11ax_htc(MLAN_BSS_TYPE_STA, option);
 
     return ret;
 }
@@ -14755,7 +14758,7 @@ int wlan_set_wmm_uapsd(t_u8 uapsd_enable)
     unsigned int condition = 0;
 #endif
 
-    if (!is_uap_state(CM_UAP_INITIALIZING) || is_sta_connecting())
+    if (is_uap_starting() || is_sta_connecting())
     {
         wlcm_e("Failed to enable/disable UAPSD, because uAP is up/STA is connecting\n");
         return -WM_FAIL;
@@ -15227,27 +15230,6 @@ int wlan_csi_cfg(wlan_csi_config_params_t *csi_params)
     ret = wifi_csi_cfg(csi_params);
 
     return ret;
-}
-#endif
-
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_11R) || (CONFIG_ROAMING)
-void wlan_set_rssi_low_threshold(uint8_t threshold)
-{
-    wlan.rssi_low_threshold = threshold;
-
-    if (is_sta_connected())
-    {
-#if CONFIG_ROAMING
-        if (wlan.roaming_enabled == true)
-        {
-            (void)wifi_config_roaming(true, &wlan.rssi_low_threshold);
-        }
-        else
-#endif
-        {
-            (void)wifi_set_rssi_low_threshold(&wlan.rssi_low_threshold);
-        }
-    }
 }
 #endif
 
@@ -16248,7 +16230,7 @@ int wlan_host_set_sta_mac_filter(int filter_mode, int mac_count, unsigned char *
 #endif
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 int wlan_set_indrst_cfg(const wlan_indrst_cfg_t *indrst_cfg)
 {
     if (!indrst_cfg || (indrst_cfg->ir_mode != 0 && indrst_cfg->ir_mode != 2
@@ -16260,7 +16242,6 @@ int wlan_set_indrst_cfg(const wlan_indrst_cfg_t *indrst_cfg)
     {
         return -WM_FAIL;
     }
-    wlan.ir_mode = indrst_cfg->ir_mode;
 
     return wifi_set_indrst_cfg(indrst_cfg, (mlan_bss_type)WLAN_BSS_TYPE_STA);
 }
@@ -16268,64 +16249,6 @@ int wlan_set_indrst_cfg(const wlan_indrst_cfg_t *indrst_cfg)
 int wlan_get_indrst_cfg(wlan_indrst_cfg_t *indrst_cfg)
 {
     return wifi_get_indrst_cfg(indrst_cfg, (mlan_bss_type)WLAN_BSS_TYPE_STA);
-}
-
-static int wlan_trigger_inband_ind_reset()
-{
-    return wifi_trigger_inband_indrst();
-}
-
-#if CONFIG_WIFI_IND_OOB_RESET
-static int wlan_trigger_oob_ind_reset()
-{
-    (void)wlan_ieeeps_off();
-
-    OSA_TimeDelay(1000);
-
-    (void)wlan_deepsleepps_off();
-
-    OSA_TimeDelay(1000);
-
-#ifdef IR_OUTBAND_TRIGGER_GPIO
-    GPIO_PinWrite(IR_OUTBAND_TRIGGER_GPIO, IR_OUTBAND_TRIGGER_GPIO_PIN, 0);
-
-    OSA_TimeDelay(10);
-
-    GPIO_PinWrite(IR_OUTBAND_TRIGGER_GPIO, IR_OUTBAND_TRIGGER_GPIO_PIN, 1);
-#endif
-    if (wifi_trigger_oob_indrst() != WM_SUCCESS)
-    {
-        (void)wlan_ieeeps_on(1);
-
-        OSA_TimeDelay(1000);
-
-        (void)wlan_deepsleepps_on();
-
-        OSA_TimeDelay(1000);
-
-        return -WM_FAIL;
-    }
-    else
-    {
-        return WM_SUCCESS;
-    }
-}
-#endif
-
-int wlan_independent_reset()
-{
-    if (wlan.ir_mode == 2)
-    {
-        return wlan_trigger_inband_ind_reset();
-    }
-#if CONFIG_WIFI_IND_OOB_RESET
-    else if (wlan.ir_mode == 1)
-    {
-        return wlan_trigger_oob_ind_reset();
-    }
-#endif
-
-    return -WM_FAIL;
 }
 #endif
 

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_csi.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_csi.c
@@ -290,7 +290,10 @@ static void csi_process_task(void *arg)
 #endif
 
     w_csi_d(" Processing task exiting\r\n");
-    OSA_TaskDestroy((osa_task_handle_t)csi_process_task_handle);
+    for (;;)
+    {
+        OSA_TimeDelay(100000);
+    }
 }
 
 
@@ -384,10 +387,11 @@ int csi_destroy_process_task(void)
 
     csi_task_state = CSI_TASK_STATE_DESTROYING;
 
-    /* Send HALT message and wait for task to self-destruct */
+    /* Send HALT message and destroy */
     csi_msg_t halt_msg = {CSI_HALT_SIGNAL, 0};
     OSA_MsgQPut((osa_msgq_handle_t)csi_msg_queue, &halt_msg);
     OSA_TimeDelay(100);
+    OSA_TaskDestroy((osa_task_handle_t)csi_process_task_handle);
 
     /* Drain remaining messages if any (prevents queue access race) */
     t_u32 remaining_msgs = OSA_MsgQAvailableMsgs((osa_msgq_handle_t)csi_msg_queue);

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
@@ -762,7 +762,8 @@ static void test_wlan_tx_pert(int argc, char **argv)
 static void dump_wlan_txrx_histogram_usage()
 {
     (void)PRINTF("Usage:\r\n");
-    (void)PRINTF("    wlan_txrx_histogram <action> <enable>\r\n");
+    (void)PRINTF("    wlan_txrx_histogram <sta/uap> <action> <enable>\r\n");
+    (void)PRINTF("        <sta/uap>: STA'  or 'UAP' \r\n");
     (void)PRINTF("        <enable> : 0 - disable TX/RX statistics\r\n");
     (void)PRINTF("                   1 - enable TX/RX statistics\r\n");
     (void)PRINTF("                   2 - get TX/RX statistics\r\n");
@@ -772,7 +773,7 @@ static void dump_wlan_txrx_histogram_usage()
     (void)PRINTF("Note:\r\n");
     (void)PRINTF("    When enable is 0 or 1, the action parameter should not be entered\r\n");
     (void)PRINTF("Example:\r\n");
-    (void)PRINTF("    wlan_txrx_histogram 2 3\r\n");
+    (void)PRINTF("    wlan_txrx_histogram sta 2 3\r\n");
 }
 
 static void test_wlan_txrx_histogram(int argc, char **argv)
@@ -788,13 +789,25 @@ static void test_wlan_txrx_histogram(int argc, char **argv)
     rx_pkt_vht_rate_info *rx_vht_info;
     rx_pkt_he_rate_info *rx_he_info;
     rx_pkt_rate_info *rx_info;
+    int bss_type;
 
     t_u8 *pos             = NULL;
     t_u16 resp_value_size = 0;
     int i                 = 0;
     t_u16 buf_size        = 0;
 
-    if (argc < 2)
+    if (argc < 3)
+    {
+        (void)PRINTF("Error: invalid number of arguments\r\n");
+        dump_wlan_txrx_histogram_usage();
+        return;
+    }
+
+    if (string_equal("sta", argv[1]))
+        bss_type = WLAN_BSS_TYPE_STA;
+    else if (string_equal("uap", argv[1]))
+        bss_type = WLAN_BSS_TYPE_UAP;
+    else
     {
         (void)PRINTF("Error: invalid number of arguments\r\n");
         dump_wlan_txrx_histogram_usage();
@@ -802,14 +815,14 @@ static void test_wlan_txrx_histogram(int argc, char **argv)
     }
 
     (void)memset(&txrx_histogram, 0, sizeof(txrx_histogram));
-    txrx_histogram.enable = atoi(argv[1]);
-    if (argc == 2)
+    txrx_histogram.enable = atoi(argv[2]);
+    if (argc == 3)
     {
         txrx_histogram.action = 0;
     }
     else
     {
-        txrx_histogram.action = atoi(argv[2]);
+        txrx_histogram.action = atoi(argv[3]);
     }
 
     if ((txrx_histogram.enable > 2) || (txrx_histogram.action > 3))
@@ -856,7 +869,7 @@ static void test_wlan_txrx_histogram(int argc, char **argv)
         (void)memcpy(buf, &buf_size, sizeof(buf_size));
     }
 
-    wlan_set_txrx_histogram(&txrx_histogram, buf);
+    wlan_set_txrx_histogram(bss_type, &txrx_histogram, buf);
 
     if (buf == NULL)
     {
@@ -989,46 +1002,67 @@ static void test_wlan_txrx_histogram(int argc, char **argv)
 static void dump_wlan_roaming_usage(void)
 {
     (void)PRINTF("Usage:\r\n");
-    (void)PRINTF(
-        "    wlan-roaming <0/1> <rssi_threshold>"
-        "\r\n");
-    (void)PRINTF("Example:\r\n");
-    (void)PRINTF("    wlan-roaming 1 40\r\n");
+    (void)PRINTF("  nxp_wifi roaming 0\r\n");
+    (void)PRINTF("  nxp_wifi roaming 1 <rssi_threshold>\r\n");
+    (void)PRINTF("  nxp_wifi roaming 2 <snr_threshold>\r\n");
+    (void)PRINTF("  nxp_wifi roaming 3 <rssi_threshold> <snr_threshold>\r\n");
+    (void)PRINTF("\r\n");
+    (void)PRINTF("bitmap: 0=disable, 1=RSSI_LOW, 2=SNR_LOW, 3=both\r\n");
 }
 
 static void test_wlan_roaming(int argc, char **argv)
 {
-    int enable                 = 0;
+    uint8_t bitmap;
     uint8_t rssi_low_threshold = 0;
+    uint8_t snr_low_threshold = 0;
 
-    if ((argc != 2) && (argc != 3))
+    if (argc < 2)
     {
         dump_wlan_roaming_usage();
-        (void)PRINTF("Error: invalid number of arguments\r\n");
         return;
     }
 
-    errno  = 0;
-    enable = (int)strtol(argv[1], NULL, 10);
-    if (errno != 0)
-    {
-        (void)PRINTF("Error during strtol:wlan roaming errno:%d\r\n", errno);
-        return;
-    }
+    bitmap = (uint8_t)atoi(argv[1]);
 
-    if (argc == 3)
+    if (bitmap == 0)
     {
-        errno              = 0;
-        rssi_low_threshold = (uint8_t)strtol(argv[2], NULL, 10);
-        if (errno != 0)
+        /* Disable - no extra args needed */
+    }
+    else if (bitmap == 1)
+    {
+        if (argc < 3)
         {
-            (void)PRINTF("Error during strtol:rssi_threshold errno:%d\r\n", errno);
+            dump_wlan_roaming_usage();
             return;
         }
+        rssi_low_threshold = (uint8_t)atoi(argv[2]);
+    }
+    else if (bitmap == 2)
+    {
+        if (argc < 3)
+        {
+            dump_wlan_roaming_usage();
+            return;
+        }
+        snr_low_threshold = (uint8_t)atoi(argv[2]);
+    }
+    else if (bitmap == 3)
+    {
+        if (argc < 4)
+        {
+            dump_wlan_roaming_usage();
+            return;
+        }
+        rssi_low_threshold = (uint8_t)atoi(argv[2]);
+        snr_low_threshold = (uint8_t)atoi(argv[3]);
+    }
+    else
+    {
+        dump_wlan_roaming_usage();
+        return;
     }
 
-    wlan_set_roaming(enable, rssi_low_threshold);
-    return;
+    wlan_set_roaming(bitmap, rssi_low_threshold, snr_low_threshold);
 }
 #endif
 
@@ -1986,6 +2020,25 @@ static void test_wlan_get_log(int argc, char **argv)
             stats.tx_mpdus_in_ampdu_cnt, stats.tx_octets_in_ampdu_cnt, stats.ampdu_rx_cnt, stats.mpdu_in_rx_ampdu_cnt,
             stats.rx_octets_in_ampdu_cnt, stats.ampdu_delimiter_crc_error_cnt);
     }
+}
+
+static void test_wlan_get_diag(int argc, char **argv)
+{
+    struct wlan_diag diag;
+    int ret;
+
+    (void)memset(&diag, 0, sizeof(struct wlan_diag));
+    ret = wlan_get_diag(&diag);
+    if (ret != WM_SUCCESS)
+    {
+        (void)PRINTF("Failed to get Wi-Fi diagnostic stats\r\n");
+        return;
+    }
+
+    (void)PRINTF("Wi-Fi Diagnostic Stats:\r\n");
+    (void)PRINTF("  hwExceptionCount      : %u\r\n", diag.hw_exception_count);
+    (void)PRINTF("  disconnectionCount    : %u\r\n", diag.disconnection_count);
+    (void)PRINTF("  disconnectionDuration : %u sec\r\n", diag.disconnection_dur_sec);
 }
 #endif
 
@@ -4524,7 +4577,7 @@ static void dump_wlan_reg_access_usage()
     (void)PRINTF("Write the register:\r\n");
     (void)PRINTF("    wlan-reg-access <type> <offset> <value>\r\n");
     (void)PRINTF("Options: \r\n");
-    (void)PRINTF("    <type>  : 1:MAC, 2:BBP, 3:RF, 4:CAU\r\n");
+    (void)PRINTF("    <type>  : 1:MAC, 2:BBP, 3:RF, 4:CAU, 5:PSU, 6:BCA, 8:CIU\r\n");
     (void)PRINTF("    <offset>: offset of register\r\n");
     (void)PRINTF("For example:\r\n");
     (void)PRINTF("    wlan-reg-access 1 0x9b8             : Read the MAC register\r\n");
@@ -4545,11 +4598,11 @@ static void test_wlan_reg_access(int argc, char **argv)
         return;
     }
 
-    if ((a2hex_or_atoi(argv[1]) != 1 && a2hex_or_atoi(argv[1]) != 2 && a2hex_or_atoi(argv[1]) != 3 &&
-         a2hex_or_atoi(argv[1]) != 4))
+    if (a2hex_or_atoi(argv[1]) < 1 || a2hex_or_atoi(argv[1]) > 8
+         || a2hex_or_atoi(argv[1]) == 7)
     {
         dump_wlan_reg_access_usage();
-        (void)PRINTF("Error: Illegal register type %s. Must be either '1','2','3' or '4'.\r\n", argv[1]);
+        (void)PRINTF("Error: Illegal register type %s.\r\n", argv[1]);
         return;
     }
     type   = a2hex_or_atoi(argv[1]);
@@ -5384,32 +5437,6 @@ static void test_wlan_start_stop_ami(int argc, char **argv)
 }
 
 #endif /* CONFIG_CSI_AMI */
-#endif
-
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_11R) || (CONFIG_ROAMING)
-static void test_wlan_rssi_low_threshold(int argc, char **argv)
-{
-    uint8_t rssi_threshold;
-
-    if (argc < 2)
-    {
-        (void)PRINTF("Usage: %s <rssi threshold value>\r\n", argv[0]);
-        (void)PRINTF("Error: Default value is 70. Specify the value you want to set as threshold.\r\n");
-        return;
-    }
-
-    errno          = 0;
-    rssi_threshold = (uint8_t)strtol(argv[1], NULL, 10);
-    if (errno != 0)
-    {
-        (void)PRINTF("Error during strtol:rssi_threshold errno:%d\r\n", errno);
-        return;
-    }
-
-    wlan_set_rssi_low_threshold(rssi_threshold);
-
-    (void)PRINTF("rssi threshold set successfully.\r\n");
-}
 #endif
 
 #if CONFIG_NET_MONITOR
@@ -7875,7 +7902,7 @@ done:
 }
 #endif
 
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
 static void dump_wlan_set_ind_rst_cfg_usage(void)
 {
     (void)PRINTF("Usage :                                                                \r\n");
@@ -7974,34 +8001,6 @@ static void test_get_indrst_cfg(int argc, char **argv)
                (indrst_cfg.ir_mode == 0) ? "disabled" : ((indrst_cfg.ir_mode == 1) ? "Out Band" : "In Band"));
         if (indrst_cfg.ir_mode == 1)
             (void)PRINTF("GPIO Pin = %d\n\n", indrst_cfg.gpio_pin);
-    }
-}
-
-static void dump_wlan_independent_reset_usage(void)
-{
-    (void)PRINTF("Usage :                                     \r\n");
-    (void)PRINTF("         wlan-independent-reset             \r\n");
-}
-
-static void test_wlan_independent_reset(int argc, char **argv)
-{
-    int ret = -WM_FAIL;
-
-    if (argc != 1)
-    {
-        dump_wlan_independent_reset_usage();
-        return;
-    }
-
-    ret = wlan_independent_reset();
-
-    if (ret == WM_SUCCESS)
-    {
-        (void)PRINTF("Independent reset success\r\n");
-    }
-    else
-    {
-        (void)PRINTF("Independent reset failed\r\n");
     }
 }
 #endif
@@ -9149,12 +9148,13 @@ static struct cli_command tests[] = {
 #endif
 #if CONFIG_WIFI_GET_LOG
     {"wlan-get-log", "<sta/uap> <ext>", test_wlan_get_log},
+    {"wlan-get-diag", NULL, test_wlan_get_diag},
 #endif
 #if CONFIG_WIFI_TX_PER_TRACK
     {"wlan-tx-pert", "<0/1> <STA/UAP> <p> <r> <n>", test_wlan_tx_pert},
 #endif
 #if CONFIG_ROAMING
-    {"wlan-roaming", "<0/1> <rssi_threshold>", test_wlan_roaming},
+    {"wlan-roaming", "<bitmap> [<rssi_threshold>] [<snr_threshold>]", test_wlan_roaming},
 #endif
 #if CONFIG_MEF_CFG
     {"wlan-multi-mef", "<ping/arp/multicast/del> [<action>]", test_wlan_set_multiple_mef_config},
@@ -9264,9 +9264,6 @@ static struct cli_command tests[] = {
 #if CONFIG_TX_AMPDU_PROT_MODE
     {"wlan-tx-ampdu-prot-mode", "<mode>", test_wlan_tx_ampdu_prot_mode},
 #endif
-#if (CONFIG_11K) || (CONFIG_11V) || (CONFIG_11R) || (CONFIG_ROAMING)
-    {"wlan-rssi-low-threshold", "<threshold_value>", test_wlan_rssi_low_threshold},
-#endif
 #if CONFIG_RX_ABORT_CFG
     {"wlan-rx-abort-cfg", NULL, test_wlan_rx_abort_cfg},
 #endif
@@ -9360,10 +9357,9 @@ static struct cli_command tests[] = {
 #if CONFIG_AUTO_RECONNECT
     {"wlan-auto-reconnect", "<0/1/2> [<reconnect counter> <reconnect interval> <flags>]", test_wlan_auto_reconnect},
 #endif
-#if (CONFIG_WIFI_IND_RESET) && (CONFIG_WIFI_IND_DNLD)
+#if CONFIG_WIFI_IND_RESET
     {"wlan-set-indrstcfg", "<mode> <gpio_pin>", test_set_indrst_cfg},
     {"wlan-get-indrstcfg", NULL, test_get_indrst_cfg},
-    {"wlan-independent-reset", "<mode>", test_wlan_independent_reset},
 #endif
 #if CONFIG_INACTIVITY_TIMEOUT_EXT
     {"wlan-sta-inactivityto", "<n> <m> <l> [k] [j]", test_wlan_sta_inactivityto},


### PR DESCRIPTION
Fix csi task exit assert.
Add register type support in register access command. Optimize independent reset for wifi recovery.
Fix infinite loop on wpa supp with nxp driver.
Custom IE Improvement.
Optimize SDIO code relocation to reduce ITCM usage. Fix WiFi UDP TX throughput is lower(10Mbps) in COEX baseline test. Fix wakelock semaphore creation order causing hardfault. The corresponding SHA is bc2cbb2.