### PR TITLE
sdk-ng: usb: update mcux usb host controller driver to support zephyr

### DIFF
--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ehci.c
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ehci.c
@@ -7,6 +7,15 @@
  */
 #include "usb_host_config.h"
 #if ((defined USB_HOST_CONFIG_EHCI) && (USB_HOST_CONFIG_EHCI > 0U))
+/* CONFIG_UHC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ehci.h"
+#if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT))
+#include "usb_phy.h"
+#endif
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "usb_host_devices.h"
@@ -20,6 +29,7 @@
 #endif
 #if ((defined USB_HOST_CONFIG_COMPLIANCE_TEST) && (USB_HOST_CONFIG_COMPLIANCE_TEST))
 #include "usb_host.h"
+#endif
 #endif
 #if (defined(FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET) && (FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET > 0U))
 #include "fsl_memory.h"

--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ip3516hs.c
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ip3516hs.c
@@ -8,11 +8,17 @@
 
 #include "usb_host_config.h"
 #if (defined(USB_HOST_CONFIG_IP3516HS) && (USB_HOST_CONFIG_IP3516HS > 0U))
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ip3516hs.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_ip3516hs.h"
 #include "usb_host_devices.h"
+#endif
 #if ((defined FSL_FEATURE_SOC_USBPHY_COUNT) && (FSL_FEATURE_SOC_USBPHY_COUNT > 0U))
 #include "usb_phy.h"
 #endif

--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_khci.c
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_khci.c
@@ -8,12 +8,19 @@
 
 #include "usb_host_config.h"
 #if ((defined USB_HOST_CONFIG_KHCI) && (USB_HOST_CONFIG_KHCI))
+/* CONFIG_UHC_DRIVER is for Zephyr, it will not be defined in NXP MCUXpresso SDK */
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_khci.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_khci.h"
 #include "usb_host_devices.h"
 #include "usb_host_framework.h"
+#endif
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -2012,7 +2019,11 @@ static usb_status_t _USB_HostKhciBusControl(usb_host_controller_handle handle, u
         _USB_HostKhciDelay(usbHostPointer, 30U);
         usbHostPointer->usbRegBase->CTL &= (uint8_t)(~USB_CTL_RESET_MASK);
         usbHostPointer->usbRegBase->CTL |= USB_CTL_ODDRST_MASK;
+#if (defined CONFIG_UHC_DRIVER)
+        usbHostPointer->usbRegBase->CTL = USB_CTL_HOSTMODEEN_MASK | USB_CTL_USBENSOFEN_MASK;
+#else
         usbHostPointer->usbRegBase->CTL = USB_CTL_HOSTMODEEN_MASK;
+#endif
 
         usbHostPointer->txBd = 0U;
         usbHostPointer->rxBd = 0U;

--- a/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ohci.c
+++ b/mcux/mcux-sdk-ng/middleware/usb/host/usb_host_ohci.c
@@ -8,11 +8,17 @@
 
 #include "usb_host_config.h"
 #if (defined(USB_HOST_CONFIG_OHCI) && (USB_HOST_CONFIG_OHCI > 0U))
+#if (defined CONFIG_UHC_DRIVER)
+#include "usb_host_mcux_drv_port.h"
+#include "fsl_device_registers.h"
+#include "usb_host_ohci.h"
+#else
 #include "usb_host.h"
 #include "usb_host_hci.h"
 #include "fsl_device_registers.h"
 #include "usb_host_ohci.h"
 #include "usb_host_devices.h"
+#endif
 
 /*******************************************************************************
  * Definitions


### PR DESCRIPTION
- EHCI, KHCI, OHCI and IP3516HS driver include Zephyr USB port file if it is Zephyr environment
 - Fix the KHCI driver bus reset issue
The pr https://github.com/zephyrproject-rtos/hal_nxp/pull/496 original changes are part lost, cherry pick changes that are needed.