### PR TITLE
wifi_nxp: support add and remove supplicant interface when wifi reset

### DIFF
--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -2709,6 +2709,12 @@ static int wifi_low_level_input(const uint8_t interface, const uint8_t *buffer, 
         OSA_RWLockWriteUnlock(&sleep_rwlock);
         mlan_adap->ps_state = PS_STATE_AWAKE;
     }
+
+    if (wifi_rx_status == WIFI_DATA_BLOCK)
+    {
+        wifi_rx_block_cnt++;
+        goto consumed;
+    }
 #if CONFIG_WPA_SUPP
 #if CONFIG_TX_RX_ZERO_COPY && !defined(RW610)
     prx_pd = (RxPD *)(void *)net_stack_buffer_skip((void *)buffer, INTF_HEADER_LEN);
@@ -2722,11 +2728,6 @@ static int wifi_low_level_input(const uint8_t interface, const uint8_t *buffer, 
         goto consumed;
     }
 #endif
-    if (wifi_rx_status == WIFI_DATA_BLOCK)
-    {
-        wifi_rx_block_cnt++;
-        goto consumed;
-    }
 
     if (wm_wifi.data_input_callback != NULL)
     {

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/wifi_nxp.c
@@ -109,6 +109,12 @@ static void wifi_nxp_event_proc_scan_done(void *if_priv, int aborted, int extern
         wifi_e("%s: wifi_if_ctx_rtos is NULL", __func__);
         return;
     }
+    if (!wifi_if_ctx_rtos->supp_drv_if_ctx)
+    {
+        supp_e("%s: Missing interface context", __func__);
+        return;
+    }
+
     wifi_nxp_wpa_supp_event_proc_scan_done(if_priv, aborted, external_scan);
 }
 
@@ -121,6 +127,11 @@ static int wifi_nxp_wpa_is_supp_scan_in_progress(void *if_priv)
     if (wifi_if_ctx_rtos == NULL)
     {
         wifi_e("%s: wifi_if_ctx_rtos is NULL", __func__);
+        return -WM_FAIL;
+    }
+    if (!wifi_if_ctx_rtos->supp_drv_if_ctx)
+    {
+        supp_e("%s: Missing interface context", __func__);
         return -WM_FAIL;
     }
 

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -8558,8 +8558,8 @@ int wlan_stop(void)
 
     if (wlan.status != WLCMGR_THREAD_STOPPED && !num_iterations)
     {
-        wlcm_w("Timed out waiting for wlcmgr to stop");
-        wlcm_w("Forcing halt for wlcmgr thread");
+        wlcm_d("Timed out waiting for wlcmgr to stop");
+        wlcm_d("Forcing halt for wlcmgr thread");
         /* Reinitiailize variable states */
         wlan.status = WLCMGR_THREAD_STOPPED;
     }
@@ -10739,16 +10739,30 @@ void wlan_reset(cli_reset_option ResetOption)
             }
 
             /* update the netif hwaddr after reset */
-#if CONFIG_WIFI_NM_WPA_SUPPLICANT
-            wlan_set_mac_addr(&wlan.sta_mac[0]);
-#else
 #if UAP_SUPPORT
             net_wlan_set_mac_address(&wlan.sta_mac[0], &wlan.uap_mac[0]);
 #else
             net_wlan_set_mac_address(&wlan.sta_mac[0], NULL);
 #endif
-#endif
+            /* Bring netif up.
+             * Triggers NET_EVENT_IF_ADMIN_UP -> add_interface()
+             * -> wpa_drv_zep_init() -> wifi_nxp_wpa_supp_dev_init()
+             * -> supp_drv_if_ctx is now valid.
+             */
             nxp_net_enable_all_networks();
+
+#if CONFIG_WIFI_NM_WPA_SUPPLICANT
+            /* Wait supp_drv_if_ctx ready
+             * and Notify FW and wpa_supplicant of MAC address.
+             * wlan_set_mac_addr() calls _wifi_set_mac_addr() -> FW cmd ->
+             * mac_changed callback -> wpa_supplicant updates its MAC.
+             * supp_drv_if_ctx is valid now
+             */
+            while (!get_supp_ready_state()) {
+                OSA_TaskYield();
+            }
+            wlan_set_mac_addr(&wlan.sta_mac[0]);
+#endif
 
             /* Unblock TX data */
             wifi_set_tx_status(WIFI_DATA_RUNNING);


### PR DESCRIPTION
1. wlan-reset wlcmgr task is destroyed, and wlan.status can't be set
to WLCMGR_THREAD_STOPPED, so print timeout log, This case is acceptable,
but this warning should not be logged, so change log warning level
to debug level.
2. set mac addr to fw needs zephyr supplicant and hostapd driver ready,
so wait wpa supplicant ready before set mac addr.
3. net_wlan_set_mac_address is redundant, as wifi_set_mac_address
already sets the net_if MAC address