### PR TITLE
wifi_nxp: upgrade wifi_nxp to 2026-07-10

### DIFF
--- a/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
+++ b/mcux/middleware/wifi_nxp/incl/nxp_wifi.h
@@ -288,6 +288,10 @@ extern "C" {
 #define CONFIG_UART_WIFI_BRIDGE 1
 #endif
 
+#if CONFIG_NXP_WIFI_SLIM
+#define CONFIG_WIFI_SLIM 1
+#endif
+
 #if CONFIG_NXP_OVERRIDE_CALIBRATION_DATA
 #if defined(CONFIG_WLAN_CALDATA_2ANT_HI_ISO)
 #define OVERRIDE_CALIBRATION_DATA "wifi_cal_data_iw612_2ant_hi_iso.h"

--- a/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
+++ b/mcux/middleware/wifi_nxp/incl/wlcmgr/wlan.h
@@ -5336,7 +5336,7 @@ int wlan_get_rf_band(uint8_t *band);
  *
  * \note  call \ref wlan_set_rf_test_mode API before using this API.
  *
- * \param[in] xtal_cal: The crystal calibration offset to be set in Wi-Fi firmware.
+ * \param[in] xtal_cal: The crystal calibration offset to be set in Wi-Fi firmware, range [0,255].
  *
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
  *
@@ -6694,6 +6694,8 @@ int wlan_set_threshold_link_quality(unsigned int evend_id,
  * \param[out] dutycycmin:        Duty cycle min(percentage)
  * \param[out] highthrtemp:       High throttle threshold temperature(celsius)
  * \param[out] lowthrtemp:        Low throttle threshold temperature(celsius)
+ * \param[out] throttledutycycle: Throttled duty cycle [3...100] (percentage)
+ * \param[out] rftemppollcnt:     RFU temperature poll/averaging count [1...100] (number of samples per average)
  * \param[out] currCAUTemp:       CAU TSEN temperature
  * \param[out] currRFUTemp:       RFU temperature
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
@@ -6706,6 +6708,8 @@ int wlan_get_tsp_cfg(t_u16 *enable,
                      t_u32 *dutycycmin,
                      int *highthrtemp,
                      int *lowthrtemp,
+                     t_u32 *throttledutycycle,
+                     t_u32 *rftemppollcnt,
                      int *currCAUTemp,
                      int *currRFUTemp);
 
@@ -6721,6 +6725,7 @@ int wlan_get_tsp_cfg(t_u16 *enable,
  * \param[in] dutycycmin:        Duty cycle min(percentage)
  * \param[out] highthrtemp:      High throttle threshold temperature (celsius)
  * \param[out] lowthrtemp:       Low throttle threshold temperature (celsius)
+ * \param[in] rftemppollcnt:      RFU temperature poll/averaging count [1...100] (number of samples per average)
  * \return WM_SUCCESS if successful otherwise return -WM_FAIL.
  */
 int wlan_set_tsp_cfg(t_u16 enable,
@@ -6730,7 +6735,8 @@ int wlan_set_tsp_cfg(t_u16 enable,
                      t_u32 dutycycstep,
                      t_u32 dutycycmin,
                      int highthrtemp,
-                     int lowthrtemp);
+                     int lowthrtemp,
+                     t_u32 rftemppollcnt);
 #endif
 
 #if CONFIG_WIFI_REG_ACCESS

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_api.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_api.h
@@ -636,6 +636,8 @@ int wifi_tsp_cfg(const t_u16 action,
                  t_u32 *dutycycmin,
                  int *highthrtemp,
                  int *lowthrtemp,
+                 t_u32 *throttledutycycle,
+                 t_u32 *rftemppollcnt,
                  int *currCAUTemp,
                  int *currRFUTemp);
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_decl.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_decl.h
@@ -124,7 +124,9 @@ Change log:
 
 /** Default Win size attached during ADDBA response */
 #ifndef MLAN_STA_AMPDU_DEF_RXWINSIZE
-#if defined(SD9177) && !defined(COEX_APP_SUPPORT)
+#if CONFIG_WIFI_SLIM
+#define MLAN_STA_AMPDU_DEF_RXWINSIZE 16
+#elif defined(SD9177) && !defined(COEX_APP_SUPPORT)
 #define MLAN_STA_AMPDU_DEF_RXWINSIZE 64
 #else
 #define MLAN_STA_AMPDU_DEF_RXWINSIZE 32

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_fw.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_fw.h
@@ -7803,6 +7803,10 @@ typedef MLAN_PACK_START struct _HostCmd_DS_TSP_CFG
     int highthrtemp;
     /** LOW_THRESHOLD_TEMP*/
     int lowthrtemp;
+    /** DTM duty cycle increment step*/
+    t_u32 throttledutycycle;
+    /** RFU temperature poll/averaging count (number of samples per average) */
+    t_u32 rftemppollcnt;
     /** CAU TSEN temperature */
     int currCAUTemp;
     /** RFU temperature */
@@ -7827,6 +7831,10 @@ typedef MLAN_PACK_START struct _TSP_CFG
     int *highthrtemp;
     /** LOW_THRESHOLD_TEMP*/
     int *lowthrtemp;
+    /** DTM duty cycle increment step*/
+    t_u32 *throttledutycycle;
+    /** RFU temperature poll/averaging count (number of samples per average) */
+    t_u32 *rftemppollcnt;
     /** CAU TSEN temperature */
     int *currCAUTemp;
     /** RFU temperature */

--- a/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ieee.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/incl/mlan_ieee.h
@@ -2399,7 +2399,7 @@ typedef struct _BSSDescriptor_t
     /** channel load */
     t_u16 chan_load;
     /** channel load */
-    t_u16 chan_noise;
+    t_s16 chan_noise;
 #endif
 
     /** Channel */

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_11k.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_11k.c
@@ -950,12 +950,7 @@ void wlan_process_neighbor_report_response(t_u8 *frame, t_u32 len, t_u8 *dest_ad
     if (len < 3U)
     {
         wifi_d("Ignoring too short radio measurement request");
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-        OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
-        return;
+        goto out;
     }
 
     memset(pnlist_rep_param, 0, sizeof(wlan_nlist_report_param));
@@ -1009,15 +1004,16 @@ void wlan_process_neighbor_report_response(t_u8 *frame, t_u32 len, t_u8 *dest_ad
     if (wifi_event_completion(WIFI_EVENT_NLIST_REPORT, WIFI_EVENT_REASON_SUCCESS, pnlist_rep_param) != WM_SUCCESS)
     {
         /* If fail to send message on queue, free allocated memory ! */
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-        OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
+        goto out;
     }
     return;
 
 out:
+    /* Post failure event to notify upper layer */
+    if (wifi_event_completion(WIFI_EVENT_NLIST_REPORT, WIFI_EVENT_REASON_FAILURE, NULL) != WM_SUCCESS)
+    {
+        wifi_e("Failed to post nlist report failure event");
+    }
 #if !CONFIG_MEM_POOLS
     OSA_MemoryFree((void *)pnlist_rep_param);
 #else

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_11v.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_11v.c
@@ -182,10 +182,11 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
     t_u8 tagnr_len                            = 0;
     wlan_nlist_report_param *pnlist_rep_param = MNULL;
     t_u8 entry_num                            = 0;
+    struct wnm_neighbor_report *preport = NULL;
 
     if (end - pos < 5)
     {
-        return;
+        goto out;
     }
 
 #if !CONFIG_MEM_POOLS
@@ -197,7 +198,7 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
     if (pnlist_rep_param == MNULL)
     {
         wifi_e("11v nlist report param buffer alloc failed %d", sizeof(wlan_nlist_report_param));
-        return;
+        goto out;
     }
 
     (void)memset(pnlist_rep_param, 0, sizeof(wlan_nlist_report_param));
@@ -214,20 +215,14 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
     if ((btm_mode & IEEE_WNM_BTM_REQUEST_PREFERENCE_CAND_LIST_INCLUDED) != 0U)
     {
 #if !CONFIG_MEM_POOLS
-        struct wnm_neighbor_report *preport =
-            OSA_MemoryAllocate((size_t)WLAN_WNM_MAX_NEIGHBOR_REPORT * sizeof(struct wnm_neighbor_report));
+        preport = OSA_MemoryAllocate((size_t)WLAN_WNM_MAX_NEIGHBOR_REPORT * sizeof(struct wnm_neighbor_report));
 #else
-        struct wnm_neighbor_report *preport = OSA_MemoryPoolAllocate(buf_128_MemoryPool);
+        preport = OSA_MemoryPoolAllocate(buf_128_MemoryPool);
 #endif
         if (preport == NULL)
         {
             wifi_e("No memory available for neighbor report.");
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-            OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
-            return;
+            goto out;
         }
 
         while (end - pos >= 2 && wnm_num_neighbor_report < (t_u8)WLAN_WNM_MAX_NEIGHBOR_REPORT)
@@ -238,14 +233,7 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
             if ((int)len > (end - pos))
             {
                 wifi_d("WNM: Truncated BTM request");
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree((void *)preport);
-                OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-                OSA_MemoryPoolFree(buf_128_MemoryPool, preport);
-                OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
-                return;
+                goto out;
             }
 
             if (tag == (t_u8)NEIGHBOR_REPORT)
@@ -261,7 +249,15 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
                 if (rep->prefer_select != (t_u8)0U && (rep->prefer > prefer_old))
                 {
                     ptagnr         = pos - 2;
-                    tagnr_len      = len + (t_u8)2U;
+                    if (len <= (0xFFU - 2U))
+                    {
+                        tagnr_len = (t_u8)(len + 2U);
+                    }
+                    else
+                    {
+                        wifi_e("WNM: Incorrect length");
+                        goto out;
+                    }
                     prefer_old     = (t_u8)rep->prefer;
                     prefer_select  = 1;
                     neighbor_index = wnm_num_neighbor_report;
@@ -275,15 +271,7 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
         {
             wlan_send_mgmt_wnm_btm_resp(dialog_token, WNM_BTM_REJECT_NO_SUITABLE_CANDIDATES, dest_addr, src_addr, NULL,
                                         ptagnr, tagnr_len, protect);
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree((void *)preport);
-            OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-            OSA_MemoryPoolFree(buf_128_MemoryPool, preport);
-            OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
-
-            return;
+            goto out;
         }
 
         if (prefer_select == (t_u8)1U)
@@ -312,18 +300,14 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
         if (wifi_event_completion(WIFI_EVENT_NLIST_REPORT, WIFI_EVENT_REASON_SUCCESS, (void *)pnlist_rep_param) !=
             WM_SUCCESS)
         {
-            /* If fail to send message on queue, free allocated memory ! */
-#if !CONFIG_MEM_POOLS
-            OSA_MemoryFree((void *)pnlist_rep_param);
-#else
-            OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
-#endif
+            goto out;
         }
 #if !CONFIG_MEM_POOLS
         OSA_MemoryFree(preport);
 #else
         OSA_MemoryPoolFree(buf_128_MemoryPool, preport);
 #endif
+        return;
     }
     else
     {
@@ -338,13 +322,21 @@ void wlan_process_mgmt_wnm_btm_req(t_u8 *pos, t_u8 *end, t_u8 *src_addr, t_u8 *d
         }
 
         wlan_send_mgmt_wnm_btm_resp(dialog_token, status, dest_addr, src_addr, NULL, ptagnr, tagnr_len, protect);
-        /* If don't use variable pnlist_rep_param, free allocated memory ! */
+    }
+
+out:
+    (void)wifi_event_completion(WIFI_EVENT_NLIST_REPORT, WIFI_EVENT_REASON_FAILURE, NULL);
 #if !CONFIG_MEM_POOLS
+    if (preport)
+        OSA_MemoryFree((void *)preport);
+    if (pnlist_rep_param)
         OSA_MemoryFree((void *)pnlist_rep_param);
 #else
+    if (preport)
+        OSA_MemoryPoolFree(buf_128_MemoryPool, preport);
+    if (pnlist_rep_param)
         OSA_MemoryPoolFree(buf_128_MemoryPool, pnlist_rep_param);
 #endif
-    }
 }
 
 int wlan_send_mgmt_bss_trans_query(mlan_private *pmpriv, t_u8 query_reason)

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_api.c
@@ -6588,6 +6588,8 @@ int wifi_tsp_cfg(const t_u16 action,
                  t_u32 *dutycycmin,
                  int *highthrtemp,
                  int *lowthrtemp,
+                 t_u32 *throttledutycycle,
+                 t_u32 *rftemppollcnt,
                  int *currCAUTemp,
                  int *currRFUTemp)
 {
@@ -6607,6 +6609,7 @@ int wifi_tsp_cfg(const t_u16 action,
     (void)memcpy(&tsp_cfg->dutycycmin, dutycycmin, sizeof(t_u32));
     (void)memcpy(&tsp_cfg->highthrtemp, highthrtemp, sizeof(t_s32));
     (void)memcpy(&tsp_cfg->lowthrtemp, lowthrtemp, sizeof(t_s32));
+    (void)memcpy(&tsp_cfg->rftemppollcnt, rftemppollcnt, sizeof(t_u32));
 
     tsp_cfg->action                 = wlan_cpu_to_le16(action);
     tsp_cfg->thermalPowerMgmtenable = wlan_cpu_to_le16(tsp_cfg->thermalPowerMgmtenable);
@@ -6617,6 +6620,7 @@ int wifi_tsp_cfg(const t_u16 action,
     tsp_cfg->dutycycmin             = wlan_cpu_to_le16(tsp_cfg->dutycycmin);
     tsp_cfg->highthrtemp            = wlan_cpu_to_le16(tsp_cfg->highthrtemp);
     tsp_cfg->lowthrtemp             = wlan_cpu_to_le16(tsp_cfg->lowthrtemp);
+    tsp_cfg->rftemppollcnt          = wlan_cpu_to_le16(tsp_cfg->rftemppollcnt);
 
     cmd->size = wlan_cpu_to_le16(cmd->size);
 
@@ -6633,6 +6637,8 @@ int wifi_tsp_cfg(const t_u16 action,
         tsp_get_cfg.dutycycmin             = dutycycmin;
         tsp_get_cfg.highthrtemp            = highthrtemp;
         tsp_get_cfg.lowthrtemp             = lowthrtemp;
+        tsp_get_cfg.throttledutycycle      = throttledutycycle;
+        tsp_get_cfg.rftemppollcnt          = rftemppollcnt;
         tsp_get_cfg.currCAUTemp            = currCAUTemp;
         tsp_get_cfg.currRFUTemp            = currRFUTemp;
 

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
@@ -5063,6 +5063,8 @@ int wifi_process_cmd_response(HostCmd_DS_COMMAND *resp)
                         *(tsp_get_cfg->dutycycmin)             = data->dutycycmin;
                         *(tsp_get_cfg->highthrtemp)            = data->highthrtemp;
                         *(tsp_get_cfg->lowthrtemp)             = data->lowthrtemp;
+                        *(tsp_get_cfg->throttledutycycle)      = data->throttledutycycle;
+                        *(tsp_get_cfg->rftemppollcnt)          = data->rftemppollcnt;
                         *(tsp_get_cfg->currCAUTemp)            = data->currCAUTemp;
                         *(tsp_get_cfg->currRFUTemp)            = data->currRFUTemp;
                     }
@@ -6054,7 +6056,6 @@ int wifi_handle_fw_event(struct bus_message *msg)
 #if CONFIG_EXT_SCAN_SUPPORT
     mlan_event_scan_result *pext_scan_result;
 #endif
-    int16_t *rssi_snr;
 
     if (evt == NULL)
     {
@@ -6307,55 +6308,17 @@ int wifi_handle_fw_event(struct bus_message *msg)
             break;
 #endif
         case EVENT_RSSI_LOW:
-        {
-#if !CONFIG_MEM_POOLS
-            rssi_snr = (t_s16 *)OSA_MemoryAllocate(sizeof(t_s16));
-#else
-            rssi_snr = (t_s16 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
-#endif
-            if (rssi_snr == MNULL)
+            if (wifi_event_completion(WIFI_EVENT_RSSI_LOW, WIFI_EVENT_REASON_SUCCESS, NULL) != WM_SUCCESS)
             {
-                wifi_w("No mem. Failed to alloc for EVENT_RSSI_LOW");
-                break;
-            }
-            *rssi_snr = (t_s16)evt->reason_code;
-            if (wifi_event_completion(WIFI_EVENT_RSSI_LOW,
-                                     WIFI_EVENT_REASON_SUCCESS,
-                                     (void *)rssi_snr) != WM_SUCCESS)
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree((void *)rssi_snr);
-#else
-                OSA_MemoryPoolFree(buf_32_MemoryPool, rssi_snr);
-#endif
+                wifi_w("Failed to post WIFI_EVENT_RSSI_LOW");
             }
             break;
-        }
         case EVENT_SNR_LOW:
-        {
-#if !CONFIG_MEM_POOLS
-            rssi_snr = (t_s16 *)OSA_MemoryAllocate(sizeof(t_s16));
-#else
-            rssi_snr = (t_s16 *)OSA_MemoryPoolAllocate(buf_32_MemoryPool);
-#endif
-            if (rssi_snr == MNULL)
+            if (wifi_event_completion(WIFI_EVENT_SNR_LOW, WIFI_EVENT_REASON_SUCCESS, NULL) != WM_SUCCESS)
             {
-                wifi_w("No mem. Failed to alloc for EVENT_SNR_LOW");
-                break;
-            }
-            *rssi_snr = (t_s16)evt->reason_code;
-            if (wifi_event_completion(WIFI_EVENT_SNR_LOW,
-                                     WIFI_EVENT_REASON_SUCCESS,
-                                     (void *)rssi_snr) != WM_SUCCESS)
-            {
-#if !CONFIG_MEM_POOLS
-                OSA_MemoryFree((void *)rssi_snr);
-#else
-                OSA_MemoryPoolFree(buf_32_MemoryPool, rssi_snr);
-#endif
+                wifi_w("Failed to post WIFI_EVENT_SNR_LOW");
             }
             break;
-        }
 #if CONFIG_SUBSCRIBE_EVENT_SUPPORT
         case EVENT_RSSI_HIGH:
             (void)wifi_event_completion(WIFI_EVENT_RSSI_HIGH, WIFI_EVENT_REASON_SUCCESS, NULL);

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_scan.c
@@ -2206,15 +2206,16 @@ static t_u16 wlan_get_chan_load(mlan_adapter *pmadapter, t_u8 channel)
     return chan_load;
 }
 
-static t_u16 wlan_get_chan_noise(mlan_adapter *pmadapter, t_u8 channel)
+static t_s16 wlan_get_chan_noise(mlan_adapter *pmadapter, t_u8 channel)
 {
-    t_u16 chan_noise = 0;
+    t_s16 chan_noise = 0;
     int i;
     for (i = 0; i < (int)pmadapter->num_in_chan_stats; i++)
     {
         if ((pmadapter->pchan_stats[i].chan_num == channel) && pmadapter->pchan_stats[i].noise)
         {
-            chan_noise = pmadapter->pchan_stats[i].noise;
+            /* Noise is stored as signed dBm in unsigned byte from FW */
+            chan_noise = (t_s16)(int8_t)pmadapter->pchan_stats[i].noise;
             break;
         }
     }

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
@@ -3332,7 +3332,7 @@ static void handle_sdio_packet_read(mlan_adapter *pmadapter)
         t_u8 *packet     = NULL;
 
         ret = _handle_sdio_packet_read(pmadapter, &packet, &datalen, &pkt_type);
-        if (ret != MLAN_STATUS_SUCCESS)
+        if (ret == MLAN_STATUS_FAILURE)
         {
             /* nothing to read. break out of while loop */
             break;

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -4263,7 +4263,7 @@ int wifi_nxp_scan_res_get2(t_u32 table_idx, nxp_wifi_event_new_scan_result_t *sc
         scan_res->ies.ie_len = (t_u16)0U;
     }
 
-    scan_res->rssi = (t_u8) - (bss_new_entry->rssi);
+    scan_res->rssi = -bss_new_entry->rssi;
 #if CONFIG_SCAN_CHANNEL_GAP
     scan_res->noise = bss_new_entry->chan_noise;
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/rtos_wpa_supp_if.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/rtos_wpa_supp_if.h
@@ -162,7 +162,7 @@ void wifi_nxp_wpa_supp_event_proc_eapol_rx(void *if_priv,
 #endif
 void wifi_nxp_wpa_supp_event_proc_dfs_cac_started(void *if_priv, nxp_wifi_dfs_cac_info *dfs_cac_info);
 void wifi_nxp_wpa_supp_event_proc_dfs_cac_finished(void *if_priv, nxp_wifi_dfs_cac_info *dfs_cac_info);
-void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 curr_rssi);
+void wifi_nxp_wpa_supp_event_signal_change(void *if_priv);
 #if CONFIG_WIFI_SOFTAP_SUPPORT
 int wifi_nxp_wpa_supp_init_ap(void *if_priv, struct wpa_driver_associate_params *params);
 #endif

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/wifi_nxp_internal.h
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/incl/wifi_nxp_internal.h
@@ -264,8 +264,8 @@ typedef MLAN_PACK_START struct _nxp_wifi_event_new_scan_result
     unsigned short beacon_interval;
     unsigned short capability;
     nxp_wifi_ie2_t ies;
-    unsigned char rssi;
-    unsigned short noise;
+    int rssi;
+    int noise;
     unsigned char mac_addr[WIFI_ETH_ADDR_LEN];
     bool more_res;
 } MLAN_PACK_END nxp_wifi_event_new_scan_result_t;
@@ -614,7 +614,7 @@ typedef MLAN_PACK_START struct _wifi_nxp_callbk_fns
     void (*dfs_cac_started_callbk_fn)(void *if_priv, nxp_wifi_dfs_cac_info *ch_switch_info);
     void (*dfs_cac_finished_callbk_fn)(void *if_priv, nxp_wifi_dfs_cac_info *ch_switch_info);
     int (*is_supp_scan_in_progress_callbk_fn)(void *if_priv);
-    void (*signal_change_callbk_fn)(void *if_priv, t_s16 rssi);
+    void (*signal_change_callbk_fn)(void *if_priv);
     void (*sched_scan_done_callbk_fn)(void *if_priv);
     void (*sched_scan_stopped_callbk_fn)(void *if_priv);
 } MLAN_PACK_END wifi_nxp_callbk_fns_t;

--- a/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wpa_supp_if/rtos_wpa_supp_if.c
@@ -3018,10 +3018,11 @@ void wifi_nxp_wpa_supp_event_proc_dfs_cac_finished(void *if_priv, nxp_wifi_dfs_c
     }
 }
 
-void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 curr_rssi)
+void wifi_nxp_wpa_supp_event_signal_change(void *if_priv)
 {
     struct wifi_nxp_ctx_rtos *wifi_if_ctx_rtos = NULL;
     union wpa_event_data event;
+    nxp_wifi_signal_info_t signal_params = {0};
 
     wifi_if_ctx_rtos = (struct wifi_nxp_ctx_rtos *)if_priv;
 
@@ -3030,9 +3031,17 @@ void wifi_nxp_wpa_supp_event_signal_change(void *if_priv, t_s16 curr_rssi)
         wifi_e("%s: wifi_if_ctx_rtos is NULL", __func__);
         return;
     }
+
+    if (wifi_nxp_get_signal(wifi_if_ctx_rtos->bss_type, &signal_params) != WM_SUCCESS)
+    {
+        supp_e("%s: wifi_nxp_get_signal failed", __func__);
+        return;
+    }
+
     memset(&event, 0, sizeof(event));
     event.signal_change.above_threshold = 0;
-    event.signal_change.data.signal = abs(curr_rssi);
+    event.signal_change.data.signal = signal_params.current_signal;
+    event.signal_change.current_noise = signal_params.current_noise;
 
     wifi_if_ctx_rtos->supp_callbk_fns.signal_change(wifi_if_ctx_rtos->supp_drv_if_ctx, &event);
 }

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -94,7 +94,6 @@
 
 #if CONFIG_ROAMING
 #define WLAN_ROAMING_COOLDOWN 2000
-#define WLAN_ROAMING_RSSI_DEFAULT_THRESHOLD -70
 #endif
 
 #define WL_ID_CONNECT      "wifi_connect"
@@ -278,7 +277,7 @@ static t_u16 scan_channel_gap = (t_u16)SCAN_CHANNEL_GAP_VALUE;
 #endif
 
 #if (CONFIG_11K) || (CONFIG_11V)
-#define NEIGHBOR_REQ_TIMEOUT (60 * 1000)
+#define NEIGHBOR_REQ_TIMEOUT (10 * 1000)
 #endif
 
 #if CONFIG_11R
@@ -1351,7 +1350,8 @@ static int security_profile_matches(const struct wlan_network *network, const st
         }
 #endif
 
-        if (res->WPA_WPA2_WEP.wepStatic || res->WPA_WPA2_WEP.wpa2 || res->WPA_WPA2_WEP.wpa)
+        if (res->WPA_WPA2_WEP.wepStatic || res->WPA_WPA2_WEP.wpa2 ||
+            res->WPA_WPA2_WEP.wpa       || res->WPA_WPA2_WEP.wpa3_sae)
         {
             return WM_SUCCESS;
         }
@@ -4388,7 +4388,19 @@ static void wlcm_process_neighbor_list_report_event(struct wifi_message *msg,
     t_u8 *bssid                               = NULL;
     wlan_nlist_report_param *pnlist_rep_param = (wlan_nlist_report_param *)msg->data;
 
-    wlan.roam_reassoc = false;
+    if (msg->reason == WIFI_EVENT_REASON_FAILURE)
+    {
+        wlcm_d("11K/11V neighbor report failed, clearing roam state");
+#if CONFIG_ROAMING
+        if (wlan.roam_reassoc == true)
+        {
+            wlan.roam_reassoc = false;
+        }
+#endif
+        wlan.neighbor_req = false;
+        (void)OSA_TimerDeactivate((osa_timer_handle_t)wlan.neighbor_req_timer);
+        return;
+    }
 
     if (is_state(CM_STA_IDLE) || (pnlist_rep_param == NULL))
     {
@@ -6937,12 +6949,12 @@ static void roaming_subscribe_process(void)
     }
 }
 
-static void roaming_report_process(struct wifi_message *msg, enum wifi_event event)
+static void roaming_report_process(void)
 {
     if (!wlan.roaming_report.subscribed)
     {
         wlcm_d("roaming_report: stale event, drop");
-        goto free_data;
+        return;
     }
 
     /* De-subscribe both from FW */
@@ -6952,26 +6964,17 @@ static void roaming_report_process(struct wifi_message *msg, enum wifi_event eve
     {
         wlcm_d("roaming_report: de-subscribe cmd failed, disabling");
         wlan.roaming_report.bitmap = 0;
-        goto free_data;
+        return;
     }
     wlan.roaming_report.subscribed = false;
     wlcm_d("roaming_report: de-subscribed");
 
-    /* Deliver signal change */
-    t_s16 rssi;
-    if (event == WIFI_EVENT_RSSI_LOW)
-    {
-        rssi = *(t_s16 *)msg->data;
-    }
-    else
-    {
-        rssi = WLAN_ROAMING_RSSI_DEFAULT_THRESHOLD;
-    }
-    wlcm_d("roaming_report: signal_change rssi=%d", rssi);
-
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
-    wm_wifi.supp_if_callbk_fns->signal_change_callbk_fn(
-        wm_wifi.if_priv, rssi);
+    if (wm_wifi.supp_if_callbk_fns != NULL &&
+        wm_wifi.supp_if_callbk_fns->signal_change_callbk_fn != NULL)
+    {
+        wm_wifi.supp_if_callbk_fns->signal_change_callbk_fn(wm_wifi.if_priv);
+    }
 #else
     wlcm_process_rssi_low_event();
 #endif
@@ -6980,16 +6983,6 @@ static void roaming_report_process(struct wifi_message *msg, enum wifi_event eve
     if (!OSA_TimerIsRunning((osa_timer_handle_t)wlan.roaming_report.roaming_timer))
     {
         (void)OSA_TimerActivate((osa_timer_handle_t)wlan.roaming_report.roaming_timer);
-    }
-
-free_data:
-    if (msg->data != NULL)
-    {
-#if !CONFIG_MEM_POOLS
-        OSA_MemoryFree(msg->data);
-#else
-        OSA_MemoryPoolFree(buf_32_MemoryPool, msg->data);
-#endif
     }
 }
 #endif
@@ -7181,7 +7174,7 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
         case WIFI_EVENT_RSSI_LOW:
             wlcm_d("got event: rssi low");
 #if CONFIG_ROAMING
-            roaming_report_process(msg, WIFI_EVENT_RSSI_LOW);
+            roaming_report_process();
 #else
             CONNECTION_EVENT(WLAN_REASON_RSSI_LOW, NULL);
 #endif
@@ -7189,7 +7182,7 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
         case WIFI_EVENT_SNR_LOW:
             wlcm_d("got event: SNR low");
 #if CONFIG_ROAMING
-            roaming_report_process(msg, WIFI_EVENT_SNR_LOW);
+            roaming_report_process();
 #else
             CONNECTION_EVENT(WLAN_REASON_RSSI_LOW, NULL);
 #endif
@@ -8067,6 +8060,13 @@ static void neighbor_req_timer_cb(osa_timer_arg_t arg)
     {
         wlan.neighbor_req = false;
     }
+#if CONFIG_ROAMING
+    if (wlan.roam_reassoc == true)
+    {
+        wlan.roam_reassoc = false;
+        wlcm_d("neighbor req timeout, clearing roam state");
+    }
+#endif
 }
 #endif
 
@@ -9049,7 +9049,7 @@ int wlan_add_network(struct wlan_network *network)
 
     /* make sure that the network name length is acceptable */
     len = strlen(network->name);
-    if (len < WLAN_NETWORK_NAME_MIN_LENGTH || len >= WLAN_NETWORK_NAME_MAX_LENGTH)
+    if (len < WLAN_NETWORK_NAME_MIN_LENGTH || len > WLAN_NETWORK_NAME_MAX_LENGTH)
     {
         wlcm_e("name length is out of bounds");
         return -WM_E_INVAL;
@@ -15823,12 +15823,14 @@ int wlan_get_tsp_cfg(t_u16 *enable,
                      t_u32 *dutycycmin,
                      int *highthrtemp,
                      int *lowthrtemp,
+                     t_u32 *throttledutycycle,
+                     t_u32 *rftemppollcnt,
                      int *currCAUTemp,
                      int *currRFUTemp)
 {
     t_u16 action = 0;
 
-    return wifi_tsp_cfg(action, enable, back_off, highThreshold, lowThreshold, dutycycstep, dutycycmin, highthrtemp, lowthrtemp, currCAUTemp, currRFUTemp);
+    return wifi_tsp_cfg(action, enable, back_off, highThreshold, lowThreshold, dutycycstep, dutycycmin, highthrtemp, lowthrtemp, throttledutycycle, rftemppollcnt, currCAUTemp, currRFUTemp);
 }
 int wlan_set_tsp_cfg(t_u16 enable,
                      t_u32 back_off,
@@ -15837,11 +15839,12 @@ int wlan_set_tsp_cfg(t_u16 enable,
                      t_u32 dutycycstep,
                      t_u32 dutycycmin,
                      int highthrtemp,
-                     int lowthrtemp)
+                     int lowthrtemp,
+                     t_u32 rftemppollcnt)
 {
     t_u16 action = 1;
 
-    return wifi_tsp_cfg(action, &enable, &back_off, &highThreshold, &lowThreshold, &dutycycstep, &dutycycmin, &highthrtemp, &lowthrtemp, NULL, NULL);
+    return wifi_tsp_cfg(action, &enable, &back_off, &highThreshold, &lowThreshold, &dutycycstep, &dutycycmin, &highthrtemp, &lowthrtemp, NULL, &rftemppollcnt, NULL, NULL);
 }
 #endif
 

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_mode_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_mode_tests.c
@@ -336,10 +336,12 @@ static void wlan_rf_band_get(int argc, char *argv[])
     }
 }
 
+#ifdef RW610
 static void dump_wlan_set_rf_xtal_usage(void)
 {
     (void)PRINTF("Usage:\r\n");
     (void)PRINTF("wlan-set-rf-xtal <xtal_cal> \r\n");
+    (void)PRINTF("xtal_cal (0 to 255) \r\n");
     (void)PRINTF("\r\n");
 }
 
@@ -409,6 +411,7 @@ static void wlan_rf_xtal_get(int argc, char *argv[])
         dump_wlan_get_rf_xtal_usage();
     }
 }
+#endif
 
 static void dump_wlan_set_bandwidth_usage(void)
 {
@@ -1602,8 +1605,10 @@ static struct cli_command wlan_test_mode_commands[] = {
     {"wlan-get-rf-rx-antenna", NULL, wlan_rf_rx_antenna_get},
     {"wlan-set-rf-band", "<band>", wlan_rf_band_set},
     {"wlan-get-rf-band", NULL, wlan_rf_band_get},
+#ifdef RW610
     {"wlan-set-rf-xtal", "<xtal_cal>", wlan_rf_xtal_set},
     {"wlan-get-rf-xtal", NULL, wlan_rf_xtal_get},
+#endif
     {"wlan-set-rf-bandwidth", "<bandwidth>", wlan_rf_bandwidth_set},
     {"wlan-get-rf-bandwidth", NULL, wlan_rf_bandwidth_get},
     {"wlan-set-rf-channel", "<channel>", wlan_rf_channel_set},

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
@@ -5989,7 +5989,7 @@ static void dump_wlan_tsp_cfg_usage()
     (void)PRINTF("Usage:\r\n");
     (void)PRINTF(
         "    wlan-set-tsp-cfg en <0/1> bo <0-20> high <0-300> low <0-300> "
-        "dcstep <1-100> dcmin <0-100> hightemp <-100-150> lowtemp <-100-150>\r\n");
+        "dcstep <1-100> dcmin <0-100> hightemp <-100-150> lowtemp <-100-150> pollcnt <0-255>\r\n");
     (void)PRINTF("	  <en>: 0 -- disable   1 -- enable\r\n");
     (void)PRINTF("	  <bo>: power backoff [0...20]\r\n");
     (void)PRINTF("	  <high>: High power Threshold [0...300]\r\n");
@@ -5998,12 +5998,13 @@ static void dump_wlan_tsp_cfg_usage()
     (void)PRINTF("	  <dcmin>: Duty Cycle min [0...100]\r\n");
     (void)PRINTF("	  <hightemp>: High Throttle Threshold temperature [-100...150]\r\n");
     (void)PRINTF("	  <lowtemp>: Low Throttle Threshold temperature [-100...150]\r\n");
+    (void)PRINTF("	  <pollcnt>: RFU temperature poll/averaging count (number of samples per average)\r\n");
     (void)PRINTF("	  High Threshold must be greater than Low Threshold\r\n");
     (void)PRINTF("	  High Throttle Threshold temperature must be greater than Low Throttle Threshold temperature.\r\n");
     (void)PRINTF("	  If you want to get tsp cfg, you can just use wlan-get-tsp-cfg.\r\n");
     (void)PRINTF("\r\nUsage example : \r\n");
     (void)PRINTF(
-        "wlan-set-tsp-cfg wlan-set-tsp-cfg en 1 bo 0 high 93 low 83 dcstep 5 dcmin 10 hightemp 120 lowtemp 110 \r\n");
+        "wlan-set-tsp-cfg en 1 bo 0 high 93 low 83 dcstep 5 dcmin 10 hightemp 120 lowtemp 110 pollcnt 2 \r\n");
     (void)PRINTF("wlan-set-tsp-cfg en 0 \r\n");
 }
 static void test_wlan_set_tsp_cfg(int argc, char **argv)
@@ -6017,6 +6018,7 @@ static void test_wlan_set_tsp_cfg(int argc, char **argv)
     t_u32 lowThreshold  = 0;
     t_u32 dutycycstep   = 0;
     t_u32 dutycycmin    = 0;
+    t_u32 rftemppollcnt = 0;
     int highthrtemp     = 0;
     int lowthrtemp      = 0;
     int ret             = WM_SUCCESS;
@@ -6031,11 +6033,13 @@ static void test_wlan_set_tsp_cfg(int argc, char **argv)
         unsigned dutycycmin : 1;
         unsigned highthrtemp : 1;
         unsigned lowthrtemp : 1;
+        unsigned pollcnt : 1;
+        unsigned rsv : 7;
     } info;
 
     (void)memset(&info, 0, sizeof(info));
 
-    if (argc < 3 || argc > 17)
+    if (argc < 3 || argc > 19)
     {
         (void)PRINTF("Error: invalid number of arguments\r\n");
         dump_wlan_tsp_cfg_usage();
@@ -6143,6 +6147,18 @@ static void test_wlan_set_tsp_cfg(int argc, char **argv)
             info.lowthrtemp = 1;
             lowthrtemp      = tempvalue;
         }
+        else if (!info.pollcnt && string_equal("pollcnt", argv[arg]))
+        {
+            if (get_uint(argv[arg + 1], &value, strlen(argv[arg + 1])))
+            {
+                (void)PRINTF("Error: invalid RFU temperature poll/averaging count argument\r\n");
+                dump_wlan_tsp_cfg_usage();
+                return;
+            }
+            arg += 2;
+            info.pollcnt     = 1;
+            rftemppollcnt = value;
+        }
         else
         {
             (void)PRINTF("Error: invalid [%d] argument\r\n", arg + 1);
@@ -6159,7 +6175,7 @@ static void test_wlan_set_tsp_cfg(int argc, char **argv)
     }
 
     ret = wlan_set_tsp_cfg(enable, back_off, highThreshold, lowThreshold, dutycycstep, dutycycmin, highthrtemp,
-                           lowthrtemp);
+                           lowthrtemp, rftemppollcnt);
 
     if (ret != WM_SUCCESS)
     {
@@ -6176,6 +6192,8 @@ static void test_wlan_get_tsp_cfg(int argc, char **argv)
     t_u32 lowThreshold  = 0;
     t_u32 dutycycstep   = 0;
     t_u32 dutycycmin    = 0;
+    t_u32 dutycycle     = 0;
+    t_u32 rftemppollcnt = 0;
     int highthrtemp     = 0;
     int lowthrtemp      = 0;
     int currCAUTemp     = 0;
@@ -6190,7 +6208,7 @@ static void test_wlan_get_tsp_cfg(int argc, char **argv)
     }
 
     ret = wlan_get_tsp_cfg(&enable, &back_off, &highThreshold, &lowThreshold, &dutycycstep, &dutycycmin, &highthrtemp,
-                           &lowthrtemp, &currCAUTemp, &currRFUTemp);
+                           &lowthrtemp, &dutycycle, &rftemppollcnt, &currCAUTemp, &currRFUTemp);
 
     if (ret != WM_SUCCESS)
     {
@@ -6210,6 +6228,8 @@ static void test_wlan_get_tsp_cfg(int argc, char **argv)
     (void)PRINTF("	Low Throttle  Threshold temperature(celcius): %d\r\n", lowthrtemp);
     (void)PRINTF("	CAU TSEN Temperature(celcius): %d\r\n", currCAUTemp);
     (void)PRINTF("	RFU      Temperature(celcius): %d\r\n", currRFUTemp);
+    (void)PRINTF("	Duty Cycle is: %d\r\n", dutycycle);
+    (void)PRINTF("	RFU temperature poll/averaging count is (percentage): %d\r\n", rftemppollcnt);
 }
 #endif
 
@@ -9289,7 +9309,7 @@ static struct cli_command tests[] = {
 #endif
 #if CONFIG_TSP
     {"wlan-set-tsp-cfg",
-     "<enable> <backoff> <highThreshold> <lowThreshold> <dutycycstep> <dutycycmin> <highthrtemp> <lowthrtemp>",
+     "<enable> <backoff> <highThreshold> <lowThreshold> <dutycycstep> <dutycycmin> <highthrtemp> <lowthrtemp> <pollcnt>",
      test_wlan_set_tsp_cfg},
     {"wlan-get-tsp-cfg", NULL, test_wlan_get_tsp_cfg},
 #endif


### PR DESCRIPTION
Fix legacy roaming after 11kv roaming failure.
Fix network name length check allows up to 32 characters.
Fix CAU TSEN and RFU temperature not read back correctly.
Fix WPA3 connection failure when open profile is added before WPA3 profile.
Support raw scan result IEs conditionally.
Restrict xtal commands to RW610.
Reduce AMPDU RX window size in SLIM mode.
Fix zero-copy RX deadlock on net_pkt pool exhaustion.
Pass right rssi and noise to supplicant.
Pass both rssi and noise in EVENT_SIGNAL_CHANGE.
Improve RF test mode xtal feature usage dump.

The corresponding downstream SHA is 731b9580.

---
_Generated by WChat AI Agent_