### PR TITLE
wifi_nxp: wlcmgr: add missing stdlib.h includes

### DIFF
--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_enhanced_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_enhanced_tests.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <wlan.h>
 #include <wifi_shell.h>
 #include <cli_utils.h>

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_features.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_features.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <wlan.h>
 #include <cli_utils.h>
 #include <string.h>

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_mode_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_test_mode_tests.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <wlan.h>
 #include <wifi_shell.h>
 #include <cli_utils.h>

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan_tests.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <osa.h>
 #include <nxp_wifi_net.h> /* for net_inet_aton */


### PR DESCRIPTION
 atoi() and strtol() are used in wlan_tests.c, wlan_enhanced_tests.c,
wlan_features.c, and wlan_test_mode_tests.c without including <stdlib.h>. Normally it's transitively included when built with NXP SDK, but they break the compilation when building with picolibc