### PR TITLE
wifi_nxp: fix AArch64 pointer-truncation heap corruption and related build/robustness issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__/
 *.swp
-zephyr/blobs/rw61x
-zephyr/blobs/iw612
-zephyr/blobs/mcxw71
-zephyr/blobs/mcxw72
+zephyr/blobs/*
+!zephyr/blobs/license/
+!zephyr/blobs/license/**

--- a/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.c
+++ b/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma.c
@@ -18,9 +18,9 @@
 #define FSL_COMPONENT_ID "platform.drivers.edma4"
 #endif
 #if defined FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET && FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET
-#define CONVERT_TO_DMA_ADDRESS(addr) (MEMORY_ConvertMemoryMapAddress((uint32_t)(addr), kMEMORY_Local2DMA))
+#define CONVERT_TO_DMA_ADDRESS(addr) (MEMORY_ConvertMemoryMapAddress((uint32_t)(uintptr_t)(addr), kMEMORY_Local2DMA))
 #else
-#define CONVERT_TO_DMA_ADDRESS(addr) ((uint32_t)(addr))
+#define CONVERT_TO_DMA_ADDRESS(addr) ((uint32_t)(uintptr_t)(addr))
 #endif
 #if defined(DMA_RSTS_N)
 #define EDMA_RESETS_ARRAY DMA_RSTS_N
@@ -402,7 +402,7 @@ void EDMA_SetTransferConfig(EDMA_Type *base,
 
     if(nextTcd != NULL)
     {
-        nextTcd = (edma_tcd_t *)(CONVERT_TO_DMA_ADDRESS(nextTcd));
+        nextTcd = (edma_tcd_t *)(uintptr_t)(CONVERT_TO_DMA_ADDRESS(nextTcd));
     }
 
     EDMA_TcdSetTransferConfigExt(base, EDMA_TCD_BASE(base, channel), config, nextTcd);
@@ -701,7 +701,7 @@ void EDMA_ConfigChannelSoftwareTCDExt(EDMA_Type *base, edma_tcd_t *tcd, const ed
     /* Enable scatter/gather processing */
     if (transfer->linkTCD != NULL)
     {
-        EDMA_TCD_DLAST_SGA(tcd, EDMA_TCD_TYPE(base)) = CONVERT_TO_DMA_ADDRESS((uint32_t)((uint8_t *)transfer->linkTCD));
+        EDMA_TCD_DLAST_SGA(tcd, EDMA_TCD_TYPE(base)) = CONVERT_TO_DMA_ADDRESS(transfer->linkTCD);
         EDMA_TCD_CSR(tcd, EDMA_TCD_TYPE(base)) =
             (EDMA_TCD_CSR(tcd, EDMA_TCD_TYPE(base)) | (uint16_t)DMA_CSR_ESG_MASK) & MCUX_MASK_INVERT_16(DMA_CSR_DREQ_MASK);
     }
@@ -1074,7 +1074,7 @@ void EDMA_ConfigChannelSoftwareTCD(edma_tcd_t *tcd, const edma_transfer_config_t
     /* Enable scatter/gather processing */
     if (transfer->linkTCD != NULL)
     {
-        EDMA_TCD_DLAST_SGA(tcd, kEDMA_EDMA4Flag) = CONVERT_TO_DMA_ADDRESS((uint32_t)((uint8_t *)transfer->linkTCD));
+        EDMA_TCD_DLAST_SGA(tcd, kEDMA_EDMA4Flag) = CONVERT_TO_DMA_ADDRESS(transfer->linkTCD);
         EDMA_TCD_CSR(tcd, kEDMA_EDMA4Flag) =
             (EDMA_TCD_CSR(tcd, kEDMA_EDMA4Flag) | (uint16_t)DMA_CSR_ESG_MASK) & MCUX_MASK_INVERT_16(DMA_CSR_DREQ_MASK);
     }
@@ -1710,14 +1710,14 @@ void EDMA_PrepareTransferConfig(edma_transfer_config_t *config,
     assert(srcWidth != 64U);
 #endif
     assert((transferBytes % bytesEachRequest) == 0U);
-    assert((((uint32_t)(uint8_t *)srcAddr) % srcWidth) == 0U);
-    assert((((uint32_t)(uint8_t *)destAddr) % destWidth) == 0U);
+    assert((((uint32_t)(uintptr_t)srcAddr) % srcWidth) == 0U);
+    assert((((uint32_t)(uintptr_t)destAddr) % destWidth) == 0U);
 
     /* Initializes the configure structure to zero. */
     (void)memset(config, 0, sizeof(*config));
 
-    config->destAddr         = CONVERT_TO_DMA_ADDRESS((uint32_t)(uint32_t *)destAddr);
-    config->srcAddr          = CONVERT_TO_DMA_ADDRESS((uint32_t)(uint32_t *)srcAddr);
+    config->destAddr         = CONVERT_TO_DMA_ADDRESS(destAddr);
+    config->srcAddr          = CONVERT_TO_DMA_ADDRESS(srcAddr);
     config->minorLoopBytes   = bytesEachRequest;
     config->majorLoopCounts  = transferBytes / bytesEachRequest;
     config->srcTransferSize  = EDMA_TransferWidthMapping(srcWidth);
@@ -1852,8 +1852,8 @@ void EDMA_PrepareTransferTCD(edma_handle_t *handle,
     assert(srcWidth != 64U);
 #endif
     assert((transferBytes % bytesEachRequest) == 0U);
-    assert((((uint32_t)(uint32_t *)srcAddr) % srcWidth) == 0U);
-    assert((((uint32_t)(uint32_t *)destAddr) % destWidth) == 0U);
+    assert((((uint32_t)(uintptr_t)srcAddr) % srcWidth) == 0U);
+    assert((((uint32_t)(uintptr_t)destAddr) % destWidth) == 0U);
 
     edma_transfer_size_t srcTransferSize  = EDMA_TransferWidthMapping(srcWidth),
                          destTransferSize = EDMA_TransferWidthMapping(srcWidth);
@@ -1864,8 +1864,8 @@ void EDMA_PrepareTransferTCD(edma_handle_t *handle,
     assert((bytesEachRequest % (1UL << ((uint32_t)destTransferSize))) == 0U);
     assert(((uint32_t)(uint16_t)srcOffset % (1UL << ((uint32_t)srcTransferSize))) == 0U);
     assert(((uint32_t)(uint16_t)destOffset % (1UL << ((uint32_t)destTransferSize))) == 0U);
-    assert(((uint32_t)(uint32_t *)srcAddr % (1UL << ((uint32_t)srcTransferSize))) == 0U);
-    assert(((uint32_t)(uint32_t *)destAddr % (1UL << ((uint32_t)destTransferSize))) == 0U);
+    assert(((uint32_t)(uintptr_t)srcAddr % (1UL << ((uint32_t)srcTransferSize))) == 0U);
+    assert(((uint32_t)(uintptr_t)destAddr % (1UL << ((uint32_t)destTransferSize))) == 0U);
 
     EDMA_TCD_SADDR(tcd, EDMA_TCD_TYPE(handle->base)) = CONVERT_TO_DMA_ADDRESS((uint32_t *)srcAddr);
     /* destination address */
@@ -2056,7 +2056,7 @@ status_t EDMA_SubmitTransferTCD(edma_handle_t *handle, edma_tcd_t *tcd)
         {
             /* Link current TCD with next TCD for identification of current TCD */
             EDMA_TCD_DLAST_SGA((&handle->tcdPool[currentTcd]), EDMA_TCD_TYPE(handle->base)) =
-                CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[nextTcd]);
+                CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[nextTcd]);
         }
 
         /* Chain from previous descriptor unless tcd pool size is 1(this descriptor is its own predecessor). */
@@ -2080,7 +2080,7 @@ status_t EDMA_SubmitTransferTCD(edma_handle_t *handle, edma_tcd_t *tcd)
                 before link the previous TCD block.
             */
             if (EDMA_TCD_DLAST_SGA(tcdRegs, EDMA_TCD_TYPE(handle->base)) ==
-                CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[currentTcd]))
+                CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[currentTcd]))
             {
                 /* Clear the DREQ bits for the dynamic scatter gather */
                 EDMA_TCD_CSR(tcdRegs, EDMA_TCD_TYPE(handle->base)) |= DMA_CSR_DREQ_MASK;
@@ -2109,7 +2109,7 @@ status_t EDMA_SubmitTransferTCD(edma_handle_t *handle, edma_tcd_t *tcd)
                     TCD block has been loaded into TCD registers.
                 */
                 if (EDMA_TCD_DLAST_SGA(tcdRegs, EDMA_TCD_TYPE(handle->base)) ==
-                    CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[nextTcd]))
+                    CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[nextTcd]))
                 {
                     return kStatus_Success;
                 }
@@ -2240,7 +2240,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
         EDMA_TCD_CSR((&handle->tcdPool[currentTcd]), EDMA_TCD_TYPE(handle->base)) |= DMA_CSR_INTMAJOR_MASK;
         /* Link current TCD with next TCD for identification of current TCD */
         EDMA_TCD_DLAST_SGA((&handle->tcdPool[currentTcd]), EDMA_TCD_TYPE(handle->base)) =
-            CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[nextTcd]);
+            CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[nextTcd]);
         /* Chain from previous descriptor unless tcd pool size is 1(this descriptor is its own predecessor). */
         if (currentTcd != previousTcd)
         {
@@ -2262,7 +2262,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
                 before link the previous TCD block.
             */
             if (EDMA_TCD_DLAST_SGA(handle->tcdBase, EDMA_TCD_TYPE(handle->base)) ==
-                CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[currentTcd]))
+                CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[currentTcd]))
             {
                 /* Clear the DREQ bits for the dynamic scatter gather */
                 EDMA_TCD_CSR(tcdRegs, EDMA_TCD_TYPE(handle->base)) |= DMA_CSR_DREQ_MASK;
@@ -2291,7 +2291,7 @@ status_t EDMA_SubmitTransfer(edma_handle_t *handle, const edma_transfer_config_t
                     TCD block has been loaded into TCD registers.
                 */
                 if (EDMA_TCD_DLAST_SGA(handle->tcdBase, EDMA_TCD_TYPE(handle->base)) ==
-                    CONVERT_TO_DMA_ADDRESS((uint32_t)&handle->tcdPool[nextTcd]))
+                    CONVERT_TO_DMA_ADDRESS(&handle->tcdPool[nextTcd]))
                 {
                     return kStatus_Success;
                 }
@@ -2632,8 +2632,8 @@ void EDMA_HandleIRQ(edma_handle_t *handle)
         bool esg = ((EDMA_TCD_CSR(handle->tcdBase, EDMA_TCD_TYPE(handle->base)) & DMA_CSR_ESG_MASK) != 0U);
 
         /* Get the offset of the next transfer TCD blocks to be loaded into the eDMA engine. */
-        assert(sga >= CONVERT_TO_DMA_ADDRESS((uint32_t)handle->tcdPool));
-        sga -= CONVERT_TO_DMA_ADDRESS((uint32_t)handle->tcdPool);
+        assert(sga >= CONVERT_TO_DMA_ADDRESS(handle->tcdPool));
+        sga -= CONVERT_TO_DMA_ADDRESS(handle->tcdPool);
         /* Get the index of the next transfer TCD blocks to be loaded into the eDMA engine. */
         sga_index = sga / sizeof(edma_tcd_t);
         /* Adjust header positions, new_header should be the index of the current transfer TCD blocks. */

--- a/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma_core.h
+++ b/mcux/mcux-sdk-ng/drivers/edma4/fsl_edma_core.h
@@ -267,20 +267,20 @@ typedef void EDMA_Type;
 
 /*!@brief EDMA base address convert macro */
 #define EDMA_CORE_BASE(base)
-#define EDMA_MP_BASE(base) ((edma_core_mp_t *)((uint32_t)(uint32_t *)(base)))
+#define EDMA_MP_BASE(base) ((edma_core_mp_t *)(uintptr_t)(base))
 #if defined EDMA_CHANNEL_ARRAY_STEPn 
-#define EDMA_CHANNEL_BASE(base, channel)                                          \
-    ((edma_core_channel_t *)((uint32_t)(uint32_t *)(base) + EDMA_CHANNEL_OFFSET + \
+#define EDMA_CHANNEL_BASE(base, channel)                                  \
+    ((edma_core_channel_t *)((uintptr_t)(base) + EDMA_CHANNEL_OFFSET +    \
                              EDMA_CHANNEL_ARRAY_STEPn(base, channel)))
-#define EDMA_TCD_BASE(base, channel)                                          \
-    ((edma_core_tcd_t *)((uint32_t)(uint32_t *)(base) + EDMA_CHANNEL_OFFSET + \
+#define EDMA_TCD_BASE(base, channel)                                  \
+    ((edma_core_tcd_t *)((uintptr_t)(base) + EDMA_CHANNEL_OFFSET +    \
                          EDMA_CHANNEL_ARRAY_STEPn(base, channel) + 0x20U))
 #else
-#define EDMA_CHANNEL_BASE(base, channel)                                          \
-    ((edma_core_channel_t *)((uint32_t)(uint32_t *)(base) + EDMA_CHANNEL_OFFSET + \
+#define EDMA_CHANNEL_BASE(base, channel)                                  \
+    ((edma_core_channel_t *)((uintptr_t)(base) + EDMA_CHANNEL_OFFSET +    \
                              (channel)*EDMA_CHANNEL_ARRAY_STEP(base)))
-#define EDMA_TCD_BASE(base, channel)                                          \
-    ((edma_core_tcd_t *)((uint32_t)(uint32_t *)(base) + EDMA_CHANNEL_OFFSET + \
+#define EDMA_TCD_BASE(base, channel)                                  \
+    ((edma_core_tcd_t *)((uintptr_t)(base) + EDMA_CHANNEL_OFFSET +    \
                          (channel)*EDMA_CHANNEL_ARRAY_STEP(base) + 0x20U))
 #endif
 

--- a/mcux/middleware/wifi_nxp/CMakeLists.txt
+++ b/mcux/middleware/wifi_nxp/CMakeLists.txt
@@ -244,9 +244,10 @@ zephyr_library_compile_definitions_ifdef(CONFIG_ARM64
 
 # mcux-sdk and mcux-sdk-ng share the wifi_nxp, the lists and osa is
 # included in another way. Need add condition here.
-if (CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL)
-  zephyr_library_sources(${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memcpy.S)
-  zephyr_library_sources(${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memset.S)
+if ((CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL) AND
+    NOT CONFIG_ARM64)
+    zephyr_library_sources(${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memcpy.S)
+    zephyr_library_sources(${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memset.S)
 endif()
 
 if(DEFINED CONFIG_SOC_SDKNG_UNSUPPORTED)
@@ -589,10 +590,12 @@ zephyr_code_relocate(FILES ${MCUX_SDK_DIR}/components/osa/fsl_os_abstraction_zep
                      FILTER "${NXP_OSA_ABS_ZEPHYR_FILTER}"
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
 
+if(NOT CONFIG_ARM64)
 zephyr_code_relocate(FILES
                      ${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memcpy.S
                      ${ZEPHYR_HAL_NXP_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memset.S
                      LOCATION ${QUICK_ACCESS_CODE_AREA} NOKEEP)
+endif()
 
 endif()
 endif()

--- a/mcux/middleware/wifi_nxp/firmware_dnld/firmware_dnld.c
+++ b/mcux/middleware/wifi_nxp/firmware_dnld/firmware_dnld.c
@@ -217,7 +217,7 @@ int32_t firmware_download(const uint8_t *fw_start_addr, const size_t size, void 
 
     conn_fw = fw_start_addr;
 
-    fwdnld_io_d("Start copying connectivity firmware from 0x%x", (t_u32)conn_fw);
+    fwdnld_io_d("Start copying connectivity firmware from %p", (const void *)conn_fw);
 
     firmwarelen = size;
     /*Making this section as #if 00 for now, as the decopress and

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_11n_rxreorder.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_11n_rxreorder.c
@@ -541,7 +541,7 @@ static t_void wlan_11n_create_rxreorder_tbl(mlan_private *priv, t_u8 *ta, int ti
         new_node->bitmap          = 0;
 
 #if !CONFIG_MEM_POOLS
-        if ((pmadapter->callbacks.moal_malloc(pmadapter->pmoal_handle, 4U * win_size, MLAN_MEM_DEF,
+        if ((pmadapter->callbacks.moal_malloc(pmadapter->pmoal_handle, sizeof(t_void *) * win_size, MLAN_MEM_DEF,
                                               (t_u8 **)&new_node->rx_reorder_ptr)) != MLAN_STATUS_SUCCESS)
 #else
         new_node->rx_reorder_ptr = OSA_MemoryPoolAllocate(buf_256_MemoryPool);

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_glue.c
@@ -5361,7 +5361,7 @@ static void wrapper_wlan_check_sta_capability(pmlan_private priv, Event_Ext_t *p
                 ie_len       = (t_u8)tlv_len - (t_u8)sizeof(IEEEtypes_FrameCtl_t) - assoc_ie_len;
                 assoc_req_ie = (t_u8 *)tlv + sizeof(MrvlIETypes_MgmtFrameSet_t) + assoc_ie_len;
 
-                support_rates = 
+                support_rates =
                     (IEEEtypes_SupportRates_t *)(void *)wlan_get_specific_ie(priv, assoc_req_ie, ie_len, SUPPORTED_RATES, 0);
 
                 if(support_rates != NULL)
@@ -8531,7 +8531,7 @@ int wifi_set_btwt_cfg(const wifi_btwt_config_t *btwt_cfg)
         return -WM_FAIL;
     }
 
-    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0],  HostCmd_CMD_TWT_CFG, 
+    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0],  HostCmd_CMD_TWT_CFG,
                                 HostCmd_ACT_GEN_SET, 0, NULL, &twt_cfg, cmd);
     ret = wifi_wait_for_cmdresp(NULL);
     if (ret == WM_SUCCESS)
@@ -8557,8 +8557,8 @@ int wifi_get_btwt_cfg(wifi_btwt_config_t *btwt_cfg)
     cmd->result  = 0x0;
 
     twt_cfg.sub_id = MLAN_11AX_TWT_BTWT_SUBID;
-    
-    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0],  HostCmd_CMD_TWT_CFG, 
+
+    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0],  HostCmd_CMD_TWT_CFG,
                                 HostCmd_ACT_GEN_GET, 0, NULL, &twt_cfg, cmd);
     ret = wifi_wait_for_cmdresp(btwt_cfg);
     if (ret != WM_SUCCESS || wm_wifi.cmd_resp_status != WM_SUCCESS)
@@ -8676,7 +8676,7 @@ int wifi_twt_information(wifi_twt_information_t *twt_information)
         return -WM_FAIL;
     }
 
-    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0], HostCmd_CMD_TWT_CFG, 
+    wlan_ops_sta_prepare_cmd((mlan_private *)mlan_adap->priv[0], HostCmd_CMD_TWT_CFG,
                        HostCmd_ACT_GEN_SET, 0, NULL, &twt_cfg, cmd);
     ret = wifi_wait_for_cmdresp(NULL);
     if (ret == WM_SUCCESS)

--- a/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/mlan_init.c
@@ -470,6 +470,9 @@ done:
         for (i = 0; i < pmadapter->priv_num; i++)
         {
             priv = pmadapter->priv[i];
+            /* not all priv slots are populated; skip unallocated ones on the error path */
+            if (priv == MNULL)
+                continue;
 #if CONFIG_WMM
             for (j = 0; j < MAX_AC_QUEUES; ++j)
             {

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-mem.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-mem.c
@@ -36,7 +36,7 @@ void *wifi_malloc_eventbuf(size_t size)
 
     if (ptr != NULL)
     {
-        w_mem_d("[evtbuf] Alloc: A: %p S: %d", ptr, size);
+        w_mem_d("[evtbuf] Alloc: A: %p S: %zu", ptr, size);
     }
     else
     {
@@ -69,12 +69,12 @@ mlan_status wrapper_moal_malloc(IN t_void *pmoal_handle, IN t_u32 size, IN t_u32
 
     if (*ppbuf != NULL)
     {
-        w_mem_d("[mlan]: Alloc: A: %p S: %d", *ppbuf, size);
+        w_mem_d("[mlan]: Alloc: A: %p S: %u", *ppbuf, size);
         return MLAN_STATUS_SUCCESS;
     }
     else
     {
-        w_mem_e("[mlan] Alloc: S: %d FAILED", size);
+        w_mem_e("[mlan] Alloc: S: %u FAILED", size);
         /*
          * fixme: check if MLAN_STATUS_SUCCESS is to be returned in
          * spite of the status failure.

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi-sdio.c
@@ -1340,10 +1340,17 @@ static mlan_status wlan_decode_rx_packet(t_u8 *pmbuf, t_u32 upld_type)
     osa_status_t status;
     struct bus_message msg;
 
+    /* Cache sdiopkt->size once: it lives in the live SDIO rx buffer, and
+     * reading it separately to size the allocation vs. as the memcpy length
+     * would let the two reads disagree if the buffer is refilled in between,
+     * overrunning the allocation into the next heap chunk's header.
+     */
+    t_u32 pkt_size = sdiopkt->size;
+
 #if CONFIG_P2P
     if (bus.special_queue != NULL && upld_type == MLAN_TYPE_CMD)
     {
-        msg.data = OSA_MemoryAllocate(sdiopkt->size);
+        msg.data = OSA_MemoryAllocate(pkt_size);
         if (!msg.data)
         {
             wifi_io_e("Buffer allocation failed");
@@ -1353,7 +1360,7 @@ static mlan_status wlan_decode_rx_packet(t_u8 *pmbuf, t_u32 upld_type)
         msg.event = upld_type;
         cmdBuf    = pmbuf;
         cmdBuf    = cmdBuf + INTF_HEADER_LEN;
-        (void)memcpy((void *)msg.data, (const void *)cmdBuf, sdiopkt->size);
+        (void)memcpy((void *)msg.data, (const void *)cmdBuf, pkt_size);
 
         status = OSA_MsgQPut(bus.special_queue, &msg);
 
@@ -1375,17 +1382,17 @@ static mlan_status wlan_decode_rx_packet(t_u8 *pmbuf, t_u32 upld_type)
         }
         else
         {
-            msg.data = wifi_malloc_eventbuf((size_t)sdiopkt->size);
+            msg.data = wifi_malloc_eventbuf((size_t)pkt_size);
         }
 
         if (msg.data == MNULL)
         {
-            wifi_io_e("[fail] Buffer alloc: T: %d S: %d", upld_type, sdiopkt->size);
+            wifi_io_e("[fail] Buffer alloc: T: %u S: %u", upld_type, pkt_size);
             return MLAN_STATUS_FAILURE;
         }
 
         msg.event = (uint16_t)upld_type;
-        (void)memcpy((void *)msg.data, (const void *)pmbuf, sdiopkt->size);
+        (void)memcpy((void *)msg.data, (const void *)pmbuf, pkt_size);
 
         status = OSA_MsgQPut(bus.event_queue, &msg);
 

--- a/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
+++ b/mcux/middleware/wifi_nxp/wlcmgr/wlan.c
@@ -6593,7 +6593,7 @@ static void wlcm_request_connect(struct wifi_message *msg, enum cm_sta_state *ne
 #endif
 #if CONFIG_WLAN_FAST_PATH
     /* Mark the fast path cache invalid. */
-    if ((int)msg->data != wlan.cur_network_idx)
+    if ((int)(uintptr_t)msg->data != wlan.cur_network_idx)
         wlan.auth_cache_valid = false;
 #endif /* CONFIG_WLAN_FAST_PATH */
 
@@ -6610,7 +6610,7 @@ static void wlcm_request_connect(struct wifi_message *msg, enum cm_sta_state *ne
         }
     }
 
-    wlcm_d("starting %s to network: %d", wlan.roam_reassoc == false ? "connection" : "reassociation", (int)msg->data);
+    wlcm_d("starting %s to network: %d", wlan.roam_reassoc == false ? "connection" : "reassociation", (int)(uintptr_t)msg->data);
 
 #if !CONFIG_WPA_SUPP
     ret = do_connect((int)(uintptr_t)msg->data);
@@ -6825,7 +6825,7 @@ static void wlcm_process_region_power_cfg(struct wifi_message *msg)
 static void wlcm_process_chan_load(void *ch_load)
 {
     HostCmd_DS_802_11_GET_CH_LOAD *ch_load_info = (HostCmd_DS_802_11_GET_CH_LOAD *)ch_load;
-    
+
     mlan_adap->noise = ch_load_info->noise;
     mlan_adap->ch_load_param = ch_load_info->ch_load;
     mlan_adap->rx_quality = ch_load_info->rx_quality;
@@ -7166,7 +7166,7 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
             wlcm_process_authentication_event(msg, &next, network);
             break;
         case WIFI_EVENT_LINK_LOSS:
-            wlcm_d("got event: link loss, code=%d", (int)msg->data);
+            wlcm_d("got event: link loss, code=%d", (int)(uintptr_t)msg->data);
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT
             if (is_sta_connected())
             {
@@ -7277,7 +7277,7 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
             break;
 #endif
         case WIFI_EVENT_DISASSOCIATION:
-            wlcm_d("got event: disassociation, code=%d", (int)(msg->data));
+            wlcm_d("got event: disassociation, code=%d", (int)(uintptr_t)msg->data);
 #if CONFIG_ECSA
             wrapper_clear_media_connected_event();
             wlan_switch_to_nondfs_channel();
@@ -7502,7 +7502,7 @@ static enum cm_sta_state handle_message(struct wifi_message *msg)
         case WIFI_EVENT_REGION_POWER_CFG:
             wlcm_process_region_power_cfg(msg);
             break;
-#if CONFIG_WIFI_CHANNEL_LOAD        
+#if CONFIG_WIFI_CHANNEL_LOAD
         case WIFI_EVENT_CHAN_LOAD:
             wlcm_process_chan_load(msg->data);
 #if !CONFIG_MEM_POOLS
@@ -14058,8 +14058,8 @@ int wlan_set_twt_setup_cfg(const wlan_twt_setup_config_t *twt_setup)
     uint32_t twt_interval = (uint32_t)twt_setup->twt_mantissa << (uint32_t)twt_setup->twt_exponent;
     uint32_t wakeup_us = (uint32_t)twt_setup->twt_wakeup_duration * 256;
     uint32_t sleep_time = twt_interval - wakeup_us;
-    
-    if (sleep_time < TWT_SLEEP_MIN)    
+
+    if (sleep_time < TWT_SLEEP_MIN)
     {
         wlcm_e("TWT interval is : %u us", twt_setup->twt_mantissa << twt_setup->twt_exponent);
         wlcm_e("Wakeup duration (WD) value is : %u us", twt_setup->twt_wakeup_duration * 256);


### PR DESCRIPTION
Enables the NXP wifi_nxp driver (IW611) to run correctly on 64-bit AArch64 targets (specifically an i.MX93 SMARC board). The driver was written with 32-bit Cortex-M pointer-size assumptions baked in; on AArch64 these caused a real heap-corruption crash during Wi-Fi association, plus several latent bugs and one build failure.