### PR TITLE
mcux: middleware: connectivity-framework: fix build issue on mcxw70

### DIFF
--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CONFIG_MCUX_COMPONENT_middleware.wireless.framework.platform.kw43_mcxw70)
     mcux_add_source(SOURCES
         configs/fwk_config.h
         configs/rpmsg_config.h
-        configs/SecLib_psa_config.h
+        # configs/SecLib_psa_config.h
         fwk_platform_definitions.h
         fwk_platform_kw43_mcxw70.c
         DEVICE_IDS ${KW43_FAMILY} ${MCXW70_FAMILY}


### PR DESCRIPTION
SecLib_psa_config.h is wrongly added when building mcxw70. Temporary hotfix to be backported to the SDK.