### PR TITLE
mcux: middleware: multicore: include zephyr/sys/clock.h

### DIFF
--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-multicore/rpmsg-lite/lib/rpmsg_lite/porting/environment/rpmsg_env_zephyr.c
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-multicore/rpmsg-lite/lib/rpmsg_lite/porting/environment/rpmsg_env_zephyr.c
@@ -46,7 +46,7 @@
 #include "rpmsg_env.h"
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include "rpmsg_platform.h"
 #include "virtqueue.h"
 


### PR DESCRIPTION
Replace inclusion of **zephyr/sys_clock.h** header file with inclusion of **zephyr/sys/clock.h** since the former is a placeholder for the latter and may be deprecated.

This change is related to P-R https://github.com/zephyrproject-rtos/zephyr/pull/112127.