### PR TITLE
drivers: caam: update caam driver to version 2.4.1

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
@@ -1,14 +1,14 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_MCUX_COMPONENT_driver.caam)
-    mcux_component_version(2.3.2)
+    mcux_component_version(2.4.0)
 
     mcux_add_source(SOURCES fsl_caam.c fsl_caam.h)
 
     mcux_add_include(INCLUDES .)
 
-    mcux_add_configuration(CC "-DCRYPTO_USE_DRIVER_CAAM -DCACHE_MODE_WRITE_THROUGH=1")
+    mcux_add_macro("-DCRYPTO_USE_DRIVER_CAAM -DCACHE_MODE_WRITE_THROUGH=1")
 
 endif()

--- a/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_MCUX_COMPONENT_driver.caam)
-    mcux_component_version(2.4.0)
+    mcux_component_version(2.4.1)
 
     mcux_add_source(SOURCES fsl_caam.c fsl_caam.h)
 

--- a/mcux/mcux-sdk-ng/drivers/caam/doxygen/ChangeLog_caam.md
+++ b/mcux/mcux-sdk-ng/drivers/caam/doxygen/ChangeLog_caam.md
@@ -1,5 +1,9 @@
 # CAAM
 
+## [2.4.1]
+
+- Fix MSG and MISRA-2012 issues.
+
 ## [2.4.0]
 
 - Add new APIs for native asymmetric operations (RSA, ECC) instead of only accelerating mathematical primitives

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
@@ -503,7 +503,7 @@ static status_t hmac_prehash_key(CAAM_Type *base,
         /* Key size is within limits */
         (void)caam_memcpy(outputKey, inputKey, inputKeySize);
         *outputKeySize = inputKeySize;
-    }
+    } 
 
     return status;
 }
@@ -514,55 +514,48 @@ static status_t caam_in_job_ring_add(CAAM_Type *base, caam_job_ring_t jobRing, u
      * as this is global variable
      */
     uint32_t currPriMask = DisableGlobalIRQ();
+    status_t status = kStatus_Success;
 
-    if (kCAAM_JobRing0 == jobRing)
+    switch (jobRing)
     {
-        s_jr0->inputJobRing[s_jrIndex0] = (ADD_OFFSET((uint32_t)descaddr));
-        s_jrIndex0++;
-        if (s_jrIndex0 >= ARRAY_SIZE(s_jr0->inputJobRing))
-        {
-            s_jrIndex0 = 0;
-        }
-    }
-    else if (kCAAM_JobRing1 == jobRing)
-    {
-        s_jr1->inputJobRing[s_jrIndex1] = ADD_OFFSET((uint32_t)descaddr);
-        s_jrIndex1++;
-        if (s_jrIndex1 >= ARRAY_SIZE(s_jr1->inputJobRing))
-        {
-            s_jrIndex1 = 0;
-        }
-    }
-    else if (kCAAM_JobRing2 == jobRing)
-    {
-        s_jr2->inputJobRing[s_jrIndex2] = ADD_OFFSET((uint32_t)descaddr);
-        s_jrIndex2++;
-        if (s_jrIndex2 >= ARRAY_SIZE(s_jr2->inputJobRing))
-        {
-            s_jrIndex2 = 0;
-        }
-    }
-    else if (kCAAM_JobRing3 == jobRing)
-    {
-        s_jr3->inputJobRing[s_jrIndex3] = ADD_OFFSET((uint32_t)descaddr);
-        s_jrIndex3++;
-        if (s_jrIndex3 >= ARRAY_SIZE(s_jr3->inputJobRing))
-        {
-            s_jrIndex3 = 0;
-        }
-    }
-    else
-    {
-        EnableGlobalIRQ(currPriMask);
-        return kStatus_InvalidArgument;
+        case kCAAM_JobRing0:
+            assert(s_jrIndex0 < ARRAY_SIZE(s_jr0->inputJobRing));
+            s_jr0->inputJobRing[s_jrIndex0] = ADD_OFFSET((uint32_t)descaddr);
+            s_jrIndex0 = (s_jrIndex0 + 1U) % ARRAY_SIZE(s_jr0->inputJobRing);
+            break;
+
+        case kCAAM_JobRing1:
+            assert(s_jrIndex1 < ARRAY_SIZE(s_jr1->inputJobRing));
+            s_jr1->inputJobRing[s_jrIndex1] = ADD_OFFSET((uint32_t)descaddr);
+            s_jrIndex1 = (s_jrIndex1 + 1U) % ARRAY_SIZE(s_jr1->inputJobRing);
+            break;
+
+        case kCAAM_JobRing2:
+            assert(s_jrIndex2 < ARRAY_SIZE(s_jr2->inputJobRing));
+            s_jr2->inputJobRing[s_jrIndex2] = ADD_OFFSET((uint32_t)descaddr);
+            s_jrIndex2 = (s_jrIndex2 + 1U) % ARRAY_SIZE(s_jr2->inputJobRing);
+            break;
+
+        case kCAAM_JobRing3:
+            assert(s_jrIndex3 < ARRAY_SIZE(s_jr3->inputJobRing));
+            s_jr3->inputJobRing[s_jrIndex3] = ADD_OFFSET((uint32_t)descaddr);
+            s_jrIndex3 = (s_jrIndex3 + 1U) % ARRAY_SIZE(s_jr3->inputJobRing);
+            break;
+
+        default:
+            status =  kStatus_InvalidArgument;
+            break;
     }
 
-    caam_input_ring_set_jobs_added(base, jobRing, 1);
+    if (status == kStatus_Success)
+    {
+        caam_input_ring_set_jobs_added(base, jobRing, 1);
+    }
 
     /* Enable IRQ */
     EnableGlobalIRQ(currPriMask);
 
-    return kStatus_Success;
+    return status;
 }
 
 static status_t caam_in_job_ring_add_and_wait(CAAM_Type *base,
@@ -588,31 +581,37 @@ static status_t caam_in_job_ring_add_and_wait(CAAM_Type *base,
 /* this function shall be only called inside CAAM driver critical section
  * because it accesses global variables.
  */
-static status_t caam_out_job_ring_remove(CAAM_Type *base, caam_job_ring_t jobRing, int outIndex)
+static status_t caam_out_job_ring_remove(CAAM_Type *base, caam_job_ring_t jobRing, uint32_t outIndex)
 {
-    if (kCAAM_JobRing0 == jobRing)
+    switch (jobRing)
     {
-        s_jr0->outputJobRing[outIndex++] = 0; /* clear descriptor address */
-        s_jr0->outputJobRing[outIndex]   = 0; /* clear status */
-    }
-    else if (kCAAM_JobRing1 == jobRing)
-    {
-        s_jr1->outputJobRing[outIndex++] = 0; /* clear descriptor address */
-        s_jr1->outputJobRing[outIndex]   = 0; /* clear status */
-    }
-    else if (kCAAM_JobRing2 == jobRing)
-    {
-        s_jr2->outputJobRing[outIndex++] = 0; /* clear descriptor address */
-        s_jr2->outputJobRing[outIndex]   = 0; /* clear status */
-    }
-    else if (kCAAM_JobRing3 == jobRing)
-    {
-        s_jr3->outputJobRing[outIndex++] = 0; /* clear descriptor address */
-        s_jr3->outputJobRing[outIndex]   = 0; /* clear status */
-    }
-    else
-    {
-        /* Intentional empty */
+        case kCAAM_JobRing0:
+            assert(outIndex < ARRAY_SIZE(s_jr0->outputJobRing) - 1U);
+            s_jr0->outputJobRing[outIndex]      = 0U; /* clear descriptor address */
+            s_jr0->outputJobRing[outIndex + 1U] = 0U; /* clear status */
+            break;
+
+        case kCAAM_JobRing1:
+            assert(outIndex < ARRAY_SIZE(s_jr1->outputJobRing) - 1U);
+            s_jr1->outputJobRing[outIndex]      = 0U; /* clear descriptor address */
+            s_jr1->outputJobRing[outIndex + 1U] = 0U; /* clear status */
+            break;
+
+        case kCAAM_JobRing2:
+            assert(outIndex < ARRAY_SIZE(s_jr2->outputJobRing) - 1U);
+            s_jr2->outputJobRing[outIndex]      = 0U; /* clear descriptor address */
+            s_jr2->outputJobRing[outIndex + 1U] = 0U; /* clear status */
+            break;
+
+        case kCAAM_JobRing3:
+            assert(outIndex < ARRAY_SIZE(s_jr3->outputJobRing) - 1U);
+            s_jr3->outputJobRing[outIndex]      = 0U; /* clear descriptor address */
+            s_jr3->outputJobRing[outIndex + 1U] = 0U; /* clear status */
+            break;
+
+        default:
+            /* Intentional empty */
+            break;
     }
 
     caam_output_ring_set_jobs_removed(base, jobRing, 1);
@@ -681,14 +680,14 @@ static status_t caam_out_job_ring_test_and_remove(
                     /* This is used by PKHA PrimalityTest to report a candidate is believed not being prime */
                     if (0x30000000u == (jr[i + 1U] & 0xff000000u))
                     {
-                        status = (int32_t)jr[i + 1U];
+                        (void)caam_memcpy((void *)&status, (void *)&jr[i + 1U], sizeof(status_t));
                     }
                     else
                     {
                         status = kStatus_Fail;
                     }
                 }
-                (void)caam_out_job_ring_remove(base, jobRing, (int)i);
+                (void)caam_out_job_ring_remove(base, jobRing, i);
             }
             else
             {
@@ -1078,16 +1077,22 @@ static void caam_aes_ccm_context_init(
 {
     caam_xcm_block_t blk;
     caam_xcm_block_t blkZero = {{0x0u, 0x0u, 0x0u, 0x0u}};
-
-    uint8_t q; /* octet length of binary representation of the octet length of the payload. computed as (15 - n), where
-              n is length of nonce(=ivSize) */
+    uint8_t q;           /* octet length of binary representation of the octet length of the payload.
+                          * computed as (15 - n), where n is length of nonce(=ivSize) */
     uint8_t flags_field; /* flags field in B0 and CTR0 */
+    uint8_t M_prime, L_prime;
 
-    /* compute B0 */
-    (void)caam_memcpy(&blk, &blkZero, sizeof(blk));
-    /* tagSize - size of output MAC */
+    /* Nonce must be in range of 7 to 13 */ 
+    assert(7U <= ivSize && ivSize <= 13U);
+    /* Tag must be either 0 or 4,6,8,10,12,14,16 */
+    assert(tagSize == 0U || (4U <= tagSize && tagSize <= 16U && (tagSize & 1U) == 0U));
+
     q           = 15U - (uint8_t)ivSize;
-    flags_field = (uint8_t)(8U * ((tagSize - 2U) / 2U) + q - 1U); /* 8*M' + L' */
+    M_prime = (tagSize >= 4U)? (uint8_t)((tagSize - 2U) / 2U) : 0xFFU;
+    L_prime = q - 1U;
+    flags_field = (uint8_t)(M_prime << 3U) + L_prime; /* 8 * M' + L' */
+
+    (void)caam_memcpy(&blk, &blkZero, sizeof(blk));
     if (aadSize != 0U)
     {
         flags_field |= 0x40U;                 /* Adata */
@@ -1096,17 +1101,16 @@ static void caam_aes_ccm_context_init(
     blk.w[3] = swap_bytes(inputSize);         /* message size, most significant byte first */
     (void)caam_memcpy(&blk.b[1], iv, ivSize); /* nonce field */
 
-    /* Write B0 data to the context register.
-     */
+    /* Write B0 data to the context register. */
     (void)caam_memcpy(b0, (void *)&blk.b[0], 16);
 
-    /* Write CTR0 to the context register.
-     */
+    /* Write CTR0 to the context register. */
     (void)caam_memcpy(&blk, &blkZero, sizeof(blk)); /* ctr(0) field = zero */
     blk.b[0] = q - 1U;                              /* flags field */
     (void)caam_memcpy(&blk.b[1], iv, ivSize);       /* nonce field */
     (void)caam_memcpy(ctr0, (void *)&blk.b[0], 16);
 }
+
 
 static const uint32_t templateAesCcm[] = {
     /* 00 */ 0xB0800000u, /* HEADER */
@@ -2690,7 +2694,8 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
 #if defined(FSL_FEATURE_CAAM_HAS_RDB) && (FSL_FEATURE_CAAM_HAS_RDB > 0)
         CAAM_SCFGR_RDB(config->scfgrEnableRandomDataBuffer) |
 #endif /* FSL_FEATURE_CAAM_HAS_RDB */
-        CAAM_SCFGR_LCK_TRNG(config->scfgrLockTrngProgramMode) | CAAM_SCFGR_RNGSH0(config->scfgrRandomRngStateHandle0) |
+        CAAM_SCFGR_LCK_TRNG(((config->scfgrLockTrngProgramMode)? 1u : 0u)) | 
+        CAAM_SCFGR_RNGSH0(((config->scfgrRandomRngStateHandle0)? 1u : 0u)) |
         CAAM_SCFGR_PRIBLOB(config->scfgrPriblob);
 
     return status;
@@ -3272,7 +3277,7 @@ status_t CAAM_AES_CryptCtr(CAAM_Type *base,
     /* Invalidate unaligned data can cause memory corruption in write-back mode   */
     DCACHE_InvalidateByRange((uint32_t)output, size);
     DCACHE_InvalidateByRange((uint32_t)counter, 16u);
-    DCACHE_InvalidateByRange((uint32_t)szLeft, sizeof(szLeft));
+    DCACHE_InvalidateByRange((uint32_t)szLeft, sizeof(size_t));
     if (counterlast != NULL)
     {
         DCACHE_InvalidateByRange((uint32_t)counterlast, 16u);
@@ -3337,7 +3342,7 @@ status_t CAAM_AES_CryptCtrExtended(CAAM_Type *base,
     /* Invalidate unaligned data can cause memory corruption in write-back mode   */
     DCACHE_InvalidateByRange((uint32_t)output, size);
     DCACHE_InvalidateByRange((uint32_t)counter, 16u);
-    DCACHE_InvalidateByRange((uint32_t)szLeft, sizeof(szLeft));
+    DCACHE_InvalidateByRange((uint32_t)szLeft, sizeof(size_t));
     if (counterlast != NULL)
     {
         DCACHE_InvalidateByRange((uint32_t)counterlast, 16u);
@@ -4136,6 +4141,8 @@ static uint32_t caam_hash_sgt_insert(caam_hash_ctx_internal_t *ctxInternal,
     uint32_t ctxBlksz   = (ctxInternal != NULL) ? ctxInternal->blksz : 0U;
     uint32_t ctxBlkAddr = (ctxInternal != NULL) ? (uint32_t)&ctxInternal->blk.b[0] : 0U;
 
+    assert(inputSize <= UINT32_MAX - ctxBlksz);
+
     currSgtEntry = 0;
     numBlocks    = (inputSize + ctxBlksz) / CAAM_HASH_BLOCK_SIZE;
     remain       = (inputSize + ctxBlksz) % CAAM_HASH_BLOCK_SIZE;
@@ -4203,16 +4210,15 @@ static status_t caam_hash_schedule_input_data(CAAM_Type *base,
                                               uint32_t keySize)
 {
     BUILD_ASSURE(sizeof(templateHash) <= sizeof(caam_desc_hash_t), caam_desc_hash_t_size);
+    
     uint32_t descriptorSize = ARRAY_SIZE(templateHash);
     uint32_t algOutSize     = 0;
-
     bool isSha = caam_hash_alg_is_sha(algo); /* MDHA engine */
                                              /* how many bytes to read from context register
                                               * we need caam_hash_algo2ctx_size() to return
                                               * full context size (to be used for context restore in descriptor[3])
                                               */
     bool isHmac = caam_hash_alg_is_hmac(algo);
-
     uint32_t caamCtxSz = caam_hash_algo2ctx_size(algo, 0 /* full context */);
 
     (void)caam_memcpy(descriptor, templateHash, sizeof(templateHash));
@@ -4367,6 +4373,8 @@ static status_t caam_hash_append_data(caam_hash_ctx_internal_t *ctxInternal,
                                       size_t *outputSize)
 {
     caam_hash_internal_sgt_t sgt;
+    assert(ctxInternal->base != NULL);
+
     (void)memset(&sgt, 0, sizeof(sgt));
     size_t num = caam_hash_sgt_insert(ctxInternal, input, inputSize, numRemain, algState, sgt, kCAAM_HashSgtEntryLast);
     return caam_hash_schedule_input_data(ctxInternal->base, ctxInternal->handle, ctxInternal->algo, sgt, num,
@@ -4496,6 +4504,7 @@ status_t CAAM_HASH_Update(caam_hash_ctx_t *ctx, const uint8_t *input, size_t inp
     {
         return status;
     }
+    assert(ctxInternal->base != NULL);
 
     /* if we are still less than 64 bytes, keep only in context */
     if ((ctxInternal->blksz + inputSize) <= CAAM_HASH_BLOCK_SIZE)
@@ -4596,6 +4605,7 @@ status_t CAAM_HASH_UpdateNonBlocking(caam_hash_ctx_t *ctx, const uint8_t *input,
     {
         return status;
     }
+    assert(ctxInternal->base != NULL);
 
     /* Add input data chunk to SGT */
     uint32_t currSgtEntry = ctxInternal->blksz;
@@ -4640,6 +4650,7 @@ status_t CAAM_HASH_Finish(caam_hash_ctx_t *ctx, uint8_t *output, size_t *outputS
     {
         return status;
     }
+    assert(ctxInternal->base != NULL);
 
     /* determine algorithm state to configure
      * based on prior processing.
@@ -4714,6 +4725,7 @@ status_t CAAM_HASH_FinishNonBlocking(caam_hash_ctx_t *ctx,
     {
         return status;
     }
+    assert(ctxInternal->base != NULL);
 
     uint32_t currSgtEntry = ctxInternal->blksz;
     if (currSgtEntry > (uint32_t)kCAAM_HashSgtMaxCtxEntries)
@@ -4728,6 +4740,10 @@ status_t CAAM_HASH_FinishNonBlocking(caam_hash_ctx_t *ctx,
     uint32_t totalLength = 0;
     for (i = 0; i < currSgtEntry; i++)
     {
+        if (sgt[i].length > UINT32_MAX - totalLength)
+        {
+            return kStatus_CAAM_DataOverflow;
+        }
         totalLength += sgt[i].length;
     }
     sgt[currSgtEntry].length |= 0x40000000u; /* Final SG entry */
@@ -5130,6 +5146,8 @@ static uint32_t caam_crc_sgt_insert(caam_crc_ctx_internal_t *ctxInternal,
 
     uint32_t ctxBlksz   = (ctxInternal != NULL) ? ctxInternal->blksz : 0U;
     uint32_t ctxBlkAddr = (ctxInternal != NULL) ? (uint32_t)&ctxInternal->blk.b[0] : 0U;
+    
+    assert(inputSize <= UINT32_MAX - ctxBlksz);
 
     currSgtEntry = 0;
     numBlocks    = (inputSize + ctxBlksz) / CAAM_HASH_BLOCK_SIZE;
@@ -5336,6 +5354,8 @@ static status_t caam_crc_append_data(caam_crc_ctx_internal_t *ctxInternal,
                                      size_t *outputSize)
 {
     caam_hash_internal_sgt_t sgt;
+    assert(ctxInternal->base != NULL);
+
     (void)memset(&sgt, 0, sizeof(sgt));
     size_t num = caam_crc_sgt_insert(ctxInternal, input, inputSize, numRemain, algState, sgt, kCAAM_HashSgtEntryLast);
     return caam_crc_schedule_input_data(ctxInternal->base, ctxInternal->handle, ctxInternal->algo, ctxInternal->crcmode,
@@ -5543,6 +5563,7 @@ status_t CAAM_CRC_Finish(caam_crc_ctx_t *ctx, uint8_t *output, size_t *outputSiz
     {
         return status;
     }
+    assert(ctxInternal->base != NULL);
 
     /* determine algorithm state to configure
      * based on prior processing.
@@ -6051,20 +6072,23 @@ status_t CAAM_RNG_GetRandomDataNonBlocking(CAAM_Type *base,
 
 size_t CAAM_BLACK_KeyBlackenSize(caam_fifost_type_t fifostType, size_t dataSize)
 {
-    size_t output;
+    size_t output = dataSize;
+
+    /* Align to 8 or 16 bytes should not wrap */ 
+    assert(output < UINT32_MAX - 19u);
 
     switch (fifostType)
     {
         case kCAAM_FIFOST_Type_Ecb_Jkek:
         case kCAAM_FIFOST_Type_Ecb_Tkek:
         {
-            output = CAAM_BLACKEN_ECB_SIZE(dataSize);
+            output = CAAM_BLACKEN_ECB_SIZE(output);
             break;
         }
         case kCAAM_FIFOST_Type_Ccm_Jkek:
         case kCAAM_FIFOST_Type_Ccm_Tkek:
         {
-            output = CAAM_BLACKEN_CCM_SIZE(dataSize);
+            output = CAAM_BLACKEN_CCM_SIZE(output);
             break;
         }
         default:
@@ -6176,6 +6200,10 @@ status_t CAAM_RedBlob_Encapsule(CAAM_Type *base,
     caam_desc_gen_enc_blob_t descriptor;
     size_t blob_size;
 
+    if (dataSize > SIZE_MAX - 32u - 16u) 
+    {
+        return kStatus_InvalidArgument;
+    }
     /* output blob will have 32 bytes key blob in beginning and 16 bytes MAC identifier at end of data blob */
     blob_size = 32u + dataSize + 16u;
 
@@ -6244,6 +6272,10 @@ status_t CAAM_RedBlob_Decapsule(CAAM_Type *base,
     size_t blob_size;
     caam_desc_gen_dep_blob_t descriptor;
 
+    if (dataSize > SIZE_MAX - 32u - 16u) 
+    {
+        return kStatus_InvalidArgument;
+    }
     /* blob have 32 bytes key blob in beginning and 16 bytes MAC identifier at end of data blob */
     blob_size = 32u + dataSize + 16u;
 
@@ -6314,6 +6346,10 @@ status_t CAAM_BlackBlob_Encapsule(CAAM_Type *base,
     caam_desc_gen_enc_blob_t descriptor;
     size_t blob_size;
 
+    if (dataSize > SIZE_MAX - 32u - 16u) 
+    {
+        return kStatus_InvalidArgument;
+    }
     /* output blob will have 32 bytes key blob in beginning and 16 bytes MAC identifier at end of data blob */
     blob_size = 32u + dataSize + 16u;
 
@@ -6386,6 +6422,10 @@ status_t CAAM_BlackBlob_Decapsule(CAAM_Type *base,
     caam_desc_gen_dep_blob_t descriptor;
     size_t blob_size;
 
+    if (dataSize > SIZE_MAX - 32u - 16u) 
+    {
+        return kStatus_InvalidArgument;
+    }
     /* blob have 32 bytes key blob in beginning and 16 bytes MAC identifier at end of data blob */
     blob_size = 32u + dataSize + 16u;
 
@@ -8832,7 +8872,7 @@ static void caam_pkha_mode_set_src_reg_copy(uint32_t *outMode, caam_pkha_reg_are
     {
         reg = (caam_pkha_reg_area_t)(uint32_t)(((uint32_t)reg) >> 1u);
         i++;
-    } while (0U != (uint32_t)reg);
+    } while (i < 4 && (uint32_t)reg != 0U);
 
     i = 4 - i;
     /* Source register must not be E. */
@@ -8850,7 +8890,7 @@ static void caam_pkha_mode_set_dst_reg_copy(uint32_t *outMode, caam_pkha_reg_are
     {
         reg = (caam_pkha_reg_area_t)(uint32_t)(((uint32_t)reg) >> 1u);
         i++;
-    } while (0U != (uint32_t)reg);
+    } while (i < 4 && (uint32_t)reg != 0U);
 
     i = 4 - i;
     *outMode |= ((uint32_t)i << 10u);
@@ -10596,19 +10636,13 @@ size_t CAAM_ECC_PrivateKeySize(caam_ecc_encryption_type_t encryptKeyType, caam_e
     switch (encryptKeyType)
     {
         case kCAAM_Ecc_Encryption_Type_Ecb_Jkek:
-        {
             output = CAAM_BLACKEN_ECB_SIZE(output);
             break;
-        }
         case kCAAM_Ecc_Encryption_Type_Ccm_Jkek:
-        {
             output = CAAM_BLACKEN_CCM_SIZE(output);
             break;
-        }
         default:
-        {
             break;
-        }
     }
 
     return output;
@@ -10849,23 +10883,20 @@ status_t CAAM_ECC_VerifyPrivateKey(CAAM_Type *base,
 size_t CAAM_RSA_PrivateExponentSize(caam_rsa_key_type_t prvKeyType, uint32_t privExponentSize)
 {
     size_t output = privExponentSize;
+    
+    /* Maximum private exponent key size is 4096 bits */ 
+    assert(output <= 4096u / 8u);
 
     switch (prvKeyType)
     {
         case kCAAM_Rsa_Key_Type_Ecb_Jkek:
-        {
             output = CAAM_BLACKEN_ECB_SIZE(output);
             break;
-        }
         case kCAAM_Rsa_Key_Type_Ccm_Jkek:
-        {
             output = CAAM_BLACKEN_CCM_SIZE(output);
             break;
-        }
         default:
-        {
             break;
-        }
     }
 
     return output;

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
@@ -222,6 +222,10 @@ static uint32_t s_jrIndex2              = 0;    /*!< Current index in the input 
 static caam_job_ring_interface_t *s_jr3 = NULL; /*!< Pointer to job ring interface 3. */
 static uint32_t s_jrIndex3              = 0;    /*!< Current index in the input job ring 3. */
 
+AT_NONCACHEABLE_SECTION(static caam_rng_config_t rngConfig);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngGenSeckey);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngInstantiate);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t descBuf);
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -2643,7 +2647,6 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
      * for FIFO STORE command to be able to store Key register as Black key
      * for example during AES XCBC-MAC context switch (need to store derived key K1 to memory)
      */
-    caam_rng_config_t rngConfig;
     (void)CAAM_RNG_GetDefaultConfig(&rngConfig);
 
     /* reset RNG */
@@ -5760,7 +5763,6 @@ status_t CAAM_RNG_Init(CAAM_Type *base,
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngInstantiate = {0};
     rngInstantiate[0]              = 0xB0800006u;
     rngInstantiate[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngInstantiate[2]              = (uint32_t)ADD_OFFSET((uint32_t)config->personalString);
@@ -5856,7 +5858,6 @@ status_t CAAM_RNG_GenerateSecureKey(CAAM_Type *base, caam_handle_t *handle, caam
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngGenSeckey = {0};
     rngGenSeckey[0]              = 0xB0800004u; /* HEADER */
     rngGenSeckey[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngGenSeckey[2]              = ADD_OFFSET((uint32_t)additionalEntropy);
@@ -5963,7 +5964,6 @@ status_t CAAM_RNG_GetRandomData(CAAM_Type *base,
                                 caam_rng_generic256_t additionalEntropy)
 {
     status_t status;
-    caam_desc_rng_t descBuf;
 
     do
     {

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
@@ -30,9 +30,9 @@ enum
 
 /*! @name Driver version */
 /*! @{ */
-/*! @brief CAAM driver version. Version 2.3.2.
+/*! @brief CAAM driver version.
  *
- * Current version: 2.3.2
+ * Current version: 2.4.0
  *
  * Change log:
  * - Version 2.0.0
@@ -74,11 +74,14 @@ enum
  *   - Add support for SHA HMAC.
  * - Version 2.3.1
  *   - Modified function caam_aes_ccm_check_input_args() to allow payload be empty as is specified in NIST800-38C
- * Section 5.3.
+ *     Section 5.3.
  * - Version 2.3.2
  *   - Fix MISRA-2012 issues.
+ * - Version 2.4.0
+ *   - Add new APIs for native asymmetric operations (RSA, ECC) instead of only accelerating mathematical primitives
+ *     and support for black keys and blobs for both symmetric and asymmetric operations.
  */
-#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 3, 2))
+#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 4, 0))
 /*! @} */
 
 /*! @brief CAAM callback function. */
@@ -155,6 +158,12 @@ typedef uint32_t caam_desc_key_black_t[64];
 typedef uint32_t caam_desc_gen_enc_blob_t[64];
 typedef uint32_t caam_desc_gen_dep_blob_t[64];
 
+/*! @brief Memory buffer to hold CAAM descriptor for performing generating dek blob jobs */
+typedef uint32_t caam_desc_rsa_t[64];
+
+/*! @brief Memory buffer to hold CAAM descriptor for performing generating dek blob jobs */
+typedef uint32_t caam_desc_ecc_t[64];
+
 typedef struct _caam_job_ring_interface
 {
     uint32_t inputJobRing[4];
@@ -208,7 +217,63 @@ typedef enum _caam_ext_key_xfr_source
     kCAAM_ExtKeyXfr_KeyRegisterClass2 = 2U, /*!< The Class 2 Key Register is the source. */
     kCAAM_ExtKeyXfr_PkhaRamE          = 3U, /*!< The PKHA E RAM is the source. */
 } caam_ext_key_xfr_source_t;
-/*! @} */                                   /* end of caam_driver */
+
+typedef enum _caam_ecc_ecdsel
+{
+    kCAAM_ECDSEL_P_192           = 0x00u,
+    kCAAM_ECDSEL_P_224           = 0x01u,
+    kCAAM_ECDSEL_P_256           = 0x02u,
+    kCAAM_ECDSEL_P_384           = 0x03u,
+    kCAAM_ECDSEL_P_521           = 0x04u,
+    kCAAM_ECDSEL_brainpoolP160r1 = 0x05u,
+    kCAAM_ECDSEL_brainpoolP160t1 = 0x06u,
+    kCAAM_ECDSEL_brainpoolP192r1 = 0x07u,
+    kCAAM_ECDSEL_brainpoolP192t1 = 0x08u,
+    kCAAM_ECDSEL_brainpoolP224r1 = 0x09u,
+    kCAAM_ECDSEL_brainpoolP224t1 = 0x0Au,
+    kCAAM_ECDSEL_brainpoolP256r1 = 0x0Bu,
+    kCAAM_ECDSEL_brainpoolP256t1 = 0x0Cu,
+    kCAAM_ECDSEL_brainpoolP320r1 = 0x0Du,
+    kCAAM_ECDSEL_brainpoolP320t1 = 0x0Eu,
+    kCAAM_ECDSEL_brainpoolP384r1 = 0x0Fu,
+    kCAAM_ECDSEL_brainpoolP384t1 = 0x10u,
+    kCAAM_ECDSEL_brainpoolP512r1 = 0x11u,
+    kCAAM_ECDSEL_brainpoolP512t1 = 0x12u,
+    kCAAM_ECDSEL_prime192v2      = 0x13u,
+    kCAAM_ECDSEL_prime192v3      = 0x14u,
+    kCAAM_ECDSEL_prime239v1      = 0x15u,
+    kCAAM_ECDSEL_prime239v2      = 0x16u,
+    kCAAM_ECDSEL_prime239v3      = 0x17u,
+    kCAAM_ECDSEL_secp112r1       = 0x18u,
+    kCAAM_ECDSEL_wtls8           = 0x19u,
+    kCAAM_ECDSEL_wtls9           = 0x1Au,
+    kCAAM_ECDSEL_secp160k1       = 0x1Bu,
+    kCAAM_ECDSEL_secp160r1       = 0x1Cu,
+    kCAAM_ECDSEL_secp160r2       = 0x1Du,
+    kCAAM_ECDSEL_secp192k1       = 0x1Eu,
+    kCAAM_ECDSEL_secp224k1       = 0x1Fu,
+    kCAAM_ECDSEL_secp256k1       = 0x20u,
+    kCAAM_ECDSEL_B_163           = 0x40u,
+    kCAAM_ECDSEL_B_233           = 0x41u,
+    kCAAM_ECDSEL_B_283           = 0x42u,
+    kCAAM_ECDSEL_B_409           = 0x43u,
+    kCAAM_ECDSEL_B_571           = 0x44u,
+    kCAAM_ECDSEL_K_163           = 0x45u,
+    kCAAM_ECDSEL_K_233           = 0x46u,
+    kCAAM_ECDSEL_K_283           = 0x47u,
+    kCAAM_ECDSEL_K_409           = 0x48u,
+    kCAAM_ECDSEL_K_571           = 0x49u,
+    kCAAM_ECDSEL_wtls1           = 0x4Au,
+    kCAAM_ECDSEL_sect113r1       = 0x4Bu,
+    kCAAM_ECDSEL_c2pnb163v1      = 0x4Cu,
+    kCAAM_ECDSEL_c2pnb163v2      = 0x4Du,
+    kCAAM_ECDSEL_c2pnb163v3      = 0x4Eu,
+    kCAAM_ECDSEL_sect163r1       = 0x4Fu,
+    kCAAM_ECDSEL_sect193r1       = 0x50u,
+    kCAAM_ECDSEL_sect193r2       = 0x51u,
+    kCAAM_ECDSEL_sect239k1       = 0x52u,
+} caam_ecc_ecdsel_t;
+/*! @} */ /* end of caam_driver */
 
 /*******************************************************************************
  * AES Definitions
@@ -239,6 +304,133 @@ typedef enum _caam_ext_key_xfr_source
 
 /*! @brief CAAM DES IV size - 8 bytes */
 #define CAAM_DES_IV_SIZE 8
+
+/*! @brief CAAM blacken key size for ECB encryption */
+#define CAAM_BLACKEN_ECB_SIZE(x) ((uint32_t)((x) + 15u) & ~15ul)
+
+/*! @brief CAAM blacken key size for CCM encryption */
+#define CAAM_BLACKEN_CCM_SIZE(x) (((uint32_t)((x) + 7u) & ~7ul) + 12u)
+
+/*! @brief CAAM DSA public key length for EC domain */
+#define CAAM_DSA_PUBLIC_KEY_LENGTH(domain)         \
+    ((domain) == kCAAM_ECDSEL_P_192           ? 24u : \
+     (domain) == kCAAM_ECDSEL_P_224           ? 28u : \
+     (domain) == kCAAM_ECDSEL_P_256           ? 32u : \
+     (domain) == kCAAM_ECDSEL_P_384           ? 48u : \
+     (domain) == kCAAM_ECDSEL_P_521           ? 66u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP160r1 ? 20u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP160t1 ? 20u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP192r1 ? 24u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP192t1 ? 24u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP224r1 ? 28u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP224t1 ? 28u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP256r1 ? 32u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP256t1 ? 32u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP320r1 ? 40u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP320t1 ? 40u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP384r1 ? 48u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP384t1 ? 48u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP512r1 ? 64u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP512t1 ? 64u : \
+     (domain) == kCAAM_ECDSEL_prime192v2      ? 24u : \
+     (domain) == kCAAM_ECDSEL_prime192v3      ? 24u : \
+     (domain) == kCAAM_ECDSEL_prime239v1      ? 30u : \
+     (domain) == kCAAM_ECDSEL_prime239v2      ? 30u : \
+     (domain) == kCAAM_ECDSEL_prime239v3      ? 30u : \
+     (domain) == kCAAM_ECDSEL_secp112r1       ? 14u : \
+     (domain) == kCAAM_ECDSEL_wtls8           ? 14u : \
+     (domain) == kCAAM_ECDSEL_wtls9           ? 20u : \
+     (domain) == kCAAM_ECDSEL_secp160k1       ? 20u : \
+     (domain) == kCAAM_ECDSEL_secp160r1       ? 20u : \
+     (domain) == kCAAM_ECDSEL_secp160r2       ? 20u : \
+     (domain) == kCAAM_ECDSEL_secp192k1       ? 24u : \
+     (domain) == kCAAM_ECDSEL_secp224k1       ? 28u : \
+     (domain) == kCAAM_ECDSEL_secp256k1       ? 32u : \
+     (domain) == kCAAM_ECDSEL_B_163           ? 21u : \
+     (domain) == kCAAM_ECDSEL_B_233           ? 30u : \
+     (domain) == kCAAM_ECDSEL_B_283           ? 36u : \
+     (domain) == kCAAM_ECDSEL_B_409           ? 52u : \
+     (domain) == kCAAM_ECDSEL_B_571           ? 72u : \
+     (domain) == kCAAM_ECDSEL_K_163           ? 21u : \
+     (domain) == kCAAM_ECDSEL_K_233           ? 30u : \
+     (domain) == kCAAM_ECDSEL_K_283           ? 36u : \
+     (domain) == kCAAM_ECDSEL_K_409           ? 52u : \
+     (domain) == kCAAM_ECDSEL_K_571           ? 72u : \
+     (domain) == kCAAM_ECDSEL_wtls1           ? 15u : \
+     (domain) == kCAAM_ECDSEL_sect113r1       ? 15u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v1      ? 21u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v2      ? 21u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v3      ? 21u : \
+     (domain) == kCAAM_ECDSEL_sect163r1       ? 21u : \
+     (domain) == kCAAM_ECDSEL_sect193r1       ? 25u : \
+     (domain) == kCAAM_ECDSEL_sect193r2       ? 25u : \
+     (domain) == kCAAM_ECDSEL_sect239k1       ? 25u : \
+                                              0u)
+
+/*! @brief CAAM ECC public key length for EC domain */
+#define CAAM_ECC_PUBLIC_KEY_LENGTH(domain) (CAAM_DSA_PUBLIC_KEY_LENGTH(domain) * 2u)
+
+/*! @brief CAAM ECC private key length for EC domain */
+#define CAAM_ECC_PRIVATE_KEY_LENGTH(domain)        \
+    ((domain) == kCAAM_ECDSEL_P_192           ? 24u : \
+     (domain) == kCAAM_ECDSEL_P_224           ? 28u : \
+     (domain) == kCAAM_ECDSEL_P_256           ? 32u : \
+     (domain) == kCAAM_ECDSEL_P_384           ? 48u : \
+     (domain) == kCAAM_ECDSEL_P_521           ? 66u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP160r1 ? 20u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP160t1 ? 20u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP192r1 ? 24u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP192t1 ? 24u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP224r1 ? 28u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP224t1 ? 28u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP256r1 ? 32u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP256t1 ? 32u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP320r1 ? 40u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP320t1 ? 40u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP384r1 ? 48u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP384t1 ? 48u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP512r1 ? 64u : \
+     (domain) == kCAAM_ECDSEL_brainpoolP512t1 ? 64u : \
+     (domain) == kCAAM_ECDSEL_prime192v2      ? 24u : \
+     (domain) == kCAAM_ECDSEL_prime192v3      ? 24u : \
+     (domain) == kCAAM_ECDSEL_prime239v1      ? 30u : \
+     (domain) == kCAAM_ECDSEL_prime239v2      ? 30u : \
+     (domain) == kCAAM_ECDSEL_prime239v3      ? 30u : \
+     (domain) == kCAAM_ECDSEL_secp112r1       ? 14u : \
+     (domain) == kCAAM_ECDSEL_wtls8           ? 15u : \
+     (domain) == kCAAM_ECDSEL_wtls9           ? 21u : \
+     (domain) == kCAAM_ECDSEL_secp160k1       ? 21u : \
+     (domain) == kCAAM_ECDSEL_secp160r1       ? 21u : \
+     (domain) == kCAAM_ECDSEL_secp160r2       ? 21u : \
+     (domain) == kCAAM_ECDSEL_secp192k1       ? 24u : \
+     (domain) == kCAAM_ECDSEL_secp224k1       ? 29u : \
+     (domain) == kCAAM_ECDSEL_secp256k1       ? 32u : \
+     (domain) == kCAAM_ECDSEL_B_163           ? 21u : \
+     (domain) == kCAAM_ECDSEL_B_233           ? 30u : \
+     (domain) == kCAAM_ECDSEL_B_283           ? 36u : \
+     (domain) == kCAAM_ECDSEL_B_409           ? 52u : \
+     (domain) == kCAAM_ECDSEL_B_571           ? 72u : \
+     (domain) == kCAAM_ECDSEL_K_163           ? 21u : \
+     (domain) == kCAAM_ECDSEL_K_233           ? 29u : \
+     (domain) == kCAAM_ECDSEL_K_283           ? 36u : \
+     (domain) == kCAAM_ECDSEL_K_409           ? 51u : \
+     (domain) == kCAAM_ECDSEL_K_571           ? 72u : \
+     (domain) == kCAAM_ECDSEL_wtls1           ? 14u : \
+     (domain) == kCAAM_ECDSEL_sect113r1       ? 15u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v1      ? 21u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v2      ? 21u : \
+     (domain) == kCAAM_ECDSEL_c2pnb163v3      ? 21u : \
+     (domain) == kCAAM_ECDSEL_sect163r1       ? 21u : \
+     (domain) == kCAAM_ECDSEL_sect193r1       ? 25u : \
+     (domain) == kCAAM_ECDSEL_sect193r2       ? 25u : \
+     (domain) == kCAAM_ECDSEL_sect239k1       ? 25u : \
+                                              0u)
+
+/*! @brief CAAM blacken key size for ECB encryption
+ *
+ * The second part of key size and buffer length needed for compution may differ.
+ */
+#define CAAM_ECC_SECOND_SIGN_BUFFER_SIZE(domain) ((CAAM_ECC_PRIVATE_KEY_LENGTH(domain) + 15u) & ~15u)
 
 /*!
  *@}
@@ -361,28 +553,82 @@ typedef struct _caam_rng_user_config
 /*! @brief CAAM FIFOST types. */
 typedef enum _caam_fifost_type
 {
-    kCAAM_FIFOST_Type_Kek_Kek = 0x24,      /*!< Key Register, encrypted using AES-ECB with the job
-     descriptor key encryption key. */
-    kCAAM_FIFOST_Type_Kek_TKek = 0x25,     /*!< Key Register, encrypted using AES-ECB with the
-    trusted descriptor key encryption key. */
-    kCAAM_FIFOST_Type_Kek_Cmm_Jkek = 0x14, /*!< Key Register, encrypted using AES-CCM with the
+    kCAAM_FIFOST_Type_Ecb_Jkek = 0x24u, /*!< Key Register, encrypted using AES-ECB with the job
+descriptor key encryption key. */
+    kCAAM_FIFOST_Type_Ecb_Tkek = 0x25u, /*!< Key Register, encrypted using AES-ECB with the
+trusted descriptor key encryption key. */
+    kCAAM_FIFOST_Type_Ccm_Jkek = 0x14u, /*!< Key Register, encrypted using AES-CCM with the
 job descriptor key encryption key. */
-    kCAAM_FIFOST_Type_Kek_Cmm_Tkek = 0x15, /*!< Key register, encrypted using AES-CCM with the
+    kCAAM_FIFOST_Type_Ccm_Tkek = 0x15u, /*!< Key register, encrypted using AES-CCM with the
 trusted descriptor key encryption key. */
 } caam_fifost_type_t;
 
 /*! @brief CAAM descriptor types. */
 typedef enum _caam_desc_type
 {
-    kCAAM_Descriptor_Type_Kek_Kek = 0x0,      /*!< Key Register, encrypted using AES-ECB with the job
-     descriptor key encryption key. */
-    kCAAM_Descriptor_Type_Kek_TKek = 0x2,     /*!< Key Register, encrypted using AES-ECB with the
-    trusted descriptor key encryption key. */
-    kCAAM_Descriptor_Type_Kek_Ccm_Jkek = 0x1, /*!< Key Register, encrypted using AES-CCM with the
+    kCAAM_Descriptor_Type_Ecb_Jkek = 0x0u, /*!< Key Register, encrypted using AES-ECB with the job
+descriptor key encryption key. */
+    kCAAM_Descriptor_Type_Ecb_Tkek = 0x2u, /*!< Key Register, encrypted using AES-ECB with the
+trusted descriptor key encryption key. */
+    kCAAM_Descriptor_Type_Ccm_Jkek = 0x1u, /*!< Key Register, encrypted using AES-CCM with the
 job descriptor key encryption key. */
-    kCAAM_Descriptor_Type_Kek_Ccm_Tkek = 0x3, /*!< Key register, encrypted using AES-CCM with the
+    kCAAM_Descriptor_Type_Ccm_Tkek = 0x3u, /*!< Key register, encrypted using AES-CCM with the
 trusted descriptor key encryption key. */
 } caam_desc_type_t;
+
+/*! @brief CAAM key types. */
+typedef enum _caam_key_type
+{
+    kCAAM_Key_Type_None     = 0x0ul,
+    kCAAM_Key_Type_Ecb_Jkek = 0x80ul << 15, /*!< Key Register, encrypted using AES-ECB with the job
+  descriptor key encryption key. */
+    kCAAM_Key_Type_Ecb_Tkek = 0x81ul << 15, /*!< Key Register, encrypted using AES-ECB with the
+  trusted descriptor key encryption key. */
+    kCAAM_Key_Type_Ccm_Jkek = 0xA0ul << 15, /*!< Key Register, encrypted using AES-CCM with the
+job descriptor key encryption key. */
+    kCAAM_Key_Type_Ccm_Tkek = 0xA1ul << 15, /*!< Key register, encrypted using AES-CCM with the
+trusted descriptor key encryption key. */
+} caam_key_type_t;
+
+/*! @brief CAAM ecc encryption types. */
+typedef enum _caam_ecc_encryption_type
+{
+    kCAAM_Ecc_Encryption_Type_None     = 0x0u,
+    kCAAM_Ecc_Encryption_Type_Ecb_Jkek = 0x1u << 2, /*!< Key Register, encrypted using AES-ECB with the job
+        descriptor key encryption key. */
+    kCAAM_Ecc_Encryption_Type_Ccm_Jkek = 0x5u << 2, /*!< Key Register, encrypted using AES-CCM with the
+    job descriptor key encryption key. */
+} caam_ecc_encryption_type_t;
+
+/*! @brief CAAM rsa key encryption types. */
+typedef enum _caam_rsa_key_type
+{
+    kCAAM_Rsa_Key_Type_None     = 0x0u,
+    kCAAM_Rsa_Key_Type_Ecb_Jkek = 0x4u << 4, /*!< Key Register, encrypted using AES-ECB with the job
+        descriptor key encryption key. */
+    kCAAM_Rsa_Key_Type_Ccm_Jkek = 0x5u << 4, /*!< Key Register, encrypted using AES-CCM with the
+    job descriptor key encryption key. */
+} caam_rsa_key_type_t;
+
+/*! @brief CAAM rsa encryption types. */
+typedef enum _caam_rsa_encryption_type
+{
+    kCAAM_Rsa_Encryption_Type_None     = 0x00u,
+    kCAAM_Rsa_Encryption_Type_Ecb_Jkek = 0x01u, /*!< Key Register, encrypted using AES-ECB with the job
+      descriptor key encryption key. */
+    kCAAM_Rsa_Encryption_Type_Ecb_Tkek = 0x05u, /*!< Key Register, encrypted using AES-ECB with the
+     trusted descriptor key encryption key. */
+    kCAAM_Rsa_Encryption_Type_Ccm_Jkek = 0x03u, /*!< Key Register, encrypted using AES-CCM with the
+  job descriptor key encryption key. */
+    kCAAM_Rsa_Encryption_Type_Ccm_Tkek = 0x07u, /*!< Key register, encrypted using AES-CCM with the
+  trusted descriptor key encryption key. */
+} caam_rsa_encryption_type_t;
+
+typedef enum _caam_rsa_format_type
+{
+    kCAAM_Rsa_Format_Type_None  = 0x00u, /*!< No formatting */
+    kCAAM_Rsa_Format_Type_PKCS1 = 0x01u, /*!< EME-PKCS1-v1_5 encryption decoding function */
+} caam_rsa_format_type_t;
 
 // #define KEYBLOB_USE_SECURE_MEMORY 1  // Define when secure memory mode is used
 
@@ -584,6 +830,54 @@ status_t CAAM_AES_DecryptEcb(CAAM_Type *base,
                              size_t keySize);
 
 /*!
+ * @brief Encrypts AES using the ECB block mode using black key.
+ *
+ * Encrypts AES using the ECB block mode.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from encrypt operation
+ */
+status_t CAAM_AES_EncryptEcbExtended(CAAM_Type *base,
+                                     caam_handle_t *handle,
+                                     const uint8_t *plaintext,
+                                     uint8_t *ciphertext,
+                                     size_t size,
+                                     const uint8_t *key,
+                                     size_t keySize,
+                                     caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES using ECB block mode using black key.
+ *
+ * Decrypts AES using ECB block mode.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param key Input key.
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from decrypt operation
+ */
+status_t CAAM_AES_DecryptEcbExtended(CAAM_Type *base,
+                                     caam_handle_t *handle,
+                                     const uint8_t *ciphertext,
+                                     uint8_t *plaintext,
+                                     size_t size,
+                                     const uint8_t *key,
+                                     size_t keySize,
+                                     caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts AES using CBC block mode.
  *
  * @param base CAAM peripheral base address
@@ -628,6 +922,54 @@ status_t CAAM_AES_DecryptCbc(CAAM_Type *base,
                              size_t keySize);
 
 /*!
+ * @brief Encrypts AES using CBC block mode using black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param iv Input initial vector to combine with the first input block.
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from encrypt operation
+ */
+status_t CAAM_AES_EncryptCbcExtended(CAAM_Type *base,
+                                     caam_handle_t *handle,
+                                     const uint8_t *plaintext,
+                                     uint8_t *ciphertext,
+                                     size_t size,
+                                     const uint8_t iv[CAAM_AES_BLOCK_SIZE],
+                                     const uint8_t *key,
+                                     size_t keySize,
+                                     caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES using CBC block mode using black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param iv Input initial vector to combine with the first input block.
+ * @param key Input key to use for decryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from decrypt operation
+ */
+status_t CAAM_AES_DecryptCbcExtended(CAAM_Type *base,
+                                     caam_handle_t *handle,
+                                     const uint8_t *ciphertext,
+                                     uint8_t *plaintext,
+                                     size_t size,
+                                     const uint8_t iv[CAAM_AES_BLOCK_SIZE],
+                                     const uint8_t *key,
+                                     size_t keySize,
+                                     caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts or decrypts AES using CTR block mode.
  *
  * Encrypts or decrypts AES using CTR block mode.
@@ -660,6 +1002,42 @@ status_t CAAM_AES_CryptCtr(CAAM_Type *base,
                            size_t keySize,
                            uint8_t counterlast[CAAM_AES_BLOCK_SIZE],
                            size_t *szLeft);
+
+/*!
+ * @brief Encrypts or decrypts AES using CTR block mode using black key.
+ *
+ * Encrypts or decrypts AES using CTR block mode.
+ * AES CTR mode uses only forward AES cipher and same algorithm for encryption and decryption.
+ * The only difference between encryption and decryption is that, for encryption, the input argument
+ * is plain text and the output argument is cipher text. For decryption, the input argument is cipher text
+ * and the output argument is plain text.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param input Input data for CTR block mode
+ * @param[out] output Output data for CTR block mode
+ * @param size Size of input and output data in bytes
+ * @param[in,out] counter Input counter (updates on return)
+ * @param key Input key to use for forward AES cipher
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] counterlast Output cipher of last counter, for chained CTR calls. NULL can be passed if chained calls are
+ * not used.
+ * @param[out] szLeft Output number of bytes in left unused in counterlast block. NULL can be passed if chained calls
+ * are not used.
+ * @param blackKeyType Type of black key
+ * @return Status from encrypt operation
+ */
+status_t CAAM_AES_CryptCtrExtended(CAAM_Type *base,
+                                   caam_handle_t *handle,
+                                   const uint8_t *input,
+                                   uint8_t *output,
+                                   size_t size,
+                                   uint8_t counter[CAAM_AES_BLOCK_SIZE],
+                                   const uint8_t *key,
+                                   size_t keySize,
+                                   uint8_t counterlast[CAAM_AES_BLOCK_SIZE],
+                                   size_t *szLeft,
+                                   caam_key_type_t blackKeyType);
 
 /*!
  * @brief Encrypts AES and tags using CCM block mode.
@@ -731,6 +1109,79 @@ status_t CAAM_AES_DecryptTagCcm(CAAM_Type *base,
                                 size_t tagSize);
 
 /*!
+ * @brief Encrypts AES and tags using CCM block mode using black key.
+ *
+ * Encrypts AES and optionally tags using CCM block mode.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text.
+ * @param size Size of input and output data in bytes. Zero means authentication only.
+ * @param iv Nonce
+ * @param ivSize Length of the Nonce in bytes. Must be 7, 8, 9, 10, 11, 12, or 13.
+ * @param aad Input additional authentication data. Can be NULL if aadSize is zero.
+ * @param aadSize Input size in bytes of AAD. Zero means data mode only (authentication skipped).
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] tag Generated output tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag to generate, in bytes. Must be 4, 6, 8, 10, 12, 14, or 16.
+ * @param blackKeyType Type of black key
+ * @return Status from encrypt operation
+ */
+status_t CAAM_AES_EncryptTagCcmExtended(CAAM_Type *base,
+                                        caam_handle_t *handle,
+                                        const uint8_t *plaintext,
+                                        uint8_t *ciphertext,
+                                        size_t size,
+                                        const uint8_t *iv,
+                                        size_t ivSize,
+                                        const uint8_t *aad,
+                                        size_t aadSize,
+                                        const uint8_t *key,
+                                        size_t keySize,
+                                        uint8_t *tag,
+                                        size_t tagSize,
+                                        caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES and authenticates using CCM block mode using black key.
+ *
+ * Decrypts AES and optionally authenticates using CCM block mode.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text.
+ * @param size Size of input and output data in bytes. Zero means authentication data only.
+ * @param iv Nonce
+ * @param ivSize Length of the Nonce in bytes. Must be 7, 8, 9, 10, 11, 12, or 13.
+ * @param aad Input additional authentication data. Can be NULL if aadSize is zero.
+ * @param aadSize Input size in bytes of AAD. Zero means data mode only (authentication data skipped).
+ * @param key Input key to use for decryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param tag Received tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the received tag to compare with the computed tag, in bytes. Must be 4, 6, 8, 10, 12,
+ *                14, or 16.
+ * @param blackKeyType Type of black key
+ * @return Status from decrypt operation
+ */
+status_t CAAM_AES_DecryptTagCcmExtended(CAAM_Type *base,
+                                        caam_handle_t *handle,
+                                        const uint8_t *ciphertext,
+                                        uint8_t *plaintext,
+                                        size_t size,
+                                        const uint8_t *iv,
+                                        size_t ivSize,
+                                        const uint8_t *aad,
+                                        size_t aadSize,
+                                        const uint8_t *key,
+                                        size_t keySize,
+                                        const uint8_t *tag,
+                                        size_t tagSize,
+                                        caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts AES and tags using GCM block mode.
  *
  * Encrypts AES and optionally tags using GCM block mode. If plaintext is NULL, only the GHASH is calculated and output
@@ -799,6 +1250,80 @@ status_t CAAM_AES_DecryptTagGcm(CAAM_Type *base,
                                 size_t keySize,
                                 const uint8_t *tag,
                                 size_t tagSize);
+
+/*!
+ * @brief Encrypts AES and tags using GCM block mode using black key.
+ *
+ * Encrypts AES and optionally tags using GCM block mode. If plaintext is NULL, only the GHASH is calculated and output
+ * in the 'tag' field. Uses black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text.
+ * @param size Size of input and output data in bytes
+ * @param iv Input initial vector
+ * @param ivSize Size of the IV
+ * @param aad Input additional authentication data
+ * @param aadSize Input size in bytes of AAD
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] tag Output hash tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag to generate, in bytes. Must be 4,8,12,13,14,15 or 16.
+ * @param blackenKeyType Type of black key
+ * @return Status from encrypt operation
+ */
+status_t CAAM_AES_EncryptTagGcmExtended(CAAM_Type *base,
+                                        caam_handle_t *handle,
+                                        const uint8_t *plaintext,
+                                        uint8_t *ciphertext,
+                                        size_t size,
+                                        const uint8_t *iv,
+                                        size_t ivSize,
+                                        const uint8_t *aad,
+                                        size_t aadSize,
+                                        const uint8_t *key,
+                                        size_t keySize,
+                                        uint8_t *tag,
+                                        size_t tagSize,
+                                        caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES and authenticates using GCM block mode using black key.
+ *
+ * Decrypts AES and optionally authenticates using GCM block mode. If ciphertext is NULL, only the GHASH is calculated
+ * and compared with the received GHASH in 'tag' field. Uses black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text.
+ * @param size Size of input and output data in bytes
+ * @param iv Input initial vector
+ * @param ivSize Size of the IV
+ * @param aad Input additional authentication data
+ * @param aadSize Input size in bytes of AAD
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param tag Input hash tag to compare. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag, in bytes. Must be 4, 8, 12, 13, 14, 15, or 16.
+ * @param blackenKeyType Type of black key
+ * @return Status from decrypt operation
+ */
+status_t CAAM_AES_DecryptTagGcmExtended(CAAM_Type *base,
+                                        caam_handle_t *handle,
+                                        const uint8_t *ciphertext,
+                                        uint8_t *plaintext,
+                                        size_t size,
+                                        const uint8_t *iv,
+                                        size_t ivSize,
+                                        const uint8_t *aad,
+                                        size_t aadSize,
+                                        const uint8_t *key,
+                                        size_t keySize,
+                                        const uint8_t *tag,
+                                        size_t tagSize,
+                                        caam_key_type_t blackKeyType);
 /*!
  *@}
  */ /* end of caam_driver_aes */
@@ -856,6 +1381,58 @@ status_t CAAM_AES_DecryptEcbNonBlocking(CAAM_Type *base,
                                         size_t keySize);
 
 /*!
+ * @brief Encrypts AES using the ECB block mode using black key.
+ *
+ * Puts AES ECB encrypt descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param[out] ciphertext Output cipher text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_EncryptEcbNonBlockingExtended(CAAM_Type *base,
+                                                caam_handle_t *handle,
+                                                caam_desc_aes_ecb_t descriptor,
+                                                const uint8_t *plaintext,
+                                                uint8_t *ciphertext,
+                                                size_t size,
+                                                const uint8_t *key,
+                                                size_t keySize,
+                                                caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES using ECB block mode using black key.
+ *
+ * Puts AES ECB decrypt descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param key Input key.
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_DecryptEcbNonBlockingExtended(CAAM_Type *base,
+                                                caam_handle_t *handle,
+                                                caam_desc_aes_ecb_t descriptor,
+                                                const uint8_t *ciphertext,
+                                                uint8_t *plaintext,
+                                                size_t size,
+                                                const uint8_t *key,
+                                                size_t keySize,
+                                                caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts AES using CBC block mode.
  *
  * Puts AES CBC encrypt descriptor to CAAM input job ring.
@@ -908,6 +1485,62 @@ status_t CAAM_AES_DecryptCbcNonBlocking(CAAM_Type *base,
                                         size_t keySize);
 
 /*!
+ * @brief Encrypts AES using CBC block mode using black key.
+ *
+ * Puts AES CBC encrypt descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param iv Input initial vector to combine with the first input block.
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_EncryptCbcNonBlockingExtended(CAAM_Type *base,
+                                                caam_handle_t *handle,
+                                                caam_desc_aes_cbc_t descriptor,
+                                                const uint8_t *plaintext,
+                                                uint8_t *ciphertext,
+                                                size_t size,
+                                                const uint8_t *iv,
+                                                const uint8_t *key,
+                                                size_t keySize,
+                                                caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES using CBC block mode using black key.
+ *
+ * Puts AES CBC decrypt descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text
+ * @param size Size of input and output data in bytes. Must be multiple of 16 bytes.
+ * @param iv Input initial vector to combine with the first input block.
+ * @param key Input key to use for decryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_DecryptCbcNonBlockingExtended(CAAM_Type *base,
+                                                caam_handle_t *handle,
+                                                caam_desc_aes_cbc_t descriptor,
+                                                const uint8_t *ciphertext,
+                                                uint8_t *plaintext,
+                                                size_t size,
+                                                const uint8_t *iv,
+                                                const uint8_t *key,
+                                                size_t keySize,
+                                                caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts or decrypts AES using CTR block mode.
  *
  * Encrypts or decrypts AES using CTR block mode.
@@ -944,6 +1577,46 @@ status_t CAAM_AES_CryptCtrNonBlocking(CAAM_Type *base,
                                       size_t keySize,
                                       uint8_t *counterlast,
                                       size_t *szLeft);
+
+/*!
+ * @brief Encrypts or decrypts AES using CTR block mode using black key.
+ *
+ * Encrypts or decrypts AES using CTR block mode.
+ * AES CTR mode uses only forward AES cipher and same algorithm for encryption and decryption.
+ * The only difference between encryption and decryption is that, for encryption, the input argument
+ * is plain text and the output argument is cipher text. For decryption, the input argument is cipher text
+ * and the output argument is plain text.
+ *
+ * Puts AES CTR crypt descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param input Input data for CTR block mode
+ * @param[out] output Output data for CTR block mode
+ * @param size Size of input and output data in bytes
+ * @param[in,out] counter Input counter (updates on return)
+ * @param key Input key to use for forward AES cipher
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] counterlast Output cipher of last counter, for chained CTR calls. NULL can be passed if chained calls are
+ * not used.
+ * @param[out] szLeft Output number of bytes in left unused in counterlast block. NULL can be passed if chained calls
+ * are not used.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_CryptCtrNonBlockingExtended(CAAM_Type *base,
+                                              caam_handle_t *handle,
+                                              caam_desc_aes_ctr_t descriptor,
+                                              const uint8_t *input,
+                                              uint8_t *output,
+                                              size_t size,
+                                              uint8_t *counter,
+                                              const uint8_t *key,
+                                              size_t keySize,
+                                              uint8_t *counterlast,
+                                              size_t *szLeft,
+                                              caam_key_type_t blackKeyType);
 
 /*!
  * @brief Encrypts AES and tags using CCM block mode.
@@ -1020,6 +1693,84 @@ status_t CAAM_AES_DecryptTagCcmNonBlocking(CAAM_Type *base,
                                            size_t tagSize);
 
 /*!
+ * @brief Encrypts AES and tags using CCM block mode using black key.
+ *
+ * Puts AES CCM encrypt and tag descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text.
+ * @param size Size of input and output data in bytes. Zero means authentication only.
+ * @param iv Nonce
+ * @param ivSize Length of the Nonce in bytes. Must be 7, 8, 9, 10, 11, 12, or 13.
+ * @param aad Input additional authentication data. Can be NULL if aadSize is zero.
+ * @param aadSize Input size in bytes of AAD. Zero means data mode only (authentication skipped).
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] tag Generated output tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag to generate, in bytes. Must be 4, 6, 8, 10, 12, 14, or 16.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_EncryptTagCcmNonBlockingExtended(CAAM_Type *base,
+                                                   caam_handle_t *handle,
+                                                   caam_desc_aes_ccm_t descriptor,
+                                                   const uint8_t *plaintext,
+                                                   uint8_t *ciphertext,
+                                                   size_t size,
+                                                   const uint8_t *iv,
+                                                   size_t ivSize,
+                                                   const uint8_t *aad,
+                                                   size_t aadSize,
+                                                   const uint8_t *key,
+                                                   size_t keySize,
+                                                   uint8_t *tag,
+                                                   size_t tagSize,
+                                                   caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES and authenticates using CCM block mode using black key.
+ *
+ * Puts AES CCM decrypt and check tag descriptor to CAAM input job ring.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text.
+ * @param size Size of input and output data in bytes. Zero means authentication data only.
+ * @param iv Nonce
+ * @param ivSize Length of the Nonce in bytes. Must be 7, 8, 9, 10, 11, 12, or 13.
+ * @param aad Input additional authentication data. Can be NULL if aadSize is zero.
+ * @param aadSize Input size in bytes of AAD. Zero means data mode only (authentication data skipped).
+ * @param key Input key to use for decryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param tag Received tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the received tag to compare with the computed tag, in bytes. Must be 4, 6, 8, 10, 12,
+ *                14, or 16.
+ * @param blackKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+
+status_t CAAM_AES_DecryptTagCcmNonBlockingExtended(CAAM_Type *base,
+                                                   caam_handle_t *handle,
+                                                   caam_desc_aes_ccm_t descriptor,
+                                                   const uint8_t *ciphertext,
+                                                   uint8_t *plaintext,
+                                                   size_t size,
+                                                   const uint8_t *iv,
+                                                   size_t ivSize,
+                                                   const uint8_t *aad,
+                                                   size_t aadSize,
+                                                   const uint8_t *key,
+                                                   size_t keySize,
+                                                   const uint8_t *tag,
+                                                   size_t tagSize,
+                                                   caam_key_type_t blackKeyType);
+
+/*!
  * @brief Encrypts AES and tags using GCM block mode.
  *
  * Encrypts AES and optionally tags using GCM block mode. If plaintext is NULL, only the GHASH is calculated and output
@@ -1094,6 +1845,88 @@ status_t CAAM_AES_DecryptTagGcmNonBlocking(CAAM_Type *base,
                                            size_t keySize,
                                            const uint8_t *tag,
                                            size_t tagSize);
+
+/*!
+ * @brief Encrypts AES and tags using GCM block mode using black key.
+ *
+ * Encrypts AES and optionally tags using GCM block mode. If plaintext is NULL, only the GHASH is calculated and output
+ * in the 'tag' field.
+ * Puts AES GCM encrypt and tag descriptor to CAAM input job ring.
+ * Uses black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param plaintext Input plain text to encrypt
+ * @param[out] ciphertext Output cipher text.
+ * @param size Size of input and output data in bytes
+ * @param iv Input initial vector
+ * @param ivSize Size of the IV
+ * @param aad Input additional authentication data
+ * @param aadSize Input size in bytes of AAD
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param[out] tag Output hash tag. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag to generate, in bytes. Must be 4,8,12,13,14,15 or 16.
+ * @return Status from job descriptor push
+ * @param blackenKeyType Type of black key
+ */
+status_t CAAM_AES_EncryptTagGcmNonBlockingExtended(CAAM_Type *base,
+                                                   caam_handle_t *handle,
+                                                   caam_desc_aes_gcm_t descriptor,
+                                                   const uint8_t *plaintext,
+                                                   uint8_t *ciphertext,
+                                                   size_t size,
+                                                   const uint8_t *iv,
+                                                   size_t ivSize,
+                                                   const uint8_t *aad,
+                                                   size_t aadSize,
+                                                   const uint8_t *key,
+                                                   size_t keySize,
+                                                   uint8_t *tag,
+                                                   size_t tagSize,
+                                                   caam_key_type_t blackKeyType);
+
+/*!
+ * @brief Decrypts AES and authenticates using GCM block mode using black key.
+ *
+ * Decrypts AES and optionally authenticates using GCM block mode. If ciphertext is NULL, only the GHASH is calculated
+ * and compared with the received GHASH in 'tag' field.
+ * Puts AES GCM decrypt and check tag descriptor to CAAM input job ring.
+ * Uses black key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param[out] descriptor Memory for the CAAM descriptor.
+ * @param ciphertext Input cipher text to decrypt
+ * @param[out] plaintext Output plain text.
+ * @param size Size of input and output data in bytes
+ * @param iv Input initial vector
+ * @param ivSize Size of the IV
+ * @param aad Input additional authentication data
+ * @param aadSize Input size in bytes of AAD
+ * @param key Input key to use for encryption
+ * @param keySize Size of the input key, in bytes. Must be 16, 24, or 32.
+ * @param tag Input hash tag to compare. Set to NULL to skip tag processing.
+ * @param tagSize Input size of the tag, in bytes. Must be 4, 8, 12, 13, 14, 15, or 16.
+ * @param blackenKeyType Type of black key
+ * @return Status from job descriptor push
+ */
+status_t CAAM_AES_DecryptTagGcmNonBlockingExtended(CAAM_Type *base,
+                                                   caam_handle_t *handle,
+                                                   caam_desc_aes_gcm_t descriptor,
+                                                   const uint8_t *ciphertext,
+                                                   uint8_t *plaintext,
+                                                   size_t size,
+                                                   const uint8_t *iv,
+                                                   size_t ivSize,
+                                                   const uint8_t *aad,
+                                                   size_t aadSize,
+                                                   const uint8_t *key,
+                                                   size_t keySize,
+                                                   const uint8_t *tag,
+                                                   size_t tagSize,
+                                                   caam_key_type_t blackKeyType);
 /*!
  *@}
  */ /* end of caam_nonblocking_driver_aes */
@@ -1708,6 +2541,16 @@ status_t CAAM_RNG_GetRandomDataNonBlocking(CAAM_Type *base,
  * @addtogroup caam_driver_black
  * @{
  */
+
+/*!
+ * @brief Return size of blacken key based on encryption type and data to encrypt size
+ *
+ * @param fifostType Type of AES-CBC or AEC-CCM to encrypt plaintext
+ * @param dataSize Size of data to be encrypted
+ *
+ * @return size_t Size of blacken key.
+ */
+size_t CAAM_BLACK_KeyBlackenSize(caam_fifost_type_t fifostType, size_t dataSize);
 
 /*!
  * @brief Construct a black key
@@ -3525,6 +4368,250 @@ status_t CAAM_PKHA_ECC_PointMul(CAAM_Type *base,
 /*!
  *@}
  */ /* end of caam_driver_pkha */
+
+/*******************************************************************************
+ * ECC
+ ******************************************************************************/
+
+/*!
+ * @addtogroup caam_driver_ecc
+ * @{
+ */
+
+/*!
+ * @brief Return size of private key based on encryption type and ecliptic curve domain
+ *
+ * @param encryptKeyType Type of key encryption.
+ * @param ecdsel Elliptic curve domain selection
+ *
+ * @return size_t Size of private key.
+ */
+size_t CAAM_ECC_PrivateKeySize(caam_ecc_encryption_type_t encryptKeyType, caam_ecc_ecdsel_t ecdsel);
+
+/*!
+ * @brief Generates public and private key for ECC.
+ *
+ * The buffer size of privKey can be determined using CAAM_ECC_PRIVATE_KEY_LENGTH.
+ * The buffer size of pubKey can be determined using CAAM_ECC_PUBLIC_KEY_LENGTH.
+ * For encrypted privKey, the buffer size can be determined using CAAM_BLACKEN_ECB_SIZE
+ * or CAAM_BLACKEN_CCM_SIZE macros.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param ecdsel Elliptic curve domain selection
+ * @param encryptKeyType Type of key encryption
+ * @param[out] privKey Private key
+ * @param[out] pubKey Public key
+ * @return Operation status.
+ */
+status_t CAAM_ECC_KeyPair(CAAM_Type *base,
+                          caam_handle_t *handle,
+                          caam_ecc_ecdsel_t ecdsel,
+                          caam_ecc_encryption_type_t encryptKeyType,
+                          uint8_t *privKey,
+                          uint8_t *pubKey);
+
+/*!
+ * @brief Generates signature using ECC.
+ *
+ * The buffer size of signFirst can be determined using CAAM_ECC_PRIVATE_KEY_LENGTH.
+ * ! The buffer size of signSecond can be determined using CAAM_ECC_SECOND_SIGN_BUFFER_SIZE.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param privKey Private key
+ * @param data Hashed data
+ * @param dataSize Hashed data length
+ * @param ecdsel Elliptic curve domain selection
+ * @param encryptKeyType Type of key encryption
+ * @param[out] signFirst First part of the signature
+ * @param[out] signSecond Second part of the signature
+ * @return Operation status.
+ */
+status_t CAAM_ECC_Sign(CAAM_Type *base,
+                       caam_handle_t *handle,
+                       const uint8_t *privKey,
+                       const uint8_t *data,
+                       size_t dataSize,
+                       caam_ecc_ecdsel_t ecdsel,
+                       caam_ecc_encryption_type_t encryptKeyType,
+                       uint8_t *signFirst,
+                       uint8_t *signSecond);
+
+/*!
+ * @brief Verify ECC signature using public key
+ *
+ * The buffer size of tmp can be determined using CAAM_ECC_PUBLIC_KEY_LENGTH.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param pubKey Public key
+ * @param data Hashed data
+ * @param dataSize Hashed data length
+ * @param signFirst First part of the signature
+ * @param signSecond Second part of the signature
+ * @param ecdsel Elliptic curve domain selection
+ * @param[in,out] tmp Temporary storage for intermediate results
+ * @return Operation status.
+ */
+status_t CAAM_ECC_VerifyPublicKey(CAAM_Type *base,
+                                  caam_handle_t *handle,
+                                  const uint8_t *pubKey,
+                                  const uint8_t *data,
+                                  size_t dataSize,
+                                  const uint8_t *signFirst,
+                                  const uint8_t *signSecond,
+                                  caam_ecc_ecdsel_t ecdsel,
+                                  uint8_t *tmp);
+
+/*!
+ * @brief Verify ECC signature using private key
+ *
+ * Faster that verifying using public key.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param privKey Private key
+ * @param data Hashed data
+ * @param dataSize Hashed data length
+ * @param signFirst First part of the signature
+ * @param signSecond Second part of the signature
+ * @param ecdsel Elliptic curve domain selection
+ * @param encryptKeyType Type of key encryption
+ * @return Operation status.
+ */
+status_t CAAM_ECC_VerifyPrivateKey(CAAM_Type *base,
+                                   caam_handle_t *handle,
+                                   const uint8_t *privKey,
+                                   const uint8_t *data,
+                                   size_t dataSize,
+                                   const uint8_t *signFirst,
+                                   const uint8_t *signSecond,
+                                   caam_ecc_ecdsel_t ecdsel,
+                                   caam_ecc_encryption_type_t encryptKeyType);
+/*!
+ *@}
+ */ /* end of caam_driver_ecc */
+
+/*******************************************************************************
+ * RSA
+ ******************************************************************************/
+
+/*!
+ * @addtogroup caam_driver_rsa
+ * @{
+ */
+
+/*!
+ * @brief Return size for private key buffer based on encryption type and ecliptic curve domain
+ *
+ * @param prvKeyType Type of private key
+ * @param privExponentSize Expected length of private exponent without encryption padding.
+ *
+ * @return size_t Size for private key buffer.
+ */
+size_t CAAM_RSA_PrivateExponentSize(caam_rsa_key_type_t prvKeyType, uint32_t privExponentSize);
+
+/*!
+ * @brief Generates RSA key.
+ *
+ * Generates modulus N and private exponent D give prime numbers P and Q and public exponent E.
+ * Public key is {E,N}. Private key is {D,N}.
+ *
+ * ! privExponentSize value may differ for different P abd Q with same bit length.
+ * For encrypted privExponent, the buffer size can be determined using CAAM_BLACKEN_ECB_SIZE
+ * or CAAM_BLACKEN_CCM_SIZE macros.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param primeP Prime number P
+ * @param primeQ Prime number Q
+ * @param primesSize Byte length of primeP or primeQ (primeP and primeQ must have the same byte length)
+ * @param pubExponent Public exponent E
+ * @param pubExponentSize  Byte length of pubExponent
+ * @param prvKeyType Type of private key
+ * @param[out] modulus Buffer for calculated modulus N
+ * @param modulusSize Byte length of modulus buffer
+ * @param[out] privExponent Buffer for calculated private exponent D
+ * @param[out] privExponentSize Byte length of calculated private exponent.
+ * @return Operation status.
+ */
+status_t CAAM_RSA_KeyPair(CAAM_Type *base,
+                          caam_handle_t *handle,
+                          const uint8_t *primeP,
+                          const uint8_t *primeQ,
+                          uint32_t primesSize,
+                          const uint8_t *pubExponent,
+                          uint32_t pubExponentSize,
+                          caam_rsa_key_type_t prvKeyType,
+                          uint8_t *modulus,
+                          uint32_t modulusSize,
+                          uint8_t *privExponent,
+                          size_t *privExponentSize);
+
+/*!
+ * @brief Performs the RSA public key primitive.
+ *
+ * Performs the RSA public key primitive which can be used when encrypting a secret or verifying a signature.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param plainText Input data
+ * @param plainTextize Byte length of the input data
+ * @param modulus Modulus N
+ * @param modulusSize Byte length of modulus
+ * @param pubExponent Public exponent E
+ * @param pubExponentSize  Byte length of pubExponent
+ * @param dataOutType Type of encryption of output data
+ * @param[out] cipherText Buffer for RSA encrypted data
+ * @return Operation status
+ */
+status_t CAAM_RSA_Encrypt(CAAM_Type *base,
+                          caam_handle_t *handle,
+                          const uint8_t *plainText,
+                          uint32_t plainTextSize,
+                          const uint8_t *modulus,
+                          uint32_t modulusSize,
+                          const uint8_t *pubExponent,
+                          uint32_t pubExponentSize,
+                          caam_rsa_encryption_type_t dataOutType,
+                          caam_rsa_format_type_t format,
+                          uint8_t *cipherText);
+
+/*!
+ * @brief Performs the RSA private key primitive.
+ *
+ * Performs the RSA private key primitive which can be used when decrypting a secret or creating a siganture.
+ *
+ * @param base CAAM peripheral base address
+ * @param handle Handle used for this request. Specifies jobRing.
+ * @param cipherText Input data
+ * @param modulus Moulus N
+ * @param modulusSize Byte length of modulus
+ * @param privExponent Private exponent D
+ * @param privExponentSize Byte length of privExponent
+ * @param prvKeyType Type of private key encryption
+ * @param dataOutType Type of encryption of output data
+ * @param[out] plainText Buffer for RSA encrypted data
+ * @param[out] rsaDecSize Returned output size
+ * @return Operation status
+ */
+status_t CAAM_RSA_Decrypt(CAAM_Type *base,
+                          caam_handle_t *handle,
+                          const uint8_t *cipherText,
+                          const uint8_t *modulus,
+                          uint32_t modulusSize,
+                          const uint8_t *privExponent,
+                          uint32_t privExponentSize,
+                          caam_rsa_encryption_type_t prvKeyType,
+                          caam_rsa_encryption_type_t dataOutType,
+                          caam_rsa_format_type_t format,
+                          uint8_t *plainText,
+                          size_t *rsaDecSize);
+
+/*!
+ *@}
+ */ /* end of caam_driver_rsa */
 
 #if defined(__cplusplus)
 }

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
@@ -32,7 +32,7 @@ enum
 /*! @{ */
 /*! @brief CAAM driver version.
  *
- * Current version: 2.4.0
+ * Current version: 2.4.1
  *
  * Change log:
  * - Version 2.0.0
@@ -80,8 +80,10 @@ enum
  * - Version 2.4.0
  *   - Add new APIs for native asymmetric operations (RSA, ECC) instead of only accelerating mathematical primitives
  *     and support for black keys and blobs for both symmetric and asymmetric operations.
+ * - Version 2.4.1
+ *   - Fix MSG and MISRA-2012 issues.
  */
-#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 4, 0))
+#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 4, 1))
 /*! @} */
 
 /*! @brief CAAM callback function. */
@@ -306,10 +308,10 @@ typedef enum _caam_ecc_ecdsel
 #define CAAM_DES_IV_SIZE 8
 
 /*! @brief CAAM blacken key size for ECB encryption */
-#define CAAM_BLACKEN_ECB_SIZE(x) ((uint32_t)((x) + 15u) & ~15ul)
+#define CAAM_BLACKEN_ECB_SIZE(x) ((uint32_t)((x) + 15u) & ~15UL)
 
 /*! @brief CAAM blacken key size for CCM encryption */
-#define CAAM_BLACKEN_CCM_SIZE(x) (((uint32_t)((x) + 7u) & ~7ul) + 12u)
+#define CAAM_BLACKEN_CCM_SIZE(x) (((uint32_t)((x) + 7u) & ~7UL) + 12u)
 
 /*! @brief CAAM DSA public key length for EC domain */
 #define CAAM_DSA_PUBLIC_KEY_LENGTH(domain)         \
@@ -579,14 +581,14 @@ trusted descriptor key encryption key. */
 /*! @brief CAAM key types. */
 typedef enum _caam_key_type
 {
-    kCAAM_Key_Type_None     = 0x0ul,
-    kCAAM_Key_Type_Ecb_Jkek = 0x80ul << 15, /*!< Key Register, encrypted using AES-ECB with the job
+    kCAAM_Key_Type_None     = 0x0UL,
+    kCAAM_Key_Type_Ecb_Jkek = 0x80UL << 15, /*!< Key Register, encrypted using AES-ECB with the job
   descriptor key encryption key. */
-    kCAAM_Key_Type_Ecb_Tkek = 0x81ul << 15, /*!< Key Register, encrypted using AES-ECB with the
+    kCAAM_Key_Type_Ecb_Tkek = 0x81UL << 15, /*!< Key Register, encrypted using AES-ECB with the
   trusted descriptor key encryption key. */
-    kCAAM_Key_Type_Ccm_Jkek = 0xA0ul << 15, /*!< Key Register, encrypted using AES-CCM with the
+    kCAAM_Key_Type_Ccm_Jkek = 0xA0UL << 15, /*!< Key Register, encrypted using AES-CCM with the
 job descriptor key encryption key. */
-    kCAAM_Key_Type_Ccm_Tkek = 0xA1ul << 15, /*!< Key register, encrypted using AES-CCM with the
+    kCAAM_Key_Type_Ccm_Tkek = 0xA1UL << 15, /*!< Key register, encrypted using AES-CCM with the
 trusted descriptor key encryption key. */
 } caam_key_type_t;
 


### PR DESCRIPTION
CAAM driver was updated to version 2.4.1, as a part of process to enable hardware-accelerated PSA crypto operations. 

## [2.4.1]

- Fix MSG and MISRA-2012 issues.

## [2.4.0]

- Add new APIs for native asymmetric operations (RSA, ECC) instead of only accelerating mathematical primitives
  and support for black keys and blobs for both symmetric and asymmetric operations.

