### PR TITLE
mcuxsdk: middleware: connectivity-framework: add fwk_config_zephyr.h

### DIFF
--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/configs/fwk_config.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/configs/fwk_config.h
@@ -9,12 +9,30 @@
 
 #include "fwk_platform_definitions.h"
 
+/* On Zephyr, include the Zephyr-specific configuration overrides first so that
+ * they take precedence over the default values defined below (each flag is
+ * #ifndef-protected). This avoids duplicating the overrides in the Zephyr
+ * repository. */
+#ifdef __ZEPHYR__
+#include "fwk_config_zephyr.h"
+#endif
+
 /*********************************************************************
  *        General
  *********************************************************************/
 
 /* This platform has an NBU domain */
 #define gPlatformHasNbu_d 1
+
+/* Defer the ECDH P256 public key generation and DH key computation from the NBU (controller) to the host (MCU) core.
+ * When enabled, the host handles the P256 public key generation and DH key computation on behalf of the NBU, and the
+ * corresponding ICS messages and handlers are compiled in.
+ * When disabled, the related APIs remain available but are empty so callers can keep the calls unconditionally.
+ * This feature is disabled by default and should be enabled only for applications that require it (e.g. hci_bb for
+ * controller qualification). Enable it by adding -DgPlatformIcsDeferDHKeyToHost_d=1 to the application build. */
+#ifndef gPlatformIcsDeferDHKeyToHost_d
+#define gPlatformIcsDeferDHKeyToHost_d 0
+#endif
 
 /* Defines the calibration duration of the ADC, it will block the task during this time in milisec before trigger the
  * ADC on a channel*/
@@ -177,13 +195,11 @@
 /*********************************************************************
  *        NBU debuggability
  *********************************************************************/
-/* Enable NBU access to GPIO PORT D - This allows easier debugging when an issue is reported with a specific main core
+/* Allocate the GPIOD to the NBU - This allows easier debugging when an issue is reported with a specific main core
  * binary.
+ * On kw45/mcxw71, kw47/mcxw72 use TRDC to authorize access. On kw43/mcxw70 enable pin control non secure.
  * \warning: Disabling this compile macro can impair the debug capability of the NBU for a specific main core binary.
- * \warning: This part of code can generate bus fault when trustzone is enabled (code executed in non secure mode).
- *      Reason is that TRDC_IDAU_CR can not be read. In this case, user shall disable this compile macro when running
- *      in non secure mode.
- * */
+ */
 #if !defined(gPlatformNbuDebugGpioDAccessEnabled_d)
 #define gPlatformNbuDebugGpioDAccessEnabled_d 0
 #endif
@@ -266,6 +282,10 @@
 #ifndef gPlatformUseTimerManager_d
 #define gPlatformUseTimerManager_d 1
 #endif
+
+/* On KW43 better to perform the cleaning of the OTA storage at initialization in order to introduce
+ * less perturbation to the NBU Link Layer during OTA transfer */
+#define gOtaEraseWholePartitionOnInit_d 0 /* to be set to 1 if OTA storage cleaning is required */
 
 /*********************************************************************
  *        Configuration check

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/configs/fwk_config_zephyr.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw43_mcxw70/configs/fwk_config_zephyr.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_CONFIG_ZEPHYR_H_
+#define FWK_CONFIG_ZEPHYR_H_
+
+/*
+ * Zephyr-specific framework configuration overrides.
+ *
+ * This file is included at the top of fwk_config.h under an #ifdef __ZEPHYR__
+ * guard, so it is compiled only for Zephyr builds. Because every flag in
+ * fwk_config.h is #ifndef-protected, any value defined here takes precedence
+ * over the default MCUXpresso SDK value.
+ *
+ * These overrides used to be maintained on the Zephyr side, in
+ * modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake.
+ * They are centralized here to avoid dual maintenance between the framework
+ * and the Zephyr integration.
+ */
+
+/* On Zephyr the ICS RX processing does not use the framework system workqueue */
+#ifndef gPlatformIcsUseWorkqueueRxProcessing_d
+#define gPlatformIcsUseWorkqueueRxProcessing_d 0
+#endif
+
+/* On Zephyr the Timer Manager is not used; Zephyr provides its own timer services */
+#ifndef gPlatformUseTimerManager_d
+#define gPlatformUseTimerManager_d 0
+#endif
+
+/* On Zephyr the framework HW parameter storage is not used */
+#ifndef gPlatformUseHwParameter_d
+#define gPlatformUseHwParameter_d 0
+#endif
+
+/* On Zephyr the NBU GPIO PORT D debug access is not enabled by the framework */
+#ifndef gPlatformNbuDebugGpioDAccessEnabled_d
+#define gPlatformNbuDebugGpioDAccessEnabled_d 0
+#endif
+
+/* On Zephyr the SFC config is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetSfcConfigAtInit_d
+#define gPlatformSetSfcConfigAtInit_d 0
+#endif
+
+/* On Zephyr the wake up delay is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetWakeUpDelayAtInit_d
+#define gPlatformSetWakeUpDelayAtInit_d 0
+#endif
+
+#endif /* FWK_CONFIG_ZEPHYR_H_ */

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw45_k32w1_mcxw71/configs/fwk_config.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw45_k32w1_mcxw71/configs/fwk_config.h
@@ -9,6 +9,14 @@
 
 #include "fwk_platform_definitions.h"
 
+/* On Zephyr, include the Zephyr-specific configuration overrides first so that
+ * they take precedence over the default values defined below (each flag is
+ * #ifndef-protected). This avoids duplicating the overrides in the Zephyr
+ * repository. */
+#ifdef __ZEPHYR__
+#include "fwk_config_zephyr.h"
+#endif
+
 /*********************************************************************
  *        General
  *********************************************************************/
@@ -181,6 +189,7 @@
  *********************************************************************/
 /* Enable NBU access to GPIO PORT D - This allows easier debugging when an issue is reported with a specific main core
  * binary.
+ * On kw45/mcxw71, kw47/mcxw72 use TRDC to authorize access. On kw43/mcxw70 enable pin control non secure.
  * \warning: Disabling this compile macro can impair the debug capability of the NBU for a specific main core binary.
  * \warning: This part of code can generate bus fault when trustzone is enabled (code executed in non secure mode).
  *      Reason is that TRDC_IDAU_CR can not be read. In this case, user shall disable this compile macro when running

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw45_k32w1_mcxw71/configs/fwk_config_zephyr.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw45_k32w1_mcxw71/configs/fwk_config_zephyr.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_CONFIG_ZEPHYR_H_
+#define FWK_CONFIG_ZEPHYR_H_
+
+/*
+ * Zephyr-specific framework configuration overrides.
+ *
+ * This file is included at the top of fwk_config.h under an #ifdef __ZEPHYR__
+ * guard, so it is compiled only for Zephyr builds. Because every flag in
+ * fwk_config.h is #ifndef-protected, any value defined here takes precedence
+ * over the default MCUXpresso SDK value.
+ *
+ * These overrides used to be maintained on the Zephyr side, in
+ * modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake.
+ * They are centralized here to avoid dual maintenance between the framework
+ * and the Zephyr integration.
+ */
+
+/* On Zephyr the ICS RX processing does not use the framework system workqueue */
+#ifndef gPlatformIcsUseWorkqueueRxProcessing_d
+#define gPlatformIcsUseWorkqueueRxProcessing_d 0
+#endif
+
+/* On Zephyr the Timer Manager is not used; Zephyr provides its own timer services */
+#ifndef gPlatformUseTimerManager_d
+#define gPlatformUseTimerManager_d 0
+#endif
+
+/* On Zephyr the framework HW parameter storage is not used */
+#ifndef gPlatformUseHwParameter_d
+#define gPlatformUseHwParameter_d 0
+#endif
+
+/* On Zephyr the NBU GPIO PORT D debug access is not enabled by the framework */
+#ifndef gPlatformNbuDebugGpioDAccessEnabled_d
+#define gPlatformNbuDebugGpioDAccessEnabled_d 0
+#endif
+
+/* On Zephyr the SFC config is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetSfcConfigAtInit_d
+#define gPlatformSetSfcConfigAtInit_d 0
+#endif
+
+/* On Zephyr the wake up delay is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetWakeUpDelayAtInit_d
+#define gPlatformSetWakeUpDelayAtInit_d 0
+#endif
+
+#endif /* FWK_CONFIG_ZEPHYR_H_ */

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw47_mcxw72/configs/fwk_config.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw47_mcxw72/configs/fwk_config.h
@@ -9,6 +9,14 @@
 
 #include "fwk_platform_definitions.h"
 
+/* On Zephyr, include the Zephyr-specific configuration overrides first so that
+ * they take precedence over the default values defined below (each flag is
+ * #ifndef-protected). This avoids duplicating the overrides in the Zephyr
+ * repository. */
+#ifdef __ZEPHYR__
+#include "fwk_config_zephyr.h"
+#endif
+
 /*********************************************************************
  *        General
  *********************************************************************/
@@ -182,6 +190,7 @@
  *********************************************************************/
 /* Enable NBU access to GPIO PORT D - This allows easier debugging when an issue is reported with a specific main core
  * binary.
+ * On kw45/mcxw71, kw47/mcxw72 use TRDC to authorize access. On kw43/mcxw70 enable pin control non secure.
  * \warning: Disabling this compile macro can impair the debug capability of the NBU for a specific main core binary.
  * \warning: This part of code can generate bus fault when trustzone is enabled (code executed in non secure mode).
  *      Reason is that TRDC_IDAU_CR can not be read. In this case, user shall disable this compile macro when running

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw47_mcxw72/configs/fwk_config_zephyr.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/kw47_mcxw72/configs/fwk_config_zephyr.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_CONFIG_ZEPHYR_H_
+#define FWK_CONFIG_ZEPHYR_H_
+
+/*
+ * Zephyr-specific framework configuration overrides.
+ *
+ * This file is included at the top of fwk_config.h under an #ifdef __ZEPHYR__
+ * guard, so it is compiled only for Zephyr builds. Because every flag in
+ * fwk_config.h is #ifndef-protected, any value defined here takes precedence
+ * over the default MCUXpresso SDK value.
+ *
+ * These overrides used to be maintained on the Zephyr side, in
+ * modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake.
+ * They are centralized here to avoid dual maintenance between the framework
+ * and the Zephyr integration.
+ */
+
+/* On Zephyr the ICS RX processing does not use the framework system workqueue */
+#ifndef gPlatformIcsUseWorkqueueRxProcessing_d
+#define gPlatformIcsUseWorkqueueRxProcessing_d 0
+#endif
+
+/* On Zephyr the Timer Manager is not used; Zephyr provides its own timer services */
+#ifndef gPlatformUseTimerManager_d
+#define gPlatformUseTimerManager_d 0
+#endif
+
+/* On Zephyr the framework HW parameter storage is not used */
+#ifndef gPlatformUseHwParameter_d
+#define gPlatformUseHwParameter_d 0
+#endif
+
+/* On Zephyr the NBU GPIO PORT D debug access is not enabled by the framework */
+#ifndef gPlatformNbuDebugGpioDAccessEnabled_d
+#define gPlatformNbuDebugGpioDAccessEnabled_d 0
+#endif
+
+/* On Zephyr the SFC config is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetSfcConfigAtInit_d
+#define gPlatformSetSfcConfigAtInit_d 0
+#endif
+
+/* On Zephyr the wake up delay is not sent to the NBU at init by the framework */
+#ifndef gPlatformSetWakeUpDelayAtInit_d
+#define gPlatformSetWakeUpDelayAtInit_d 0
+#endif
+
+#endif /* FWK_CONFIG_ZEPHYR_H_ */

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/mcxw23/configs/fwk_config.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/mcxw23/configs/fwk_config.h
@@ -9,6 +9,14 @@
 
 #include "fwk_platform_definitions.h"
 
+/* On Zephyr, include the Zephyr-specific configuration overrides first so that
+ * they take precedence over the default values defined below (each flag is
+ * #ifndef-protected). This avoids duplicating the overrides in the Zephyr
+ * repository. */
+#ifdef __ZEPHYR__
+#include "fwk_config_zephyr.h"
+#endif
+
 #define gPlatformRamStartAddress_c   (0x20004000U)
 #define gPlatformRamEndAddress_c     (0x2001FFFF)
 #define gPlatformFlashStartAddress_c (0)

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/mcxw23/configs/fwk_config_zephyr.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/mcxw23/configs/fwk_config_zephyr.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_CONFIG_ZEPHYR_H_
+#define FWK_CONFIG_ZEPHYR_H_
+
+/*
+ * Zephyr-specific framework configuration overrides.
+ *
+ * This file is included at the top of fwk_config.h under an #ifdef __ZEPHYR__
+ * guard, so it is compiled only for Zephyr builds. Because every flag in
+ * fwk_config.h is #ifndef-protected, any value defined here takes precedence
+ * over the default MCUXpresso SDK value.
+ *
+ * These overrides used to be maintained on the Zephyr side, in
+ * modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake.
+ * They are centralized here to avoid dual maintenance between the framework
+ * and the Zephyr integration.
+ */
+
+/* On Zephyr the Timer Manager is not used; Zephyr provides its own timer services */
+#ifndef gPlatformUseTimerManager_d
+#define gPlatformUseTimerManager_d 0
+#endif
+
+#endif /* FWK_CONFIG_ZEPHYR_H_ */

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/rw61x/configs/fwk_config.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/rw61x/configs/fwk_config.h
@@ -9,6 +9,14 @@
 
 #include "fwk_platform_definitions.h"
 
+/* On Zephyr, include the Zephyr-specific configuration overrides first so that
+ * they take precedence over the default values defined below (each flag is
+ * #ifndef-protected). This avoids duplicating the overrides in the Zephyr
+ * repository. */
+#ifdef __ZEPHYR__
+#include "fwk_config_zephyr.h"
+#endif
+
 #ifndef gPlatformUseHwParameter_d
 #define gPlatformUseHwParameter_d 0
 #endif

--- a/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/rw61x/configs/fwk_config_zephyr.h
+++ b/mcux/mcux-sdk-ng/middleware/mcuxsdk-middleware-connectivity-framework/platform/rw61x/configs/fwk_config_zephyr.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_CONFIG_ZEPHYR_H_
+#define FWK_CONFIG_ZEPHYR_H_
+
+/*
+ * Zephyr-specific framework configuration overrides.
+ *
+ * This file is included at the top of fwk_config.h under an #ifdef __ZEPHYR__
+ * guard, so it is compiled only for Zephyr builds. Because every flag in
+ * fwk_config.h is #ifndef-protected, any value defined here takes precedence
+ * over the default MCUXpresso SDK value.
+ *
+ * These overrides used to be maintained on the Zephyr side, in
+ * modules/hal_nxp/mcux/mcux-sdk-ng/middleware/connectivity_framework.cmake.
+ * They are centralized here to avoid dual maintenance between the framework
+ * and the Zephyr integration.
+ */
+
+/* On Zephyr the vendor specific init is disabled; Zephyr handles it itself */
+#ifndef gPlatformDisableVendorSpecificInit
+#define gPlatformDisableVendorSpecificInit 1U
+#endif
+
+/* On Zephyr the Timer Manager is not used; Zephyr provides its own timer services */
+#ifndef gPlatformUseTimerManager_d
+#define gPlatformUseTimerManager_d 0
+#endif
+
+#endif /* FWK_CONFIG_ZEPHYR_H_ */


### PR DESCRIPTION
Override default framework's configs with a specific config for Zephyr.
Not yet in use but will be in following release integrations.