### PR TITLE
wifi_nxp: replace CONFIG_WIFI_CORE_STACK_SIZE with CONFIG_NXP_WIFI_CO…

### DIFF
--- a/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
+++ b/mcux/middleware/wifi_nxp/sdio_nxp_abs/mlan_sdio.c
@@ -235,7 +235,7 @@ static void sdio_controller_init(void)
 static int sdio_card_init(void)
 {
     int ret = WM_SUCCESS;
-    uint32_t resp;
+    uint32_t resp = 0;
 
     if (!device_is_ready(sdhc_dev))
     {

--- a/mcux/middleware/wifi_nxp/wifidriver/wifi.c
+++ b/mcux/middleware/wifi_nxp/wifidriver/wifi.c
@@ -56,9 +56,6 @@ t_u64 csi_event_data_len = 0;
 extern wifi_ecsa_status_control ecsa_status_control;
 #endif
 
-#if !CONFIG_WIFI_CORE_STACK_SIZE
-#define CONFIG_WIFI_CORE_STACK_SIZE (2048)
-#endif
 
 #define MAX_MCAST_LEN (MLAN_MAX_MULTICAST_LIST_SIZE * MLAN_MAC_ADDR_LENGTH)
 #if CONFIG_WiFi_878x
@@ -146,7 +143,7 @@ typedef enum __mlan_status
 static void wifi_core_task(osa_task_param_t arg);
 
 /* OSA_TASKS: name, priority, instances, stackSz, useFloat */
-static OSA_TASK_DEFINE(wifi_core_task, OSA_PRIORITY_NORMAL, 1, CONFIG_WIFI_CORE_STACK_SIZE, 0);
+static OSA_TASK_DEFINE(wifi_core_task, OSA_PRIORITY_NORMAL, 1, CONFIG_NXP_WIFI_CORE_TASK_STACK_SIZE, 0);
 #endif
 
 static void wifi_scan_task(osa_task_param_t arg);


### PR DESCRIPTION
…RE_TASK_STACK_SIZE

CONFIG_NXP_WIFI_CORE_TASK_STACK_SIZE is now defined as a Kconfig option in Zephyr (merged in zephyrproject-rtos/zephyr#111487). Remove the local fallback definition of CONFIG_WIFI_CORE_STACK_SIZE and replace all usages with the new Kconfig option.