### PR TITLE
script: sync_msdk: Add script to sync SDK code to hal_nxp

### DIFF
--- a/mcux/import.yaml
+++ b/mcux/import.yaml
@@ -1,0 +1,149 @@
+# import.yaml
+#
+# Records the address, version, and restore steps (copy / remove / pin) of every
+# sync source in hal_nxp. See scripts/sync_msdk/import-schema.md for the schema,
+# and scripts/sync_msdk/sync-guide.md for the concepts and workflow.
+#
+
+entries:
+
+  - name: basic
+    description: "MCUXpresso SDK basic files (device headers, components)"
+    manifest:
+      repo: https://github.com/nxp-mcuxpresso/mcuxsdk-manifests
+      revision: v26.09.00-pvw2
+
+    sources:
+      - repo: https://github.com/nxp-mcuxpresso/mcuxsdk-core
+        name: mcuxsdk-core
+        revision: 88e69085dfaab35652ca79fdf3f05c7551eed601
+        dest_path: mcux/mcux-sdk-ng
+        copy:
+          - "^arch/arm/"
+          - "^arch/xtensa/"
+          - "^cmake/extension/basic_settings_lite.cmake"
+          - "^cmake/extension/function.cmake"
+          - "^cmake/extension/logging.cmake"
+          - "^drivers/"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-component
+        name: mcux-component
+        revision: 496290abd168b9fcee2fd6a16c12c14ae99d5f50
+        dest_path: mcux/mcux-sdk-ng/components
+        copy:
+          - "^conn_fwloader/"
+          - "^flash/fsl_flash\\.h$"
+          - "^flash/mflash/\\w*\\.[ch]$"
+          - "^flash/mflash/evkcmimxrt1060/"
+          - "^flash/mflash/rdrw612bga/"
+          - "^flash/nand/"
+          - "^flash/nor/"
+          - "^imu_adapter/"
+          - "^lists/"
+          - "^misc_utilities/"
+          - "^osa/"
+          - "^phy/"
+          - "^rpmsg/"
+          - "^wifi_bt_module/"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-imx
+        name: mcux-devices-imx
+        revision: c44c70545f236cf75b9f3a5a72c6694816593ca6
+        dest_path: mcux/mcux-sdk-ng/devices/i.MX
+        copy:
+          - ".*"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-rt
+        name: mcux-devices-rt
+        revision: 5aca9adfa3dd9be25fb31144dc52a5a845fd95aa
+        dest_path: mcux/mcux-sdk-ng/devices/RT
+        copy:
+          - ".*"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-kinetis
+        name: mcux-devices-kinetis
+        revision: b8c9e31246223da57b9e85bfe638da9a853bf125
+        dest_path: mcux/mcux-sdk-ng/devices/Kinetis
+        copy:
+          - ".*"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-lpc
+        name: mcux-devices-lpc
+        revision: fdf4429f3dda7f427bf4ef438a0e85fca083e178
+        dest_path: mcux/mcux-sdk-ng/devices/LPC
+        copy:
+          - ".*"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-mcx
+        name: mcux-devices-mcx
+        revision: fcdafec0dec36f939375b3c67a40967c98dde0f8
+        dest_path: mcux/mcux-sdk-ng/devices/MCX
+        copy:
+          - ".*"
+
+      - repo: https://github.com/nxp-mcuxpresso/mcux-devices-wireless
+        name: mcux-devices-wireless
+        revision: e565121a5b815d43e85144ee6f34d53f758822eb
+        dest_path: mcux/mcux-sdk-ng/devices/Wireless
+        copy:
+          - ".*"
+
+    actions:
+      - type: remove
+        patterns:
+          - "^mcux/mcux-sdk-ng/(devices|components|drivers|arch)/(.*/)?Kconfig[^/]*$"
+          - "^mcux/mcux-sdk-ng/(devices|components|drivers)/(.*/)?[Dd]oxygen(/|$)"
+      - type: remove
+        patterns:
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?example(/|$)"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?arm(/|$)"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?xtensa(/|$)"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?README\\.md$"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?RTE_Device\\.h$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.yml$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.icf$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.ld$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.scf$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.FLM$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.sdf$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.a$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.lib$"
+          - "^mcux/mcux-sdk-ng/devices/.*\\.dbgconf$"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?startup[^/]*\\.(s|S|c|cpp)$"
+          - "^mcux/mcux-sdk-ng/devices/.*/mcuxpresso/startup_[^/]*\\.cpp$"
+          - "^mcux/mcux-sdk-ng/devices/(.*/)?prj\\.conf$"
+          - "^mcux/mcux-sdk-ng/drivers/.*/\\.gitignore$"
+          - "^mcux/mcux-sdk-ng/drivers/.*\\.template$"
+          - "^mcux/mcux-sdk-ng/drivers/.*\\.dox$"
+          - "^mcux/mcux-sdk-ng/drivers/\\.gitignore$"
+          - "^mcux/mcux-sdk-ng/drivers/.*/template\\.readme$"
+          - "^mcux/mcux-sdk-ng/arch/arm/target/.*$"
+    drop_patch:
+      - bc22c70f46957b2a8d3855f71a560ac417dc8287
+      - 6c77523dfdfc5a1ecefbafb31feee6499a5de8ec
+      - 4ed7196fbaab68050354b6c359ed6ecd567a5fd8
+      - fbb03f0e57d0b771a2b06c66525b866bd93881aa
+      - 650b0cbf1053bc99c00a56bce487dd2639fb2ae5
+
+  - name: usb
+    description: "NXP MCUXpresso SDK USB middleware"
+    manifest:
+      repo: https://github.com/nxp-mcuxpresso/mcuxsdk-manifests
+      revision: 02c9635cb200291d1664aefdd6a48aee5f4901d6
+
+    sources:
+      - repo: https://github.com/nxp-mcuxpresso/mcuxsdk-middleware-usb
+        name: mcuxsdk-middleware-usb   # TODO: confirm the GitHub repo name
+        revision: <revision-here>   # TODO: resolve from manifest and fill in, source branch: release/25.12.00-pvw2
+        note: "from branch: release/25.12.00-pvw2"
+        dest_path: mcux/mcux-sdk-ng/middleware/usb
+        copy:
+          - ".*"
+
+    actions:
+      - type: remove
+        patterns:
+          - "^mcux/.*\\.a$"
+          - "^mcux/mcux-sdk-ng/middleware/usb/(.*/)?Kconfig[^/]*$"
+          - "^mcux/mcux-sdk-ng/middleware/usb/example(/|$)"
+          - "^mcux/mcux-sdk-ng/middleware/usb/docs(/|$)"

--- a/mcux/scripts/sync_msdk/_sync/__init__.py
+++ b/mcux/scripts/sync_msdk/_sync/__init__.py
@@ -1,0 +1,14 @@
+"""Internal package for the hal_nxp sync driver.
+
+The public entry point is scripts/sync_msdk/sync_msdk.py; this package holds the
+implementation split into cohesive modules:
+
+  gitutil    - thin wrappers around git/subprocess
+  config     - import.yaml load/save and SDK-dir resolution
+  manifest   - west manifest parsing and source-clone location
+  patches    - Patch model, trailer parsing, dest_path ownership
+  checkpoint - sync checkpoint markers and the import snapshot commit
+  actions    - copy / remove / pin execution
+  conflicts  - interactive cherry-pick conflict resolution
+  commands   - the `update` and `sync` subcommands
+"""

--- a/mcux/scripts/sync_msdk/_sync/actions.py
+++ b/mcux/scripts/sync_msdk/_sync/actions.py
@@ -1,0 +1,251 @@
+"""Phase-2 copy / remove / pin execution, plus the update-time deletion scan."""
+
+import re
+import subprocess
+from pathlib import Path
+
+from .gitutil import (GIT_ARGV_CHUNK, print_capped, run, run_git_chunked,
+                      run_status)
+from .manifest import ensure_revision, resolve_source_clone
+
+
+# ---------------------------------------------------------------------------
+# Upstream deletion scan (used by `update`)
+# ---------------------------------------------------------------------------
+
+def upstream_deleted_files(clone: Path, old_rev: str, new_rev: str,
+                           copy_pats: list[str], dest_rel: str) -> list[str]:
+    """hal_nxp-root-relative paths DELETED between `old_rev` and `new_rev`.
+
+    Restricted to files the source actually copies (matching `copy_pats`). Each
+    returned path is `dest_rel/<repo-relative-path>`, i.e. exactly where the file
+    lives in hal_nxp, so it can feed a `type: remove` action verbatim. Files
+    upstream deletes are otherwise invisible to the Phase-2 overlay copy.
+    """
+    diff = run(
+        ["git", "diff", "--name-only", "--diff-filter=D",
+         f"{old_rev}", f"{new_rev}"],
+        clone, capture=True, check=False,
+    )
+    copy_res = [re.compile(p) for p in copy_pats]
+    deleted = []
+    for rel in diff.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        # A source with copy patterns only owns files those patterns match.
+        if copy_res and not any(r.search(rel) for r in copy_res):
+            continue
+        deleted.append(f"{dest_rel}/{rel}" if dest_rel else rel)
+    return deleted
+
+
+def append_remove_action(entry, paths: list[str]) -> int:
+    """Record `paths` into the entry's `actions` as a `type: remove` action.
+
+    Patterns are anchored, regex-escaped (`^<path>$`) so each matches exactly one
+    file, and are appended to an existing auto-generated remove action when
+    present (or a new one otherwise), skipping duplicates. Returns the number of
+    newly added patterns. The action is tagged with an auto-generated `note` so
+    re-running `update` reuses the same block.
+    """
+    if not paths:
+        return 0
+    auto_note = "auto: upstream-deleted files (added by sync_msdk.py update)"
+    actions = entry.get("actions")
+    if actions is None:
+        actions = []
+        entry["actions"] = actions
+
+    target = None
+    for action in actions:
+        if action.get("type") == "remove" and action.get("note") == auto_note:
+            target = action
+            break
+    if target is None:
+        target = {"type": "remove", "note": auto_note, "patterns": []}
+        actions.append(target)
+    if target.get("patterns") is None:
+        target["patterns"] = []
+
+    existing = set(target["patterns"])
+    added = 0
+    for p in paths:
+        pat = f"^{re.escape(p)}$"
+        if pat not in existing:
+            target["patterns"].append(pat)
+            existing.add(pat)
+            added += 1
+    return added
+
+
+def source_deleted_files(src: dict, old_rev, new_rev, manifest_paths: dict,
+                         sdk_dir: Path) -> list[str]:
+    """Best-effort list of paths this source deletes going old_rev -> new_rev.
+
+    Locates the source's local clone, guarantees both revisions are present
+    (fetching if needed), then delegates to upstream_deleted_files(). Returns []
+    (with a warning) when the clone or a revision cannot be resolved, so `update`
+    never aborts on it.
+    """
+    name = src.get("name", "?")
+    dest_rel = (src.get("dest_path") or "").strip("/")
+    copy_pats = src.get("copy") or []
+    clone = resolve_source_clone(src, manifest_paths, sdk_dir)
+    if not clone:
+        print(f"  WARNING: {name}: clone not found under {sdk_dir}; "
+              f"cannot compute upstream deletions.")
+        return []
+    for rev in (old_rev, new_rev):
+        if not ensure_revision(clone, src.get("repo"), str(rev)):
+            print(f"  WARNING: {name}: revision {str(rev)[:12]} not in clone "
+                  f"and could not be fetched; skipping deletion scan.")
+            return []
+    return upstream_deleted_files(clone, str(old_rev), str(new_rev),
+                                  copy_pats, dest_rel)
+
+
+# ---------------------------------------------------------------------------
+# Copy (Phase 2a)
+# ---------------------------------------------------------------------------
+
+def copy_sources(entry: dict, hal_root: Path, west_topdir: Path,
+                 manifest_paths: dict, dry_run: bool) -> int:
+    """Overlay each source's `copy`-matched files at its `revision` into dest_path.
+
+    The exact pinned `revision` is fetched into the clone first (see
+    ensure_revision): the extraction always reads the pinned SHA, never
+    "whatever is currently checked out". Overlay semantics (no pre-clean): files
+    deleted upstream are handled by `update` appending them to a `remove` action.
+    Returns the number of files copied (0 in dry-run, but still validates), or
+    -1 on error.
+    """
+    total = 0
+    for src in entry.get("sources", []):
+        name = src.get("name", "?")
+        rev = src.get("revision")
+        dest_rel = (src.get("dest_path") or "").strip("/")
+        copy_pats = src.get("copy") or []
+        if not rev or "<" in str(rev):
+            print(f"  [copy] {name}: SKIP (revision unresolved: {rev})")
+            continue
+        clone = resolve_source_clone(src, manifest_paths, west_topdir)
+        if not clone:
+            print(f"  [copy] {name}: ERROR clone not found under {west_topdir}")
+            return -1
+        # Guarantee the EXACT pinned revision is available before extraction.
+        if not ensure_revision(clone, src.get("repo"), rev):
+            print(f"  [copy] {name}: ERROR revision {str(rev)[:12]} not in "
+                  f"clone {clone} and could not be fetched from "
+                  f"{src.get('repo') or 'origin'}")
+            return -1
+
+        copy_res = [re.compile(p) for p in copy_pats]
+        files = run(["git", "ls-tree", "-r", "--name-only", rev],
+                    clone, capture=True).splitlines()
+        matched = [f for f in files if any(r.search(f) for r in copy_res)]
+        # dest_path is already relative to the hal_nxp git root.
+        dest_root = hal_root / dest_rel
+
+        print(f"  [copy] {name} @ {str(rev)[:12]}: {len(matched)} file(s) "
+              f"-> {dest_root.relative_to(hal_root)}")
+        if dry_run:
+            total += len(matched)
+            continue
+        # Stream the selected paths out of the clone at the exact revision via
+        # `git archive` and untar straight into the destination. This preserves
+        # each file's repo-relative path and never touches the clone's worktree.
+        dest_root.mkdir(parents=True, exist_ok=True)
+        # git archive has an argv length limit; chunk the path list.
+        for i in range(0, len(matched), GIT_ARGV_CHUNK):
+            chunk = matched[i:i + GIT_ARGV_CHUNK]
+            archive = run_status(
+                ["git", "archive", "--format=tar", rev, "--"] + chunk,
+                clone, text=False,
+            )
+            if archive.returncode != 0:
+                print(f"  [copy] {name}: git archive failed: "
+                      f"{archive.stderr.decode(errors='replace')}")
+                return -1
+            untar = run_status(
+                ["tar", "-x", "-C", str(dest_root)],
+                clone, input_bytes=archive.stdout, text=False,
+            )
+            if untar.returncode != 0:
+                print(f"  [copy] {name}: tar extract failed: "
+                      f"{untar.stderr.decode(errors='replace')}")
+                return -1
+        total += len(matched)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Actions: remove / pin (Phase 2a)
+# ---------------------------------------------------------------------------
+
+def _iter_repo_files(hal_root: Path) -> list[str]:
+    """All tracked + untracked (non-ignored) files, relative to hal_root."""
+    out = run(["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+              hal_root, capture=True)
+    return [l for l in out.splitlines() if l]
+
+
+def apply_actions(entry: dict, hal_root: Path, dry_run: bool) -> int:
+    """Execute the entry-level `actions` list in order (`remove` and `pin`).
+
+    Patterns/files are Python regexes matched against paths relative to the
+    hal_nxp repo root. Returns 0 on success, -1 on error.
+    """
+    actions = entry.get("actions") or []
+    if not actions:
+        print("  [actions] none")
+        return 0
+    for idx, action in enumerate(actions):
+        atype = action.get("type")
+        if atype == "remove":
+            rc = _apply_remove(action, idx, hal_root, dry_run)
+        elif atype == "pin":
+            rc = _apply_pin(action, idx, hal_root, dry_run)
+        else:
+            print(f"  [action #{idx}] ERROR unsupported type: {atype}")
+            return -1
+        if rc < 0:
+            return -1
+    return 0
+
+
+def _apply_remove(action: dict, idx: int, hal_root: Path, dry_run: bool) -> int:
+    pats = [re.compile(p) for p in (action.get("patterns") or [])]
+    files = _iter_repo_files(hal_root)
+    victims = [f for f in files if any(r.search(f) for r in pats)]
+    print(f"  [remove #{idx}] {len(victims)} file(s) match {len(pats)} pattern(s)")
+    if dry_run:
+        print_capped(victims)
+        return 0
+    for v in victims:
+        fp = hal_root / v
+        try:
+            if fp.is_file() or fp.is_symlink():
+                fp.unlink()
+        except OSError as e:
+            print(f"      WARN could not remove {v}: {e}")
+    return 0
+
+
+def _apply_pin(action: dict, idx: int, hal_root: Path, dry_run: bool) -> int:
+    commit = action.get("commit") or "HEAD"
+    file_res = [re.compile(p) for p in (action.get("patterns") or [])]
+    # Enumerate files present at that commit, keep matches, check them out.
+    tree = run(["git", "ls-tree", "-r", "--name-only", commit],
+               hal_root, capture=True, check=False).splitlines()
+    targets = [f for f in tree if any(r.search(f) for r in file_res)]
+    print(f"  [pin #{idx}] {len(targets)} file(s) from {commit[:12]}")
+    if dry_run:
+        print_capped(targets)
+        return 0
+    try:
+        run_git_chunked(["git", "checkout", "-q", commit], targets, hal_root)
+    except subprocess.CalledProcessError as e:
+        print(f"      ERROR git checkout failed: {e}")
+        return -1
+    return 0

--- a/mcux/scripts/sync_msdk/_sync/checkpoint.py
+++ b/mcux/scripts/sync_msdk/_sync/checkpoint.py
@@ -1,0 +1,86 @@
+"""Sync checkpoint markers and the imported-snapshot commit.
+
+The import snapshot commit carries the `mcux-sync-<entry>` marker in its title
+(per-source SHAs in its body), so it doubles as the checkpoint for the next
+sync. No separate empty marker commit is created.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from .gitutil import run
+
+
+def checkpoint_marker(entry_name: str) -> str:
+    return f"mcux-sync-{entry_name}"
+
+
+def find_last_checkpoint(hal_root: Path, entry_name: str) -> Optional[str]:
+    """SHA of the most recent commit whose title starts with the marker, or None."""
+    marker = checkpoint_marker(entry_name)
+    out = run(
+        ["git", "log", "--format=%H %s", "-n", "2000"],
+        hal_root, capture=True, check=False,
+    )
+    for line in out.splitlines():
+        sha, _, subject = line.partition(" ")
+        if subject.startswith(marker):
+            return sha
+    return None
+
+
+def entry_dest_prefixes(entry: dict) -> list[str]:
+    """Return the dest_path prefixes for every source in the entry.
+
+    dest_path is already relative to the hal_nxp git root (starts with the mcux/
+    prefix), so it is used verbatim. Used to scope `git add` so the import commit
+    only stages the trees this entry manages.
+    """
+    prefixes = []
+    for src in entry.get("sources", []):
+        dest = (src.get("dest_path") or "").strip("/")
+        if dest:
+            prefixes.append(dest)
+    return prefixes
+
+
+def commit_import(hal_root: Path, entry: dict, dry_run: bool) -> bool:
+    """Stage the entry's dest_path trees and commit them as the upstream snapshot.
+
+    This commit MUST exist before patches are re-applied so cherry-pick runs on
+    top of the new upstream tree, not the stale previous HEAD. Returns True if a
+    commit was created (or would be, in dry-run), False if nothing to commit.
+    """
+    prefixes = entry_dest_prefixes(entry)
+    if not prefixes:
+        print("  [import] no dest paths to stage")
+        return False
+    # -A picks up new/modified/deleted files under each prefix.
+    run(["git", "add", "-A", "--"] + prefixes, hal_root)
+    staged = run(["git", "diff", "--cached", "--name-only"],
+                 hal_root, capture=True, check=False)
+    if not staged.strip():
+        print("  [import] tree already matches upstream; nothing to commit")
+        return False
+    n_staged = len([l for l in staged.splitlines() if l.strip()])
+    marker = checkpoint_marker(entry["name"])
+    man_rev = (entry.get("manifest") or {}).get("revision", "?")
+    title = f"{marker}: import {entry['name']} sources @ {man_rev}"
+    # Record the per-source revisions in the body: this commit carries the
+    # imported tree AND doubles as the sync checkpoint.
+    # `- name: revision` list form (not bare `name: revision`): the leading
+    # `- ` stops git from treating these as a trailer block, so `git commit -s`
+    # leaves a blank line before the appended Signed-off-by.
+    body_lines = [
+        f"- {src.get('name', '?')}: {src.get('revision', '?')}"
+        for src in entry.get("sources", [])
+    ]
+    message = title + ("\n\n" + "\n".join(body_lines) + "\n" if body_lines
+                       else "")
+    if dry_run:
+        print(f"[dry-run] would commit imported snapshot ({n_staged} path(s)):\n"
+              f"{message}\n")
+        return True
+    run(["git", "commit", "-q", "-s", "-m", message], hal_root)
+    print(f"Committed imported snapshot ({n_staged} path(s)): {title}")
+    return True

--- a/mcux/scripts/sync_msdk/_sync/commands.py
+++ b/mcux/scripts/sync_msdk/_sync/commands.py
@@ -1,0 +1,295 @@
+"""The `update` (Phase 1) and `sync` (Phase 2) subcommands."""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .actions import (append_remove_action, apply_actions, copy_sources,
+                      source_deleted_files)
+from .checkpoint import commit_import, find_last_checkpoint
+from .config import (IMPORT_YAML, SCRIPT_DIR, find_entry, load_import_yaml,
+                     load_import_yaml_rt, manifest_repo_for, resolve_sdk_dir,
+                     save_import_yaml_rt)
+from .conflicts import resolve_conflict_interactively, skip_if_cherry_pick_empty
+from .gitutil import git_toplevel, is_ancestor, print_capped, run_status
+from .manifest import (build_manifest_path_map, ensure_revision,
+                       parse_manifest_projects, resolve_source_clone)
+from .patches import (Patch, build_prefix_table, collect_patches,
+                      entry_dropped_shas, patch_belongs_to_entry)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: update
+# ---------------------------------------------------------------------------
+
+def cmd_update(args) -> int:
+    """Resolve every source's revision for an entry from the west manifest.
+
+    Writes the resolved SHAs (and the manifest revision) back into import.yaml
+    in place, preserving comments/formatting. For each source whose revision
+    changes, diffs the old vs new upstream tree (restricted to the source's
+    `copy` patterns) and appends every upstream-deleted file to a `type: remove`
+    action, so the maintainer can review the removals before running the sync.
+    """
+    # ruamel round-trip so comments in import.yaml survive the write.
+    y, data = load_import_yaml_rt(IMPORT_YAML)
+    entry = find_entry(data, args.entry)
+    sources = entry.get("sources", [])
+    print(f"Entry '{args.entry}': {len(sources)} source(s)")
+
+    sdk_dir = resolve_sdk_dir(args)
+    manifest_repo = manifest_repo_for(sdk_dir)
+    if not (manifest_repo / ".git").exists():
+        print(f"Error: manifest repo not found at {manifest_repo} "
+              f"(expected <sdk-dir>/manifests; set --sdk-dir or MCUX_SDK_DIR)",
+              file=sys.stderr)
+        return 1
+
+    # Manifest revision to resolve against: explicit --manifest, else the value
+    # already recorded on the entry.
+    man_rev = args.manifest or (entry.get("manifest") or {}).get("revision")
+    if not man_rev:
+        print("Error: no manifest revision given (pass --manifest or set "
+              "entry.manifest.revision)", file=sys.stderr)
+        return 1
+    print(f"Resolving revisions from manifest {manifest_repo} @ {man_rev}")
+
+    projects = parse_manifest_projects(manifest_repo, man_rev)
+    if not projects:
+        print(f"Error: no projects parsed from manifest at {man_rev}",
+              file=sys.stderr)
+        return 1
+
+    # Locate each source's local clone so old->new trees can be diffed.
+    manifest_paths = build_manifest_path_map(manifest_repo, man_rev)
+
+    updates, missing, deleted_paths = _resolve_source_revisions(
+        sources, projects, manifest_paths, sdk_dir)
+
+    # Refresh the entry-level manifest revision too.
+    if entry.get("manifest") is not None:
+        entry["manifest"]["revision"] = man_rev
+
+    for name, old, new in updates:
+        print(f"  {name}: {str(old)[:12]} -> {str(new)[:12]}")
+    if not updates:
+        print("  (all source revisions already up to date)")
+    if missing:
+        print(f"  WARNING: {len(missing)} source(s) not found in manifest: "
+              f"{', '.join(missing)}")
+
+    # Record upstream-deleted files into a `remove` action for review.
+    added = append_remove_action(entry, deleted_paths) if deleted_paths else 0
+    if deleted_paths:
+        print(f"  {len(deleted_paths)} file(s) deleted upstream; "
+              f"{added} new remove pattern(s) queued for review:")
+        print_capped(deleted_paths)
+
+    if args.dry_run:
+        print(f"[dry-run] would update {len(updates)} revision(s), the manifest "
+              f"revision, and {added} remove pattern(s) in {IMPORT_YAML.name}.")
+        return 0
+
+    save_import_yaml_rt(y, data, IMPORT_YAML)
+    print(f"Wrote {len(updates)} revision update(s) and {added} remove "
+          f"pattern(s) to {IMPORT_YAML.name}.")
+    return 0
+
+
+def _resolve_source_revisions(sources, projects, manifest_paths, sdk_dir):
+    """Resolve each source's new revision; collect updates, misses, deletions.
+
+    Mutates each source's `revision` in place. Returns
+    (updates, missing, deleted_paths) where updates is [(name, old, new)].
+    """
+    updates = []
+    missing = []
+    deleted_paths = []   # hal_nxp-root-relative paths deleted upstream
+    for src in sources:
+        name = src.get("name")
+        if not name:
+            continue
+        new_rev = projects.get(name)
+        if not new_rev:
+            missing.append(name)
+            continue
+        old_rev = src.get("revision")
+        if str(old_rev) != str(new_rev):
+            updates.append((name, old_rev, new_rev))
+            # Diff old->new upstream tree for files this source copies that were
+            # deleted upstream. Best-effort: skip silently if unavailable.
+            deleted_paths += source_deleted_files(
+                src, old_rev, new_rev, manifest_paths, sdk_dir)
+        src["revision"] = new_rev
+    return updates, missing, deleted_paths
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: sync
+# ---------------------------------------------------------------------------
+
+def _load_manifest_paths(entry: dict, sdk_dir: Path) -> dict:
+    """Locate each source's local clone path via the west manifest, if available."""
+    manifest_repo = manifest_repo_for(sdk_dir)
+    man_rev = (entry.get("manifest") or {}).get("revision")
+    if manifest_repo and (manifest_repo / ".git").exists() and man_rev:
+        return build_manifest_path_map(manifest_repo, man_rev)
+    return {}
+
+
+def select_entry_patches(data: dict, entry: dict, hal_root: Path,
+                         since: Optional[str]) -> list[Patch]:
+    """Collect the checkpoint range and keep ONLY patches belonging to this entry.
+
+    The range is shared by every team's entry, so it contains unrelated patches
+    and patches with no trailer. Classification is by the files each commit
+    changes, resolving nested west dest_paths with longest-prefix-wins.
+    """
+    all_patches = collect_patches(hal_root, since)
+    prefix_table = build_prefix_table(data)
+    repo_names = {
+        src.get("name") for src in entry.get("sources", []) if src.get("name")
+    }
+    patches = [
+        p for p in all_patches
+        if patch_belongs_to_entry(p, entry, hal_root, prefix_table, repo_names)
+    ]
+    print(f"{len(all_patches)} patch(es) in range; {len(patches)} belong to "
+          f"entry '{entry.get('name')}'.")
+    return patches
+
+
+def upstream_has_patch(src: dict, upstream_sha: str, new_release_sha: str,
+                       manifest_paths: dict, sdk_dir: Path) -> bool:
+    """Answer "has this patch already reached the release being synced?"
+
+    Tests, INSIDE THE SOURCE'S UPSTREAM CLONE, whether `upstream_sha` is an
+    ancestor of `new_release_sha` (the revision import.yaml pins for this
+    source). Conservative on any uncertainty (returns False -> the patch
+    re-applies): when the clone can't be located, or either commit can't be made
+    present in it (fetched if missing), we do NOT skip the patch.
+    """
+    clone = resolve_source_clone(src, manifest_paths, sdk_dir)
+    if not clone:
+        return False
+    for rev in (upstream_sha, new_release_sha):
+        if not ensure_revision(clone, src.get("repo"), str(rev)):
+            return False
+    return is_ancestor(clone, upstream_sha, new_release_sha)
+
+
+def compute_reapply_set(patches: list[Patch], entry: dict, hal_root: Path,
+                        manifest_paths: dict, sdk_dir: Path) -> list[Patch]:
+    """Decide skip vs re-apply for each entry patch; return the re-apply set.
+
+    A drop_patch listing wins over everything; otherwise an SDK-origin patch
+    whose upstream commit is already an ancestor of the new release is skipped;
+    all other patches re-apply.
+    """
+    # repo name -> its source dict (carries revision, repo URL, clone hints).
+    src_by_repo = {
+        src.get("name"): src
+        for src in entry.get("sources", [])
+        if src.get("name")
+    }
+    dropped_shas = entry_dropped_shas(entry, hal_root)
+
+    to_reapply = []
+    for p in patches:
+        src = src_by_repo.get(p.upstream_repo) if p.upstream_repo else None
+        new_sha = src.get("revision") if src else None
+
+        verdict = "re-apply"
+        if p.hal_sha in dropped_shas:
+            verdict = "skip (drop_patch)"
+        # Only SDK-origin patches with a resolvable upstream SHA can be skipped
+        # by the ancestor test; trailer-less or hal_nxp-origin patches always
+        # re-apply. Ignore unresolved "<...>" placeholder revisions.
+        elif src and p.upstream_sha and new_sha and "<" not in str(new_sha):
+            if upstream_has_patch(src, p.upstream_sha, str(new_sha),
+                                  manifest_paths, sdk_dir):
+                verdict = "skip (already present)"
+
+        if verdict.startswith("skip"):
+            print(f"  SKIP    {p.hal_sha[:12]} {p.subject[:56]}  ({verdict})")
+        else:
+            print(f"  REAPPLY {p.hal_sha[:12]} {p.subject[:56]}")
+            to_reapply.append(p)
+    return to_reapply
+
+
+def apply_patches(to_reapply: list[Patch], hal_root: Path, dry_run: bool) -> int:
+    """Cherry-pick the re-apply set on top of the imported snapshot, in order.
+
+    Empty cherry-picks (change already present) are skipped; conflicts pause for
+    interactive resolution on a TTY and abort otherwise. Returns 0 on success, 1
+    if the sync was aborted.
+    """
+    print(f"\n{len(to_reapply)} patch(es) to re-apply on top of the imported "
+          f"snapshot.")
+    # Re-apply by cherry-picking the hal_nxp commits (they still carry
+    # trailers). Deliberately NOT using `-x`: patch provenance is already tracked
+    # by the trailers, so the original commit message is kept verbatim.
+    for p in to_reapply:
+        if dry_run:
+            print(f"[dry-run] git cherry-pick {p.hal_sha[:12]}")
+            continue
+
+        r = run_status(["git", "cherry-pick", p.hal_sha], hal_root)
+        if r.returncode != 0:
+            if skip_if_cherry_pick_empty(hal_root, r):
+                print(f"Skipped {p.hal_sha[:12]} (already present / empty).")
+                continue
+            print(f"cherry-pick conflict for {p.hal_sha[:12]}:\n"
+                  f"{r.stdout}\n{r.stderr}")
+            # A conflict is not fatal: let the developer resolve it by hand and
+            # continue. When stdin is not a TTY (CI / piped input) we abort.
+            if not resolve_conflict_interactively(hal_root, p):
+                run_status(["git", "cherry-pick", "--abort"], hal_root)
+                print("Aborted. Resolve manually and re-run with --since-sha.")
+                return 1
+            continue
+        print(f"Re-applied {p.hal_sha[:12]}")
+    return 0
+
+
+def cmd_sync(args) -> int:
+    hal_root = git_toplevel(SCRIPT_DIR)
+    data = load_import_yaml(IMPORT_YAML)
+    entry = find_entry(data, args.entry)
+
+    # Phase 2a: copy upstream sources, apply the entry's remove/pin actions, then
+    # commit the imported snapshot. This snapshot commit carries the
+    # `mcux-sync-<entry>` checkpoint marker and MUST exist before the patch
+    # re-apply below, so the cherry-picks land on top of the fresh upstream tree.
+    sdk_dir = resolve_sdk_dir(args)
+    west_topdir = sdk_dir
+    manifest_paths = _load_manifest_paths(entry, sdk_dir)
+    print(f"Copying sources into hal_nxp (west topdir {west_topdir}) ...")
+    if copy_sources(entry, hal_root, west_topdir, manifest_paths,
+                    args.dry_run) < 0:
+        print("Copy step failed; aborting before touching history.")
+        return 1
+    if apply_actions(entry, hal_root, args.dry_run) < 0:
+        print("Action step failed; aborting.")
+        return 1
+    commit_import(hal_root, entry, args.dry_run)
+
+    # Phase 2b: find the scan range, keep this entry's patches, decide skip vs
+    # re-apply, then cherry-pick the re-apply set on top of the snapshot.
+    since = args.since_sha or find_last_checkpoint(hal_root, args.entry)
+    if since:
+        print(f"Scanning patches since checkpoint {since[:12]}")
+    else:
+        print("No checkpoint found; scanning full history for patches.")
+
+    patches = select_entry_patches(data, entry, hal_root, since)
+    to_reapply = compute_reapply_set(patches, entry, hal_root,
+                                     manifest_paths, sdk_dir)
+    if apply_patches(to_reapply, hal_root, args.dry_run) != 0:
+        return 1
+
+    # No trailing checkpoint commit: the import snapshot commit made by
+    # commit_import already carries the `mcux-sync-<entry>` marker and per-source
+    # SHAs, so find_last_checkpoint() uses THAT commit as the next boundary.
+    return 0

--- a/mcux/scripts/sync_msdk/_sync/config.py
+++ b/mcux/scripts/sync_msdk/_sync/config.py
@@ -1,0 +1,86 @@
+"""import.yaml loading/saving and SDK-dir (west topdir) resolution."""
+
+import os
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(1)
+
+
+# Layout: mcux/scripts/sync_msdk/_sync/config.py
+#   this file    -> _sync/
+#   .parent      -> sync_msdk/   (SCRIPT_DIR: holds sync_msdk.py)
+#   .parent x3   -> mcux/        (holds import.yaml)
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+IMPORT_YAML = SCRIPT_DIR.parent.parent / "import.yaml"
+
+
+def load_import_yaml(path: Path) -> dict:
+    """Read-only load of import.yaml (comments discarded)."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# ruamel round-trips YAML while preserving comments, key order and formatting.
+# `update` edits import.yaml in place (only the resolved `revision:` scalars),
+# so it must NOT go through yaml.safe_dump (that would strip every comment).
+def _ruamel():
+    try:
+        from ruamel.yaml import YAML
+    except ImportError:
+        print("Error: ruamel.yaml is required for 'update' "
+              "(pip install ruamel.yaml)", file=sys.stderr)
+        raise SystemExit(1)
+    y = YAML()
+    y.preserve_quotes = True
+    # import.yaml uses 2-space block indent with a 2-space sequence offset.
+    y.indent(mapping=2, sequence=4, offset=2)
+    y.width = 4096  # don't wrap long scalars/comments
+    return y
+
+
+def load_import_yaml_rt(path: Path):
+    """Comment-preserving (round-trip) load; returns (yaml, data)."""
+    y = _ruamel()
+    with open(path) as f:
+        return y, y.load(f)
+
+
+def save_import_yaml_rt(y, data, path: Path) -> None:
+    with open(path, "w") as f:
+        y.dump(data, f)
+
+
+def resolve_sdk_dir(args) -> Path:
+    """Resolve the MCUX SDK dir, which IS the west workspace topdir.
+
+    Preference order:
+      1. the --sdk-dir argument, when given;
+      2. the MCUX_SDK_DIR environment variable.
+
+    This single directory holds the source clones (west topdir), and its
+    `manifests` subdirectory is the west manifest git clone.
+    """
+    raw = getattr(args, "sdk_dir", None) or os.environ.get("MCUX_SDK_DIR")
+    if not raw:
+        print("Error: SDK dir not set (pass --sdk-dir or set MCUX_SDK_DIR)",
+              file=sys.stderr)
+        raise SystemExit(1)
+    return Path(raw).expanduser().resolve()
+
+
+def manifest_repo_for(sdk_dir: Path) -> Path:
+    """The west manifest git clone lives at <sdk_dir>/manifests."""
+    return sdk_dir / "manifests"
+
+
+def find_entry(data: dict, name: str) -> dict:
+    for e in data.get("entries", []):
+        if e.get("name") == name:
+            return e
+    print(f"Error: entry '{name}' not found in {IMPORT_YAML}", file=sys.stderr)
+    raise SystemExit(1)

--- a/mcux/scripts/sync_msdk/_sync/conflicts.py
+++ b/mcux/scripts/sync_msdk/_sync/conflicts.py
@@ -1,0 +1,116 @@
+"""Interactive cherry-pick conflict resolution."""
+
+import os
+import sys
+from pathlib import Path
+
+from .gitutil import combined_output, print_capped, run, run_status
+from .patches import Patch
+
+
+def conflicted_files(hal_root: Path) -> list[str]:
+    """Paths git currently reports as unmerged (conflicted)."""
+    out = run(["git", "diff", "--name-only", "--diff-filter=U"],
+              hal_root, capture=True, check=False)
+    return [l.strip() for l in out.splitlines() if l.strip()]
+
+
+def cherry_pick_in_progress(hal_root: Path) -> bool:
+    """True while a cherry-pick sequence is still active (CHERRY_PICK_HEAD set)."""
+    git_dir = run(["git", "rev-parse", "--git-dir"], hal_root, capture=True)
+    return (hal_root / git_dir / "CHERRY_PICK_HEAD").exists()
+
+
+def skip_if_cherry_pick_empty(hal_root: Path, proc) -> bool:
+    """If a failed cherry-pick came out "empty", run `--skip` and return True.
+
+    An empty cherry-pick means the change is already in HEAD. Returns False when
+    it was a genuine (non-empty) failure the caller must handle.
+    """
+    if "empty" in combined_output(proc).lower():
+        run_status(["git", "cherry-pick", "--skip"], hal_root)
+        return True
+    return False
+
+
+def resolve_conflict_interactively(hal_root: Path, patch: Patch) -> bool:
+    """Pause on a cherry-pick conflict and let the developer resolve it by hand.
+
+    Returns True when the conflict has been dealt with (committed/continued or
+    skipped) and the sync loop may proceed. Returns False when the caller should
+    abort the whole sync (developer asked to abort, or no TTY so it is not safe
+    to wait for input).
+    """
+    if not sys.stdin.isatty():
+        print("Not running interactively (no TTY); cannot resolve the conflict "
+              "here.")
+        return False
+
+    sha = patch.hal_sha[:12]
+    print("\n" + "=" * 72)
+    print(f"Cherry-pick of {sha} ({patch.subject[:60]}) hit a conflict.")
+    print("Resolve it in another shell (edit files, `git add` them), then come")
+    print("back here and choose how to proceed:")
+    print("=" * 72)
+
+    while True:
+        files = conflicted_files(hal_root)
+        if files:
+            print(f"\nStill {len(files)} conflicted file(s):")
+            print_capped(files, cap=20, indent="    ")
+        else:
+            print("\nNo conflicted files remain (all resolved / staged).")
+
+        print("\nOptions:")
+        print("  [c] continue  - stage resolved files and finish this patch")
+        print("  [s] skip      - drop this patch and move on")
+        print("  [a] abort     - abort the cherry-pick and stop the whole sync")
+        try:
+            choice = input("Your choice [c/s/a]: ").strip().lower()
+        except EOFError:
+            print("\nEOF on input; aborting.")
+            return False
+
+        if choice in ("c", "continue"):
+            if _continue_cherry_pick(hal_root, sha):
+                return True
+            continue
+        if choice in ("s", "skip"):
+            run_status(["git", "cherry-pick", "--skip"], hal_root)
+            print(f"Skipped {sha} at developer's request.")
+            return True
+        if choice in ("a", "abort"):
+            print("Aborting sync at developer's request.")
+            return False
+        print("Unrecognized choice; please pick one of c/s/a.")
+
+
+def _continue_cherry_pick(hal_root: Path, sha: str) -> bool:
+    """Stage resolved files and finish the current cherry-pick.
+
+    Returns True when the patch is finished (committed or skipped-as-empty) and
+    the loop should move on; False when the developer must keep resolving.
+    """
+    run(["git", "add", "-A"], hal_root)
+    remaining = conflicted_files(hal_root)
+    if remaining:
+        print(f"Cannot continue: {len(remaining)} file(s) still conflicted. "
+              f"Resolve and `git add` them first.")
+        return False
+    cont = run_status(
+        ["git", "cherry-pick", "--continue"], hal_root,
+        env={**os.environ, "GIT_EDITOR": "true"},
+    )
+    if cont.returncode != 0:
+        # If the resolution left nothing to commit, git reports the cherry-pick
+        # as empty (or the sequence is already finished); treat as "already
+        # present" and skip.
+        if skip_if_cherry_pick_empty(hal_root, cont) or \
+                not cherry_pick_in_progress(hal_root):
+            print(f"Nothing to commit after resolution; skipped {sha}.")
+            return True
+        print(f"git cherry-pick --continue failed:\n{cont.stdout}\n"
+              f"{cont.stderr}")
+        return False
+    print(f"Re-applied {sha} after manual resolution.")
+    return True

--- a/mcux/scripts/sync_msdk/_sync/gitutil.py
+++ b/mcux/scripts/sync_msdk/_sync/gitutil.py
@@ -1,0 +1,89 @@
+"""Thin git/subprocess helpers shared across the sync driver."""
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+# git has an argv length limit, so long path lists are passed in chunks.
+GIT_ARGV_CHUNK = 500
+
+
+def run(cmd: list[str], cwd: Path, capture: bool = False, check: bool = True,
+        input_text: Optional[str] = None) -> str:
+    """Run `cmd`; return stripped stdout when `capture`, else "".
+
+    Raises on non-zero exit unless `check=False`. This is the fire-and-forget /
+    raise-on-failure helper; use `run_status` when you need to branch on the
+    exit code without raising.
+    """
+    if capture:
+        r = subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True,
+            check=check, input=input_text,
+        )
+        return r.stdout.rstrip("\n")
+    subprocess.run(cmd, cwd=str(cwd), check=check, input=input_text, text=True)
+    return ""
+
+
+def run_status(cmd: list[str], cwd: Path,
+               input_bytes: Optional[bytes] = None,
+               text: bool = True,
+               env: Optional[dict] = None) -> subprocess.CompletedProcess:
+    """Run `cmd` capturing returncode/stdout/stderr WITHOUT raising.
+
+    For call sites that must branch on the exit status (git ancestor tests,
+    fetches, cherry-picks, archive/untar).
+    """
+    return subprocess.run(
+        cmd, cwd=str(cwd), capture_output=True,
+        text=text, input=input_bytes, env=env,
+    )
+
+
+def combined_output(proc: subprocess.CompletedProcess) -> str:
+    """stdout + stderr of a completed process as one searchable string."""
+    return (proc.stdout or "") + (proc.stderr or "")
+
+
+def run_git_chunked(base_cmd: list[str], paths: list[str], cwd: Path) -> None:
+    """Run `base_cmd -- <paths>` in chunks, raising on the first failure."""
+    for i in range(0, len(paths), GIT_ARGV_CHUNK):
+        run(base_cmd + ["--"] + paths[i:i + GIT_ARGV_CHUNK], cwd)
+
+
+def git_toplevel(path: Path) -> Path:
+    """Resolve the git repository root that contains `path`."""
+    top = run(["git", "rev-parse", "--show-toplevel"], path, capture=True)
+    return Path(top).resolve()
+
+
+def is_ancestor(repo: Path, ancestor_sha: str, descendant_sha: str) -> bool:
+    """True iff `ancestor_sha` is an ancestor of `descendant_sha` in `repo`."""
+    r = run_status(
+        ["git", "merge-base", "--is-ancestor", ancestor_sha, descendant_sha],
+        repo,
+    )
+    # 0 -> is ancestor, 1 -> not ancestor, other -> error (treat as unknown)
+    return r.returncode == 0
+
+
+def changed_files(hal_root: Path, sha: str) -> list[str]:
+    """List the git-root-relative paths a single commit changes."""
+    # `git show -s`/`--no-patch` cannot be combined with `--name-only`, so use
+    # diff-tree directly: it lists the paths a commit changes (relative to the
+    # git root), handling the normal single-parent case cleanly.
+    out = run(
+        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha],
+        hal_root, capture=True, check=False,
+    )
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def print_capped(items: list[str], cap: int = 10, indent: str = "      ") -> None:
+    """Print up to `cap` items, then a '... and N more' summary line."""
+    for it in items[:cap]:
+        print(f"{indent}- {it}")
+    if len(items) > cap:
+        print(f"{indent}... and {len(items) - cap} more")

--- a/mcux/scripts/sync_msdk/_sync/manifest.py
+++ b/mcux/scripts/sync_msdk/_sync/manifest.py
@@ -1,0 +1,119 @@
+"""West manifest parsing and location of each source's local clone."""
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from .gitutil import run, run_status
+
+
+def _iter_manifest_projects(manifest_repo: Path, rev: str):
+    """Yield every west-manifest project dict found at `rev`.
+
+    Projects live in submanifests/*.yml (and the top-level west.yml); we
+    enumerate the tree at `rev` and safe_load each YAML (read-only), yielding the
+    `manifest.projects` entries.
+    """
+    out = run(["git", "ls-tree", "-r", "--name-only", rev],
+              manifest_repo, capture=True)
+    for f in out.splitlines():
+        if not f.endswith((".yml", ".yaml")):
+            continue
+        content = run(["git", "show", f"{rev}:{f}"],
+                      manifest_repo, capture=True, check=False)
+        if not content.strip():
+            continue
+        try:
+            doc = yaml.safe_load(content)
+        except yaml.YAMLError:
+            continue
+        man = doc.get("manifest") if isinstance(doc, dict) else None
+        if not isinstance(man, dict):
+            continue
+        for proj in man.get("projects", []) or []:
+            if isinstance(proj, dict):
+                yield proj
+
+
+def _index_manifest(manifest_repo: Path, rev: str, select) -> dict:
+    """Build {project-key -> select(proj)} over every manifest project at `rev`.
+
+    Keyed by BOTH `repo-path` and `name` so an import.yaml source `name` (== the
+    upstream GitHub repo name == the manifest `repo-path`) resolves regardless of
+    which the manifest used. First definition wins. Projects whose `select(proj)`
+    is falsy are skipped.
+    """
+    index: dict = {}
+    for proj in _iter_manifest_projects(manifest_repo, rev):
+        v = select(proj)
+        if not v:
+            continue
+        for key in (proj.get("repo-path"), proj.get("name")):
+            if key and key not in index:
+                index[key] = v
+    return index
+
+
+def parse_manifest_projects(manifest_repo: Path, rev: str) -> dict:
+    """{project-key -> revision} for locating each source's pinned SHA."""
+    return _index_manifest(manifest_repo, rev, lambda p: p.get("revision"))
+
+
+def build_manifest_path_map(manifest_repo: Path, rev: str) -> dict:
+    """{project-key -> checkout path} (west `path:`, defaulting to name).
+
+    Used to locate each source's local clone so its files can be copied.
+    """
+    return _index_manifest(manifest_repo, rev,
+                           lambda p: p.get("path") or p.get("name"))
+
+
+def resolve_source_clone(src: dict, manifest_paths: dict,
+                         west_topdir: Path) -> Optional[Path]:
+    """Locate the local clone directory for a source.
+
+    Preference order:
+      1. the west `path:` for the source's name from the manifest;
+      2. west topdir / name as a last resort.
+    Returns the path if it is a git repo, else None.
+    """
+    name = src.get("name")
+    candidates = []
+    if name and name in manifest_paths and manifest_paths[name]:
+        candidates.append(Path(manifest_paths[name]))
+    if name:
+        candidates.append(Path(name))
+    for c in candidates:
+        d = c if c.is_absolute() else (west_topdir / c)
+        d = d.resolve()
+        if (d / ".git").exists():
+            return d
+    return None
+
+
+def ensure_revision(clone: Path, repo_url: Optional[str], rev: str) -> bool:
+    """Guarantee commit `rev` exists as an object in `clone` before extraction.
+
+    The west workspace clone is whatever the maintainer last checked out /
+    fetched, so the exact SHA pinned in import.yaml is NOT guaranteed to be
+    present locally. If the object is already present, do nothing; otherwise
+    fetch that specific revision from the source's `repo` URL (falling back to
+    `origin`), then re-test. Returns True when `rev` resolves to a commit.
+    """
+    def present() -> bool:
+        chk = run_status(["git", "cat-file", "-e", f"{rev}^{{commit}}"], clone)
+        return chk.returncode == 0
+
+    if present():
+        return True
+
+    # Try fetching the exact revision. Prefer the explicit source repo URL so we
+    # pull from the same GitHub repo import.yaml pins against; fall back to the
+    # clone's configured `origin` remote.
+    remotes = [r for r in (repo_url, "origin") if r]
+    for remote in remotes:
+        fetched = run_status(["git", "fetch", "--quiet", remote, rev], clone)
+        if fetched.returncode == 0 and present():
+            return True
+    return present()

--- a/mcux/scripts/sync_msdk/_sync/patches.py
+++ b/mcux/scripts/sync_msdk/_sync/patches.py
@@ -1,0 +1,218 @@
+"""Patch model, trailer parsing, and dest_path ownership resolution.
+
+How a patch is attributed to an entry
+-------------------------------------
+The checkpoint range is a slice of the single, shared hal_nxp history, so it
+contains patches from *every* team/entry, not just the one being synced. Not
+every commit carries a tracking trailer either. Therefore a patch's owning entry
+is decided primarily by *the files it changes*, resolved with longest-prefix-
+wins across the dest_paths of ALL sources in ALL entries (west lays sub-repos
+out with NESTED destinations). Trailers, when present, enrich the decision and
+drive the ancestor test, but are not required.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .gitutil import changed_files, run
+
+
+# mcux-sdk-commit: <repo-name>: <sha>
+SDK_TRAILER = re.compile(
+    r"^mcux-sdk-commit:\s*(?P<repo>[^:\s]+):\s*(?P<sha>[0-9a-f]{7,40})\s*$",
+    re.MULTILINE,
+)
+# hal-nxp-commit: <sha>
+HAL_TRAILER = re.compile(
+    r"^hal-nxp-commit:\s*(?P<sha>[0-9a-f]{7,40})\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass
+class Patch:
+    """One hal_nxp commit in the sync range.
+
+    `upstream_repo`/`upstream_sha` come from a tracking trailer when present
+    (None otherwise); a patch is fully usable without them (it just always
+    re-applies). `has_trailer` is True iff either trailer was found.
+    """
+    hal_sha: str
+    subject: str
+    upstream_repo: Optional[str] = None
+    upstream_sha: Optional[str] = None
+    has_trailer: bool = False
+
+
+def collect_patches(hal_root: Path, since_sha: Optional[str]) -> list[Patch]:
+    """Walk hal_nxp history from HEAD back to `since_sha` (exclusive).
+
+    Returns a Patch for *every* non-checkpoint commit in range. Commits without
+    a tracking trailer still need re-applying, so we do NOT drop them; trailer
+    info is captured when present and left None otherwise. Order is oldest-first
+    so re-application preserves original order.
+    """
+    rev_range = f"{since_sha}..HEAD" if since_sha else "HEAD"
+    # Use a record separator that won't appear in commit messages.
+    sep = "\x1e"
+    fmt = f"%H%n%s%n%b{sep}"
+    out = run(
+        ["git", "log", "--reverse", f"--format={fmt}", rev_range],
+        hal_root, capture=True,
+    )
+    patches = []
+    for record in out.split(sep):
+        record = record.strip("\n")
+        if not record:
+            continue
+        lines = record.split("\n", 2)
+        sha = lines[0].strip()
+        subject = lines[1].strip() if len(lines) > 1 else ""
+        body = lines[2] if len(lines) > 2 else ""
+
+        # Skip checkpoint commits themselves.
+        if subject.startswith("mcux-sync-"):
+            continue
+
+        full = subject + "\n" + body
+        sdk = SDK_TRAILER.search(full)
+        hal = HAL_TRAILER.search(full)
+
+        patch = Patch(hal_sha=sha, subject=subject)
+        if sdk:
+            patch.upstream_repo = sdk.group("repo")
+            patch.upstream_sha = sdk.group("sha")
+            patch.has_trailer = True
+        elif hal:
+            patch.upstream_sha = hal.group("sha")
+            patch.has_trailer = True
+        patches.append(patch)
+    return patches
+
+
+# ---------------------------------------------------------------------------
+# dest_path prefix table (longest-prefix-wins, across ALL entries)
+# ---------------------------------------------------------------------------
+
+def build_prefix_table(data: dict) -> list[dict]:
+    """Return {prefix, entry, source, copy} for every source's dest_path.
+
+    Sorted by descending prefix length so the first match wins. dest_path is
+    already relative to the hal_nxp git root (starts with the mcux/ prefix),
+    matching the paths git reports, so it is used verbatim.
+
+    Ownership is NOT decided by the prefix alone: a source only owns files it
+    actually copies. west lays sub-repos out with NESTED destinations and one
+    source (mcuxsdk-core -> mcux-sdk-ng) sits at the top; without gating on the
+    copy patterns it would claim every file under mcux-sdk-ng. So we keep the
+    copy regexes here and apply them in owning_source_for_file(). A source with
+    no copy patterns matches everything under its dest_path (prefix-only).
+    """
+    table = []
+    for entry in data.get("entries", []):
+        for src in entry.get("sources", []):
+            dest = src.get("dest_path")
+            if not dest:
+                continue
+            full = dest.strip("/")
+            if not full:
+                continue
+            copy_res = [re.compile(pat) for pat in (src.get("copy") or [])]
+            table.append({
+                "prefix": full,
+                "entry": entry.get("name"),
+                "source": src.get("name"),
+                "copy": copy_res,
+            })
+    # Longest prefix first so nested dest_paths are resolved correctly.
+    table.sort(key=lambda e: len(e["prefix"]), reverse=True)
+    return table
+
+
+def owning_source_for_file(path: str, prefix_table: list[dict]) -> Optional[dict]:
+    """Return the table entry that owns `path`, or None.
+
+    A source owns `path` when (a) `path` lies under the source's dest_path prefix
+    AND (b) the path relative to that prefix (i.e. relative to the upstream repo
+    root, which is what the copy regexes are written against) matches one of the
+    source's copy patterns. Table entries are ordered longest-prefix-first. A
+    source with no copy patterns matches anything under its prefix.
+    """
+    for e in prefix_table:
+        pfx = e["prefix"]
+        if path == pfx:
+            rel = ""
+        elif path.startswith(pfx + "/"):
+            rel = path[len(pfx) + 1:]
+        else:
+            continue
+        copy_res = e["copy"]
+        if not copy_res:
+            return e
+        if any(r.search(rel) for r in copy_res):
+            return e
+    return None
+
+
+def patch_owning_entries(patch: Patch, hal_root: Path,
+                         prefix_table: list[dict]) -> set[str]:
+    """Which entries a patch belongs to, by resolving each changed file's owner.
+
+    A patch that touches several nested trees (rare) can belong to more than one
+    entry; each such entry re-applies it when it is synced.
+    """
+    entries: set[str] = set()
+    for f in changed_files(hal_root, patch.hal_sha):
+        owner = owning_source_for_file(f, prefix_table)
+        if owner and owner["entry"]:
+            entries.add(owner["entry"])
+    return entries
+
+
+def patch_belongs_to_entry(patch: Patch, entry: dict, hal_root: Path,
+                           prefix_table: list[dict],
+                           repo_names: set[str]) -> bool:
+    """Decide whether a patch (trailer or not) belongs to the entry being synced.
+
+    Primary signal: the files the patch changes resolve (longest-prefix) to a
+    source owned by this entry. Secondary signal: an mcux-sdk-commit trailer
+    naming one of this entry's upstream repos (catches patches whose files were
+    later removed/relocated but whose trailer still ties them to the entry).
+    """
+    if patch.upstream_repo and patch.upstream_repo in repo_names:
+        return True
+    return entry.get("name") in patch_owning_entries(patch, hal_root, prefix_table)
+
+
+def entry_dropped_shas(entry: dict, hal_root: Path) -> set[str]:
+    """Return the set of FULL hal_nxp commit SHAs listed under `drop_patch`.
+
+    Maintainers use this to suppress patches the tool would otherwise re-apply
+    (chiefly commits that predate the trailer convention). Each list item may be
+    a full/abbreviated SHA (or a "sha: reason" note); it is resolved to a full
+    SHA via `git rev-parse`. Entries that cannot be resolved are warned about
+    and ignored.
+    """
+    dropped: set[str] = set()
+    for item in entry.get("drop_patch") or []:
+        if isinstance(item, dict):
+            # Allow `- <sha>: <reason>` mapping form for inline documentation.
+            raw = next(iter(item), None)
+        else:
+            raw = item
+        if not raw:
+            continue
+        # Keep only the leading token so `sha  # note` style still resolves.
+        token = str(raw).split()[0].strip()
+        if not token:
+            continue
+        full = run(["git", "rev-parse", "--verify", "--quiet",
+                    f"{token}^{{commit}}"], hal_root, capture=True, check=False)
+        if not full:
+            print(f"  WARNING: drop_patch entry '{token}' does not resolve to a "
+                  f"commit in hal_nxp; ignoring.")
+            continue
+        dropped.add(full.strip())
+    return dropped

--- a/mcux/scripts/sync_msdk/import-schema.md
+++ b/mcux/scripts/sync_msdk/import-schema.md
@@ -1,0 +1,164 @@
+# import.yaml Schema
+
+This document describes **how to write `import.yaml`** — its structure and every
+field. `import.yaml` (at the hal_nxp root, `mcux/`) declares which MCUXpresso SDK
+files are imported into hal_nxp, from which upstream repo and revision, and which
+files are trimmed afterwards.
+
+For the *why* and *how* — the sync problem, the patch-tracking mechanism
+(trailers, checkpoints, `drop_patch`), the two-phase workflow, and the
+`west pick_hal_nxp` tool — see
+[`sync-guide.md`](./sync-guide.md).
+
+## Top-level Structure
+
+```yaml
+entries:
+  - <entry>
+  - <entry>
+  ...
+```
+
+## Entry
+
+An entry corresponds to a group of logically related upstream repos, owned by the
+same maintainer.
+
+```yaml
+- name: <string>           # Unique entry identifier, used by the --entry argument,
+                           # and also the suffix of the checkpoint marker
+  description: <string>    # Human-readable description
+  manifest:                # Manifest info for this release, for reference and the
+                           # update command only
+    repo: <url>
+    revision: <git-revision>
+  sources:                 # One or more upstream sub-repos
+    - <source>
+    - <source>
+  actions:                 # Entry-level ordered action list, executed in order
+    - <action>             # after all sources have been copied
+    - <action>             # Only type: remove / type: pin allowed (no type: patch)
+  drop_patch:              # Optional. hal_nxp commit SHAs in this entry that the
+    - <hal_nxp-sha>        # sync tool must NOT re-apply (manual skip list)
+    - <hal_nxp-sha>
+```
+
+## Source (upstream repo)
+
+```yaml
+- repo: <url>              # Upstream git repo address (GitHub repo address)
+  name: <string>           # The GitHub repo name for this source (the key used in
+                           # the trailer)
+                           # = last segment of the GitHub clone origin URL without .git
+                           # e.g.: mcux-component, mcux-devices-rt, mcux-devices-wireless
+  revision: <git-revision> # Revision used for this sync: a commit SHA or a tag
+  note: <string>           # Optional, supplementary note, e.g. the source branch name
+  dest_path: <path>        # Destination path in the hal_nxp repo (relative to hal_nxp root);
+                           # the upstream repo root maps directly onto this path
+  copy:                    # Python regex list, matched against paths relative to the
+    - <regex>              # upstream repo root; selects which files are copied
+    - <regex>
+```
+
+**A source has no `src_path`.** The upstream repo root maps directly onto
+`dest_path`. The `copy` list selects *which* files under the repo root are
+copied: each entry is a Python regex matched against the file path relative to
+the repo root (using `/`, no leading `/`). A matched file is copied to
+`dest_path` while **keeping its path relative to the repo root**, so
+`^cmake/extension/` copied with `dest_path: mcux-sdk-ng` lands under
+`mcux-sdk-ng/cmake/extension/...`. Use `".*"` to copy the whole repo.
+
+**A source only describes where to copy from and to.** It has no `remove` (or any
+other action) field: every remove/pin step is an **entry-level action**, executed
+in order after all sources are copied. This keeps all trimming logic in one place
+(the entry's `actions` list) instead of being scattered per source.
+
+**About `name` (important)**: Each upstream sub-repo is published on GitHub after
+release; `repo` and the local development clone both point to the same GitHub repo.
+The patch trailer records the **GitHub repo name**, and the ancestor test
+(`git merge-base --is-ancestor`) is done against the same GitHub repo. Therefore
+the `name` field must contain the **GitHub-side repo name** (last segment of the
+repo URL without `.git`), consistent with the `<repo-name>` used by
+`west pick_hal_nxp` (from the GitHub clone's origin URL). It is also the key used
+to look the source up in the west manifest.
+
+**Execution order**:
+1. For every source in the entry, copy the files under `repo@revision`'s root
+   that match the `copy` regex list into `dest_path` (preserving each file's
+   path relative to the repo root).
+2. Once all sources are copied, execute the entry-level `actions` list in order.
+
+## Action (entry-level operation)
+
+After all sources are copied, the actions list is executed in order.
+**Only two action types are supported: `remove` and `pin`.**
+
+### type: remove
+
+Deletes files in hal_nxp that match. Used to:
+- Delete files no longer needed after all sources are copied
+- Delete files removed upstream that must be removed in sync (auto-appended by the
+  `update` command)
+
+```yaml
+- type: remove
+  patterns:                # Python regex list, matched against file paths relative
+    - <regex>              # to the hal_nxp root
+    - <regex>
+```
+
+### type: pin
+
+Takes specific files from a certain commit in hal_nxp's own history and overwrites
+the current working tree. Used for scenarios where "certain files must stay at a
+fixed version and not follow upstream updates".
+
+```yaml
+- type: pin
+  commit: <git-sha>        # Optional. A commit SHA in the hal_nxp repo.
+                           # Defaults to HEAD when omitted.
+  patterns:                # Python regex list, matched against files to overwrite
+    - <regex>              # relative to the hal_nxp root
+```
+
+## drop_patch (optional per-entry field)
+
+`drop_patch` is a per-entry list of **hal_nxp commit SHAs the sync tool must NOT
+re-apply** for that entry. Its purpose and behavior (why it exists, how it
+interacts with trailers and the ancestor test) are explained in the guide; here
+is only the field shape:
+
+```yaml
+- name: basic
+  # ...
+  drop_patch:
+    - 1234abcd   # absorbed by mcuxsdk-core v26.09; no trailer, drop it
+    - deadbeef   # obsolete workaround, do not carry forward
+```
+
+- Each item is a hal_nxp commit SHA (full or abbreviated); any git-recognizable
+  abbreviation works.
+- An optional trailing `# reason` comment is strongly recommended.
+- The list is scoped to the entry it lives under.
+
+## Regex Matching Notes
+
+- All `copy`/`remove`/`pin` patterns use **Python standard regular expressions**
+  (the `re` module).
+- `copy` patterns are matched relative to the **upstream repo root**.
+- `remove` and `pin` patterns are matched relative to the hal_nxp **repo root**
+  (i.e. they start with the `mcux/` prefix, matching the paths git reports).
+- The match target is always the **file path** (using the `/` separator), without
+  a leading `/`.
+
+## Maintenance Rules
+
+- **`revision` may be a full 40-character commit SHA or a tag**; branch names are
+  not allowed (record a branch hint in the `note` field if useful).
+- After each sync, `sources[].revision` should be updated to the revision (SHA
+  or tag) actually used this time — the `update` command does this for you.
+- The source `name` field must contain the **GitHub repo name**, consistent with
+  the `<repo-name>` used by `west pick_hal_nxp` when injecting trailers.
+- For patches that carry **no trailer** (e.g. commits predating the trailer
+  convention) but should not be re-applied, add their hal_nxp SHA to the entry's
+  `drop_patch` list with a short `# reason` comment.

--- a/mcux/scripts/sync_msdk/sync-guide.md
+++ b/mcux/scripts/sync_msdk/sync-guide.md
@@ -1,0 +1,241 @@
+# Syncing MCUXpresso SDK code into hal_nxp
+
+## 1. Background
+
+Some code in hal_nxp — device headers, drivers, middleware — comes from the
+[MCUXpresso SDK (MCUX SDK)](https://github.com/nxp-mcuxpresso), whose source is
+**spread across many separate Git repos** (`mcuxsdk-core`, `mcux-component`,
+`mcux-devices-rt`, ...), pinned by a **west manifest**. The SDK **releases
+periodically**, and each release is **imported into hal_nxp**.
+
+**The import is a direct file copy, not a `git merge`/patch replay**, because:
+
+- hal_nxp needs only a *subset* of the SDK; build scripts, examples, Kconfig,
+  linker scripts, prebuilt archives, etc. must be **removed**.
+- A merge assumes shared history and 1:1 file correspondence — neither holds
+  when curating a subset of many repos into a rearranged layout.
+
+So the model is: **copy the wanted files → trim the rest → commit a snapshot.**
+
+### The problem: patches hal_nxp carries ahead of the SDK
+
+A plain copy would clobber fixes hal_nxp carries on top of upstream. Fixes flow
+**both directions**, and the SDK release window makes the two sides drift:
+
+- **hal_nxp → SDK:** a fix lands in hal_nxp first and is cherry-picked back to
+  the SDK, but misses the release window. On re-import it must be **re-applied**.
+- **SDK → hal_nxp:** an SDK fix is cherry-picked *early* into hal_nxp. Whether
+  the next release contains it depends on the window — on re-import we must
+  **skip** the ones the release already absorbed and **re-apply** the rest.
+
+So on every re-import, for each hal_nxp patch, we must decide: **does the new
+release already contain it?** That requires linking each hal_nxp patch to its
+counterpart commit on the other side.
+
+---
+
+## 2. How it works
+
+Three parts cooperate:
+
+| Part | Where | Role |
+|------|-------|------|
+| `import.yaml` | hal_nxp root (`mcux/`) | Declares what to copy, from which repo@revision, and what to trim. See [`import-schema.md`](./import-schema.md). |
+| `sync_msdk.py` | `mcux/scripts/sync_msdk/` | Runs the two-phase import + patch re-apply. |
+| `west pick_hal_nxp` | SDK private | Cherry-picks patches between the two sides and stamps the link trailer. |
+
+Two ideas make the patch decision automatic:
+
+- **A trailer links each patch to its counterpart.** Every patch cherry-picked
+  between the two sides carries a commit-message trailer naming the matching
+  commit (injected automatically by `west pick_hal_nxp`):
+  - SDK → hal_nxp: `mcux-sdk-commit: <repo-name>: <sdk-sha>`
+  - hal_nxp → SDK: `hal-nxp-commit: <hal_nxp-sha>`
+
+  `<repo-name>` is the GitHub repo name (matching a source's `name` in
+  `import.yaml`). With the link, the tool answers "already in the release?" via
+  an ancestor test: `git merge-base --is-ancestor <patch-sha> <release-sha>`.
+
+- **A checkpoint bounds the scan.** The import snapshot commit's *title* carries
+  a `mcux-sync-<entry>` marker. Every time import new SDK code, the tool will
+  scan back to the previous checkpoint to find patches that need re-applying.
+
+### The sync algorithm
+
+`sync_msdk.py sync --entry <entry>`:
+
+1. Copy each source's files, run the `remove`/`pin` trims, and **commit the
+   snapshot** (the new checkpoint).
+2. Scan hal_nxp history back to the previous `mcux-sync-<entry>` checkpoint (or
+   `--since-sha`) and collect commits carrying a trailer.
+3. **Keep only this entry's patches.** The shared history holds every team's
+   patches; a patch belongs to this entry if its trailer `<repo-name>` is one of
+   the entry's sources, or (for `hal-nxp-commit`) it touches one of the entry's
+   `dest_path` prefixes (longest-prefix-wins). Others are ignored here.
+4. **Decide each patch:** ancestor of the new release → **skip**; otherwise
+   **re-apply**. Trailer-less patches can't be tested, so they re-apply
+   unconditionally unless listed in `drop_patch` (see below).
+5. **Re-apply** by cherry-pick, in order. Empty picks are skipped. On conflict:
+   an interactive terminal prompts `[c]`ontinue / `[s]`kip / `[a]`bort.
+
+### A picture of the two histories
+
+The diagram traces one entry through **two imports**. The bottom lane is
+**hal_nxp** (a single shared history; `-o-` are unrelated commits); the top
+lane is one of the entry's **SDK source repos**. `[ SYNC@rel ]` are the copy-in
+**snapshots**, whose commit title carries the `mcux-sync-<entry>` checkpoint.
+Fixes flow *both* ways, and every cherry-pick carries a trailer linking it to
+its twin on the other side.
+
+```text
+                               trailer:                     trailer:
+                               hal-nxp-commit: <P1-SHA>     hal-nxp-commit: <P2-SHA>
+                                      |                            |
+                   SDK rel1           |                 SDK rel2   |
+SDK (mcux-core)   /                   v                /           v
+  ...--o---o--- R1 --o--  .... --o--  P1' --o-- .... R2 --o .. -- P2' --o--...
+                |                     ^              |            ^
+                |                     | pick         |           / pick patch
+                |                     |              |          /
+                |                     |              +--------------------------+
+                |                     |                       /                 |
+=============== | =================== | ==================== /==================|===================
+                |                     |                     /                   |                P2 reapplied
+HAL_NXP         v                     |                    /                    v                /
+    --o-- [SYNC @rel1] --o-- ...--o-- P1 ---o-- .. --o-- P2 --o-- --o--o-- [SYNC @rel2] ------- P2" ------
+                ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         ^
+            sync snapshot                          ^                        sync snapshot
+            title: mcux-sync-basic: sync R1        |                        title: mcux-sync-basic: sync R2
+                                                   |
+                            scan patches in this range, P1 is included in rel2,
+                            but P2 is not, so apply P2 again as P2"
+```
+
+**Reading the diagram.** `P1` and `P2` are two fixes that were born in hal_nxp
+and cherry-picked back into the SDK as their twins `P1'` and `P2'`. Each twin
+carries a `hal-nxp-commit: <sha>` trailer that points back at the hal_nxp commit
+it came from - that trailer is what lets the tool pair the two sides later. On
+the SDK line the releases `R1` and `R2` are cut at fixed points, and the timing
+of each cherry-pick relative to `R2` is the whole story:
+
+- `P1'` lands **before** `R2`, so `R2` already contains `P1`'s change.
+- `P2'` lands **after** `R2`, so `R2` does **not** contain `P2`'s change yet.
+
+**What the sync does.** When importing `R2`, the tool first copies the `R2` tree
+and commits it as the snapshot `[SYNC @rel2]` (its title carries
+`mcux-sync-basic: sync R2`, which also becomes the next checkpoint). It then
+looks only at the hal_nxp commits in the scan range - the commits **after** the
+previous checkpoint `[SYNC @rel1]` up to now (the `~~~~` span, which includes
+`P1` and `P2`). For each one it runs the ancestor test against the release SHA:
+
+```text
+  P1   hal-nxp-commit: <P1-SHA>   is-ancestor(P1', R2)?  YES -> SKIP     (R2 already has it)
+  P2   hal-nxp-commit: <P2-SHA>   is-ancestor(P2', R2)?  NO  -> RE-APPLY (missed the release)
+```
+
+**Result:** on top of the fresh `[SYNC @rel2]` snapshot the tool re-applies only
+`P2`, which reappears as `P2"` - while `P1` is dropped because the new copy
+already carries it.
+
+
+### drop_patch -- the manual skip list
+
+
+Commits predating the trailer convention have **no trailer**, so the ancestor
+test can't skip them. `drop_patch` is a per-entry list of hal_nxp SHAs that must
+**never** be re-applied -- it wins over the ancestor test. Use it for such legacy
+commits or obsolete workarounds; prefer the automatic trailer test otherwise.
+Field syntax is in [`import-schema.md`](./import-schema.md).
+
+---
+
+## 3. Quick start
+
+**Prerequisites:**
+- A local west workspace of the MCUX SDK, folders `manifests`, `mcuxsdk` are in this workspace.
+- Define the system environment variable `MCUX_SDK_DIR` to point to the root of the MCUX SDK workspace.
+- Python deps: `pip install pyyaml ruamel.yaml`.
+
+```bash
+cd <hal_nxp>/mcux
+
+# Phase 1 — update: resolve each source's revision from the manifest, write it
+# back into import.yaml, and queue upstream-deleted files as `remove` patterns.
+# For example, this command will fill the SHAs for the `basic` entry from the v26.09.00-pvw2 manifest:
+python scripts/sync_msdk/sync_msdk.py update --entry basic --manifest v26.09.00-pvw2
+
+#   --> Review import.yaml: confirm the revisions, remove patterns, and pins. <--
+
+# Phase 2 — sync: copy + trim + commit the snapshot, then re-apply patches the
+# release does not yet contain.
+python scripts/sync_msdk/sync_msdk.py sync --entry basic
+```
+
+Note: flag `--since-sha <sha>`, it is needed when this is the first time you run the sync
+for a new entry, it means the hal_nxp SHA when the entry was synced last time. The tool
+will scan back to this SHA to find patches that need re-applying. For example,
+```bash
+python scripts/sync_msdk/sync_msdk.py sync --entry basic --since-sha 2ba4f142394d01bb2c159bee1188b352274dcf40
+```
+
+Note: If you want to manually modify the `import.yaml` revisions, phase 1 is optional.
+
+---
+
+## 4. Onboarding your own repo
+
+Add an **entry** to `import.yaml` — a group of related upstream repos owned by
+one maintainer, advancing on its own checkpoint independently of other teams.
+
+```yaml
+entries:
+  - name: mine                       # unique; also the checkpoint suffix
+    description: "My middleware for hal_nxp"
+    manifest:                        # for reference + the `update` command
+      repo: https://github.com/nxp-mcuxpresso/mcuxsdk-manifests
+      revision: v26.09.00-pvw2
+    sources:
+      - repo: https://github.com/nxp-mcuxpresso/my-repo
+        name: my-repo                # GitHub repo name; the trailer key
+        revision: <40-char-sha-or-tag>
+        dest_path: mcux/mcux-sdk-ng/middleware/mine   # relative to hal_nxp ROOT
+        copy:                        # Python regexes, relative to the repo root
+          - ".*"                     # ".*" copies the whole repo
+    actions:                         # trimming, run in order after all copies
+      - type: remove                 # remove files matching these regexes
+        patterns:                    # Python regexes, relative to hal_nxp root
+          - "^mcux/.*\\.a$"
+          - "^mcux/mcux-sdk-ng/middleware/mine/(.*/)?Kconfig[^/]*$"
+          - "^mcux/mcux-sdk-ng/middleware/mine/example(/|$)"
+      - type: pin                    # hold specific files which will not be updated
+        patterns:                    # Python regexes, relative to hal_nxp root
+          - "^mcux/mcux-sdk-ng/middleware/mine/(.*/)?Kconfig[^/]*$"
+```
+
+The data you prepare (full field reference in [`import-schema.md`](./import-schema.md)):
+
+- **Sources** — for each repo: `repo` (clone URL); `name` (GitHub repo name,
+  last URL segment without `.git` — the trailer key, ancestor-test target, and
+  manifest lookup key, so it must be exact); `revision` (SHA or tag, filled by
+  `update`); `dest_path` (where the repo root maps, from the hal_nxp root);
+  `copy` (regexes selecting which files to copy).
+- **Trim actions** — `remove` regexes for everything Zephyr doesn't need
+  (build glue, examples, Kconfig, docs, archives). See the `basic` entries.
+- **`pin`** (optional) — hold specific files at a fixed hal_nxp version.
+- **`drop_patch`** (optional) — hal_nxp SHAs never to re-apply (§2).
+
+Verify before running for real:
+
+```bash
+python scripts/sync_msdk/sync_msdk.py update --entry mine --dry-run
+python scripts/sync_msdk/sync_msdk.py sync   --entry mine --dry-run
+```
+
+On the first sync there is no checkpoint, use `--sync-sha` instead, otherwise
+the tool scans full history for your entry's patches; later syncs scan only
+back to the previous checkpoint.
+
+---
+
+See [`import-schema.md`](./import-schema.md) for the full `import.yaml` field
+reference.

--- a/mcux/scripts/sync_msdk/sync_msdk.py
+++ b/mcux/scripts/sync_msdk/sync_msdk.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+sync_msdk.py - Drive the SDK -> hal_nxp sync from import.yaml.
+
+This is the thin CLI entry point. The implementation lives in the `_sync`
+package next to this file (see _sync/__init__.py for the module map).
+
+Two-phase workflow (see sync-guide.md for the concepts and import-schema.md for
+the import.yaml field reference):
+
+  Phase 1 - update (run by the maintainer when a new release lands):
+      python sync_msdk.py update --manifest <manifest-revision> --entry <entry-name>
+    Refreshes each source's `revision` for the entry and, by diffing the old vs
+    new upstream tree, appends upstream-deleted files to a `type: remove` action
+    so the human can review them before syncing.
+
+  Phase 2 - sync (run after import.yaml has been reviewed):
+      python sync_msdk.py sync --entry <entry-name>
+    1. Copies each source's `copy`-matched files into its `dest_path`, applies
+       the entry-level `remove`/`pin` actions, and commits the result as the
+       imported snapshot. That commit carries the `mcux-sync-<entry>` marker in
+       its title (per-source SHAs in its body), so it doubles as the checkpoint
+       for the next sync.
+    2. Walks the hal_nxp history back to the last `mcux-sync-<entry>` checkpoint
+       (or `--since-sha`) and collects every patch commit in range.
+    3. Classifies each patch to its owning entry (by the files it changes, with
+       longest-prefix-wins over all sources' dest_paths) and, for the entry
+       being synced, decides skip vs re-apply, then cherry-picks the re-apply
+       set on top of the snapshot commit from step 1.
+
+See sync-guide.md for how patches are attributed to entries, the `drop_patch`
+manual skip list, trailer conventions, and MCUX_SDK_DIR / west-workspace layout.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow `python scripts/sync_msdk/sync_msdk.py ...` from any cwd by putting
+# sync_msdk/ (which holds the _sync package) on sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _sync.commands import cmd_sync, cmd_update  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="hal_nxp sync driver (import.yaml)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    up = sub.add_parser("update", help="Phase 1: resolve+write per-source revisions")
+    up.add_argument("--entry", required=True)
+    up.add_argument("--manifest", default=None,
+                    help="Manifest revision/tag to resolve against "
+                         "(default: entry.manifest.revision in import.yaml)")
+    up.add_argument("--sdk-dir", default=None,
+                    help="MCUX SDK dir (== west topdir); its `manifests` "
+                         "subdir is the west manifest git clone. "
+                         "(default: $MCUX_SDK_DIR)")
+    up.add_argument("--dry-run", action="store_true")
+    up.set_defaults(func=cmd_update)
+
+    sy = sub.add_parser("sync", help="Phase 2: copy + commit snapshot + re-apply patches")
+    sy.add_argument("--entry", required=True)
+    sy.add_argument("--since-sha", default=None,
+                    help="Override the scan start (default: last checkpoint)")
+    sy.add_argument("--sdk-dir", default=None,
+                    help="MCUX SDK dir (== west topdir) holding the source "
+                         "clones; its `manifests` subdir is the west manifest "
+                         "git clone. (default: $MCUX_SDK_DIR)")
+    sy.add_argument("--dry-run", action="store_true")
+    sy.set_defaults(func=cmd_sync)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add a tool to import MCUXpresso SDK code into hal_nxp and re-apply the patches hal_nxp carries on top of upstream.

SDK code is imported by direct file copy (not a git merge): only a curated subset is kept. Patches hal_nxp carries ahead of a release are tracked by commit-message trailers plus a per-entry checkpoint, so the sync can skip the ones the new release already absorbed and re-apply the rest.

* import.yaml: what to copy from which repo@revision, and how to trim.
* scripts/sync_msdk/: the sync_msdk.py CLI and _sync/ package, plus import-schema.md (import.yaml reference) and sync-guide.md (guide).