### PR TITLE
drivers: clock: rw6xx: fix wrong ENET MDC clock frequency

### DIFF
--- a/mcux/mcux-sdk-ng/devices/Wireless/RW/RW610/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk-ng/devices/Wireless/RW/RW610/drivers/fsl_clock.c
@@ -236,7 +236,15 @@ uint32_t CLOCK_GetTddrMciFlexspiClkFreq(void)
  */
 uint32_t CLOCK_GetTddrMciEnetClkFreq(void)
 {
-    uint32_t freq = CLOCK_MHZ(50UL);
+    /* The ENET module's MSCR/MDC divider is calculated by ENET_SetSMI() against
+     * whatever this function reports, but it is actually clocked from the M33
+     * processor/platform bus clock (260MHz), not from TDDR. The previous 50MHz
+     * value produced a real MDC of ~13MHz instead of the intended 2.5MHz, which
+     * exceeds the KSZ8081 (and most RMII PHYs') MIIM interface limits and causes
+     * unreliable/non-functional MDIO. Confirmed root cause and fix:
+     * https://community.nxp.com/t5/Zephyr-Project/Wrong-MDC-frequency-RW612-frdm-rw612/td-p/2054592
+     */
+    uint32_t freq = CLOCK_MHZ(260UL);
     return freq;
 }
 

--- a/mcux/mcux-sdk-ng/devices/Wireless/RW/RW612/drivers/fsl_clock.c
+++ b/mcux/mcux-sdk-ng/devices/Wireless/RW/RW612/drivers/fsl_clock.c
@@ -236,7 +236,15 @@ uint32_t CLOCK_GetTddrMciFlexspiClkFreq(void)
  */
 uint32_t CLOCK_GetTddrMciEnetClkFreq(void)
 {
-    uint32_t freq = CLOCK_MHZ(50UL);
+    /* The ENET module's MSCR/MDC divider is calculated by ENET_SetSMI() against
+     * whatever this function reports, but it is actually clocked from the M33
+     * processor/platform bus clock (260MHz), not from TDDR. The previous 50MHz
+     * value produced a real MDC of ~13MHz instead of the intended 2.5MHz, which
+     * exceeds the KSZ8081 (and most RMII PHYs') MIIM interface limits and causes
+     * unreliable/non-functional MDIO. Confirmed root cause and fix:
+     * https://community.nxp.com/t5/Zephyr-Project/Wrong-MDC-frequency-RW612-frdm-rw612/td-p/2054592
+     */
+    uint32_t freq = CLOCK_MHZ(260UL);
     return freq;
 }
 


### PR DESCRIPTION
CLOCK_GetTddrMciEnetClkFreq() hardcodes 50MHz with no register read. This value is used by ENET_SetSMI() to calculate the ENET module's MSCR MII_SPEED/HOLDTIME divider, on the assumption that it reflects the module's real clock source (TDDR).

In reality, on RW610/RW612 that divider is calculated against the bus clock, which runs at 260MHz, not 50MHz. With the wrong assumed base clock, the resulting real MDC frequency comes out around 13MHz instead of the intended 2.5MHz, exceeding common RMII PHY MIIM interface limits (e.g. KSZ8081, ~10MHz max) and causing unreliable or completely non-functional MDIO.

I have reproduced this on my custom RW610 board, and was independently confirmed by NXP (Pavel Krenek) on an old community forum discussion, including the same fix: [Link to NXP forum discussion](https://community.nxp.com/t5/Zephyr-Project/Wrong-MDC-frequency-RW612-frdm-rw612/td-p/2054592)

Fix both the RW610 and RW612 copies of this stub to report the real 260MHz clock, so ENET_SetSMI() computes a correct MII_SPEED/HOLDTIME for actual MDC operation.