### PR TITLE
mcux: lpi2c: avoid divide-by-zero in LPI2C_GetCyclesForWidth

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/lpflexcomm/lpi2c/fsl_lpi2c.c
+++ b/mcux/mcux-sdk-ng/drivers/lpflexcomm/lpi2c/fsl_lpi2c.c
@@ -163,9 +163,22 @@ static uint32_t LPI2C_GetCyclesForWidth(
         prescaler--;
     }
 
-    uint32_t busCycle_ns = 1000000U / (sourceClock_Hz / divider / 1000U);
-    /* Calculate the cycle count, round up the calculated value. */
-    uint32_t cycles = (width_ns * 10U / busCycle_ns + 5U) / 10U;
+    uint32_t busClockKhz = sourceClock_Hz / divider / 1000U;
+    uint32_t cycles;
+    if (busClockKhz == 0U)
+    {
+        /* sourceClock_Hz too small (or transiently 0, e.g. a clock mux
+         * that has not yet settled) to express as a >0 kHz bus clock at
+         * this divider - fall back to the caller's minimum instead of
+         * dividing by zero. */
+        cycles = minCycles;
+    }
+    else
+    {
+        uint32_t busCycle_ns = 1000000U / busClockKhz;
+        /* Calculate the cycle count, round up the calculated value. */
+        cycles = (width_ns * 10U / busCycle_ns + 5U) / 10U;
+    }
 
     /* If the calculated value is smaller than the minimum value, use the minimum value */
     if (cycles < minCycles)


### PR DESCRIPTION
## Summary

`LPI2C_GetCyclesForWidth()` divides by `(sourceClock_Hz / divider / 1000U)`
to get a bus cycle time in nanoseconds, without validating that this
intermediate value is non-zero. When `sourceClock_Hz` is small relative
to `divider` (or, observed in practice, transiently 0 immediately after
a clock mux switch that has not yet settled), this triggers a real
USAGE FAULT (division by zero) inside `LPI2C_MasterInit()`.

Reproduced on real hardware: Zephyr RTOS v4.4.0, MCX-N9XX-EVK
(MCXN947), FlexComm2 configured for I2C (`flexcomm2_lpi2c2`), with an
identical fault PC/registers on every occurrence:

```
***** USAGE FAULT *****
  Division by zero
r0/a1:  0x0000000f  r1/a2:  0x00000000  r2/a3:  0x00000000
r3/a4:  0x000f4240 r12/ip:  0x00000002 r14/lr:  0x10012815
Faulting instruction address (r15/pc): 0x1001271c
>>> ZEPHYR FATAL ERROR 30: Unknown error on CPU 0
```

## Fix

Guard the division and fall back to the caller's `minCycles` instead
of dividing by zero. This is also the mathematically correct result
whenever `width_ns` is 0 (i.e. the glitch filter width is unset) - the
case hit in this reproduction, since callers only pass a non-zero
`width_ns` for the optional `busIdleTimeout`/`pinLowTimeout` paths,
each gated on the timeout itself being non-zero.

## Test plan

- [x] Reproduced the crash on real MCX-N9XX-EVK hardware (GDB +
      `addr2line` confirmed the fault PC against this function).
- [x] Applied this fix, rebuilt, reflashed, and confirmed the board
      now boots cleanly with `flexcomm2_lpi2c2` enabled, with a real
      (non-zero) source clock reported by the driver.
- [x] Confirmed via a temporary diagnostic print that `sourceClock_Hz`
      was `0` for the crashing call before this fix.