### PR TITLE
[ZEP-6246] Updated module.yml to record advc lib

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -347,3 +347,19 @@ blobs:
     license-path: zephyr/blobs/license/BSD_3.txt
     url: https://github.com/nxp-mcuxpresso/mcuxsdk-middleware-eiq/raw/4a3cb9ad/neutron/rt700/cm33/libNeutronFirmware.a
     description: "Neutron firmware library for RT700 CM33"
+
+#For MCXL255
+  - path: mcxl255/libadvc_cm0p.a
+    sha256: a2bbd65e25a7f1f363c0a4ee6ac8b03084301e8970c7d2224186a5c38bad71a6
+    type: lib
+    version: '26.09.00-pvw2'
+    license-path: zephyr/blobs/license/BSD_3.txt
+    url: https://github.com/nxp-mcuxpresso/mcux-devices-mcx/raw/main/MCXL/MCXL255/drivers/libadvc_cm0p.a
+    description: "ADVC library for MCXL255 CM0P core"
+  - path: mcxl255/libadvc_cm33.a
+    sha256: cc487d00944870fabf7433ab60833b175e37fe46ffd6024831cb67fd654afa68
+    type: lib
+    version: '26.09.00-pvw2'
+    license-path: zephyr/blobs/license/BSD_3.txt
+    url: https://github.com/nxp-mcuxpresso/mcux-devices-mcx/raw/main/MCXL/MCXL255/drivers/libadvc_cm33.a
+    description: "ADVC library for MCXL255 CM33 core"


### PR DESCRIPTION
## Binary Blob Information

**Binary blob origin:**
`libadvc_cm0p.a` and `libadvc_cm33.a` are sourced from NXP's official
`mcux-devices-mcx` repository (MCUXpresso SDK device package for MCXL255):
https://github.com/nxp-mcuxpresso/mcux-devices-mcx/tree/main/MCXL/MCXL255/drivers

**Type of blob:**
Precompiled static libraries (`.a`), one per core (armgcc-compatible), not
firmware images.

**Zephyr module the blob(s) will be referenced from:**
`hal_nxp`, registered under the `blobs:` list in `zephyr/module.yml`
(`mcxl255/libadvc_cm0p.a`, `mcxl255/libadvc_cm33.a`).

**Description of what the blob(s) do:**
These libraries implement the ADVC (Adaptive Voltage Control) driver for the
MCXL255 SoC. The open-source `fsl_advc.c`/`fsl_advc.h` (already present in
`mcux-sdk-ng`) only declare `ADVC_DRIVER_*` functions as `extern`; the actual
implementation is closed-source and shipped solely as these precompiled
libraries. MCXL255 is a dual-core device (Cortex-M33 + Cortex-M0+), so a
separate lib is provided for each core: `libadvc_cm33.a` for the CM33 core
and `libadvc_cm0p.a` for the CM0P core.

**Dependencies on other components:**
None beyond the standard, already-open-source MCXL255 device headers
(`fsl_advc.h`) present in the `mcux-sdk-ng` tree. No additional blobs or
external libraries are required.

**License:**
BSD-3-Clause — verified against the `mcux-devices-mcx` repository license
(matches `zephyr/blobs/license/BSD_3.txt`, the same license file already
referenced by other existing blob entries in this module, e.g. the Neutron
firmware library for RT700).