### PR TITLE
mcux: devices: MKL25Z4: add missing TPM 32-bit macro

### DIFF
--- a/mcux/mcux-sdk/devices/MKL25Z4/MKL25Z4_features.h
+++ b/mcux/mcux-sdk/devices/MKL25Z4/MKL25Z4_features.h
@@ -1818,6 +1818,8 @@
 #define FSL_FEATURE_TPM_FILTER_HAS_EFFECTn(x) (0)
 /* @brief Has TPM_QDCTRL register. */
 #define FSL_FEATURE_TPM_HAS_QDCTRL (0)
+/* @brief Has 32-bit counter in TPM. */
+#define FSL_FEATURE_TPM_HAS_32BIT_COUNTERn(x) (0)
 /* @brief Whether QDCTRL register has effect. */
 #define FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(x) (0)
 


### PR DESCRIPTION
The common TPM driver (`fsl_tpm.c` / `fsl_tpm.h`) relies on the `FSL_FEATURE_TPM_HAS_32BIT_COUNTERn` macro. This macro was missing in the `MKL25Z4_features.h` header. 

This omission breaks compilation for the KL25Z family when the PWM API is enabled in Zephyr.

This PR adds the missing macro and sets it to 0, since the MKL25Z4 uses a 16-bit counter.