### PR TITLE
drivers: caam: update caam driver to version 2.4.2

### DIFF
--- a/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
+++ b/mcux/mcux-sdk-ng/drivers/caam/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_MCUX_COMPONENT_driver.caam)
-    mcux_component_version(2.4.1)
+    mcux_component_version(2.4.2)
 
     mcux_add_source(SOURCES fsl_caam.c fsl_caam.h)
 

--- a/mcux/mcux-sdk-ng/drivers/caam/doxygen/ChangeLog_caam.md
+++ b/mcux/mcux-sdk-ng/drivers/caam/doxygen/ChangeLog_caam.md
@@ -1,4 +1,6 @@
 # CAAM
+## [2.4.2]
+- Sync Zephyr-only changes to entropy descriptors which need to be placed in non-cacheable sections 
 
 ## [2.4.1]
 

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2025 NXP
+ * Copyright 2016-2026 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -8,6 +8,10 @@
 
 #include "fsl_caam.h"
 #include "fsl_clock.h"
+
+#if defined(__ZEPHYR__)
+#include <zephyr/linker/sections.h>
+#endif
 
 #if defined(FSL_FEATURE_HAS_L1CACHE) || defined(__DCACHE_PRESENT)
 #include "fsl_cache.h"
@@ -222,10 +226,17 @@ static uint32_t s_jrIndex2              = 0;    /*!< Current index in the input 
 static caam_job_ring_interface_t *s_jr3 = NULL; /*!< Pointer to job ring interface 3. */
 static uint32_t s_jrIndex3              = 0;    /*!< Current index in the input job ring 3. */
 
+#if defined(__ZEPHYR__)
+static caam_rng_config_t rngConfig __nocache;
+static caam_desc_rng_t rngGenSeckey __nocache;
+static caam_desc_rng_t rngInstantiate __nocache;
+static caam_desc_rng_t descBuf __nocache;
+#else
 AT_NONCACHEABLE_SECTION(static caam_rng_config_t rngConfig);
 AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngGenSeckey);
 AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngInstantiate);
 AT_NONCACHEABLE_SECTION(static caam_desc_rng_t descBuf);
+#endif
 /*******************************************************************************
  * Code
  ******************************************************************************/

--- a/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
+++ b/mcux/mcux-sdk-ng/drivers/caam/fsl_caam.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
- * Copyright 2016-2023 NXP
+ * Copyright 2016-2026 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -32,7 +32,7 @@ enum
 /*! @{ */
 /*! @brief CAAM driver version.
  *
- * Current version: 2.4.1
+ * Current version: 2.4.2
  *
  * Change log:
  * - Version 2.0.0
@@ -82,8 +82,10 @@ enum
  *     and support for black keys and blobs for both symmetric and asymmetric operations.
  * - Version 2.4.1
  *   - Fix MSG and MISRA-2012 issues.
+ * - Version 2.4.2
+ *   - Sync Zephyr-only changes to entropy descriptors which need to be placed in non-cacheable sections 
  */
-#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 4, 1))
+#define FSL_CAAM_DRIVER_VERSION (MAKE_VERSION(2, 4, 2))
 /*! @} */
 
 /*! @brief CAAM callback function. */


### PR DESCRIPTION
Version 2.4.2 uses native Zephyr __nocache attribute for automatedly generating
noncacheable regions. These attributes are used  for the entropy-related buffers
in the CAAM driver.